### PR TITLE
Forward-port proven fixes to Nexus 1.19.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 Thumbs.db
 
 # Local development and test output
+.tools/
 coverage/
 dist/
 build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Nexus 1.19.3
 
+- Forward-ported the proven queue-aware Echo policy, exact-quality targets, final-search handling, refusal recovery, equal-progress wishlist rotation, and truthful horizon/final diagnostics without changing the 1.19.3 version or UI architecture.
+- Added pre-click Tome of Echo bag detection and a 20-second mutation pause while leaving the stock bind confirmation fully owned by the client.
+- Hardened build and DPS sync against oversized/conflicting transfers, sender/author spoofing, unsigned deletion relays, evidence-free legacy DPS records, partial build edits, and stale derived identities.
+- Made locked-Echo migration and current-run owned-state synchronization generation-aware and idempotent across reloads and new runs.
 - Wishlist progress is now counted per exact Echo/quality everywhere, matching the rule the save gate already used. A forced Uncommon copy no longer counts as one of the Rare copies your wishlist asked for.
 - Fixes STILL NEEDED and the save message contradicting the save decision: a run that shed forced Uncommon copies while gaining a real Rare one reported "loadout cleaned up — shed Quick Hands" and showed Quick Hands going backwards, even though the run was genuinely closer to the wishlist.
 - Clearing a wrong-quality copy now counts as cleanup in the save gate instead of scoring nothing, so a run whose only achievement is removing them can still save.

--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -1,4 +1,4 @@
-# Nexus — internal module contracts (v1.17.2)
+# Nexus — internal module contracts (v1.19.3)
 
 Binding interface spec for all modules. Authored from `WISHLIST_REALIZER_BUILD_PROMPT.md`
 + `WISHLIST_REALIZER_SPEC_ADDENDUM.md` + `WISHLIST_REALIZER_DESIGN.md` (the addendum wins
@@ -7,8 +7,8 @@ SavedVariables, NO `ProjectEbonhold.*` — loadable under bare LuaJIT. All cross
 data is plain tables produced by `core/GameAdapter.lua` (the only IO module).
 
 Global namespace: `Nexus` (each file: `Nexus = Nexus or {};
-local M = {}; Nexus.<Name> = M`). Version: `Nexus.VERSION = "1.17.2"`
-set in Main; .toc `## Version: 1.17.2` kept in lockstep.
+local M = {}; Nexus.<Name> = M`). Version: `Nexus.VERSION = "1.19.3"`
+set in Main; .toc `## Version: 1.19.3` kept in lockstep.
 
 Lua 5.1 rules: no `goto`, no `#` on non-sequences, `unpack` global, sort pairs for
 deterministic output, forward-declare every closure-captured local BEFORE the closure,

--- a/core/DpsCapture.lua
+++ b/core/DpsCapture.lua
@@ -18,7 +18,21 @@ local SAMPLE_INTERVAL  = 5
 local MIN_LK_SESSION_SECS = 20
 local MIN_DUMMY_SESSION_SECS = 30
 local MAX_LB_ENTRIES   = 1
-local PROTOCOL_VERSION = 6
+local PROTOCOL_VERSION = 7
+local VALID_CLASS = {
+    WARRIOR=true, PALADIN=true, HUNTER=true, ROGUE=true, PRIEST=true,
+    DEATHKNIGHT=true, SHAMAN=true, MAGE=true, WARLOCK=true, DRUID=true,
+}
+local CLASS_LABEL = {
+    WARRIOR="Warrior", PALADIN="Paladin", HUNTER="Hunter", ROGUE="Rogue",
+    PRIEST="Priest", DEATHKNIGHT="Death Knight", SHAMAN="Shaman", MAGE="Mage",
+    WARLOCK="Warlock", DRUID="Druid",
+}
+
+local function NormalizeClass(class)
+    class = type(class) == "string" and class:upper() or nil
+    return class and VALID_CLASS[class] and class or nil
+end
 
 local Adapter, Sync
 local inCombat         = false
@@ -98,6 +112,79 @@ end
 
 local function PlayerKey(name)
     return tostring(name or "?"):lower()
+end
+
+local function CurrentRealm()
+    local realm = GetNormalizedRealmName and GetNormalizedRealmName()
+    if not realm or realm == "" then realm = GetRealmName and GetRealmName() end
+    return tostring(realm or "unknown"):lower():gsub("%s+", "")
+end
+
+local function OwnerKey(name, realm)
+    name = tostring(name or ""):lower():gsub("^%s+", ""):gsub("%s+$", "")
+    if name == "" then return nil end
+    realm = tostring(realm or CurrentRealm()):lower():gsub("%s+", "")
+    return name .. "@" .. realm
+end
+
+-- Repair legacy class metadata only for the exact character currently logged
+-- in. SavedVariables are account-wide, so no other player's row is inferred.
+local function RepairCurrentCharacterClass()
+    if not (UnitName and UnitClass) then return false end
+    local me = tostring(UnitName("player") or "")
+    local _, token = UnitClass("player")
+    local class = NormalizeClass(token)
+    if me == "" or not class then return false end
+
+    local realm = CurrentRealm()
+    local localOwner = OwnerKey(me, realm)
+    if not localOwner then return false end
+    local changed = false
+    local builds = NexusDB and NexusDB.communityBuilds or {}
+    local character = CharacterBestStore()
+    local personal = PersonalBestStore()
+
+    for _, category in ipairs({ "dummy", "lk" }) do
+        for _, row in pairs(character[category] or {}) do
+            local rowOwner = tostring(row and row.ownerKey or ""):lower()
+            local derivedOwner = row and OwnerKey(row.player,
+                row.realm and row.realm ~= "" and row.realm or realm)
+            if row and (rowOwner == localOwner or derivedOwner == localOwner) then
+                if row.class ~= class then row.class = class; changed = true end
+                local prow = row.fingerprint and personal[row.fingerprint]
+                    and personal[row.fingerprint][category]
+                if prow then
+                    if prow.class ~= class then prow.class = class; changed = true end
+                    prow.ownerKey = prow.ownerKey or localOwner
+                    prow.realm = prow.realm or realm
+                end
+
+                local build = row.buildId and builds[row.buildId]
+                if build and build.autoDps then
+                    local buildOwner = tostring(build.ownerKey or ""):lower()
+                    local legacyOwned = buildOwner == ""
+                        and tostring(build.author or ""):lower() == me:lower()
+                    if buildOwner == localOwner or legacyOwned then
+                        local buildChanged = false
+                        if build.class ~= class then build.class = class; buildChanged = true end
+                        local title = tostring(build.title or "")
+                        if title:match("^[%a%s]+ Record Loadout$") then
+                            local corrected = (CLASS_LABEL[class] or class) .. " Record Loadout"
+                            if title ~= corrected then build.title = corrected; buildChanged = true end
+                        end
+                        if not build.ownerKey then build.ownerKey = localOwner; buildChanged = true end
+                        if buildChanged then
+                            local now = (time and time()) or 0
+                            local old = tonumber(build.lastModified or build.postedAt) or 0
+                            build.lastModified = now > old and now or old + 1
+                            changed = true
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return changed
 end
 
 local legacyMigrated = false
@@ -329,10 +416,9 @@ local function BackfillLocalLockedRows()
 end
 
 local migratedLockedBaseline = false
-local function CorrectLockedRows(store)
-    if not (Adapter and Adapter.LockedOwned) then return end
-    local locked = Adapter.LockedOwned()
-    local lockedBySpell = locked and locked.bySpell or {}
+local LOCKED_MIGRATION_VERSION = 1
+local function CorrectLockedRows(store, lockedBySpell)
+    lockedBySpell = type(lockedBySpell) == "table" and lockedBySpell or {}
     -- If no locked echoes are known yet, abort. Subtracting zero from
     -- everything would produce identical keys (no-op), but if the locked
     -- data simply hasn't loaded yet we must not run at all -- a partially
@@ -373,44 +459,88 @@ local function CorrectLockedRows(store)
         -- Only clear the old slot after successfully writing the new one
         if store[m.newKey][m.category] then
             store[m.oldKey][m.category] = nil
+            if next(store[m.oldKey]) == nil then store[m.oldKey] = nil end
         end
     end
 end
 
+local function DeepCopy(value, seen)
+    if type(value) ~= "table" then return value end
+    seen = seen or {}
+    if seen[value] then return seen[value] end
+    local copy = {}
+    seen[value] = copy
+    for key, child in pairs(value) do
+        copy[DeepCopy(key, seen)] = DeepCopy(child, seen)
+    end
+    return copy
+end
+
 local function MigrateLocalLockedBaseline()
     if migratedLockedBaseline then return end
-    migratedLockedBaseline = true
-    MigrateLegacyLeaderboard()
-    CorrectLockedRows(PersonalBestStore())
-    CorrectLockedRows(BuildBestStore())
-    local character = CharacterBestStore()
+    local db = DB()
+    if (tonumber(db.lockedMigrationVersion) or 0)
+        >= LOCKED_MIGRATION_VERSION then
+        migratedLockedBaseline = true
+        return
+    end
     local locked = Adapter and Adapter.LockedOwned and Adapter.LockedOwned()
+    if not (locked and locked.synced == true) then
+        return
+    end
+    MigrateLegacyLeaderboard()
     local lockedBySpell = locked and locked.bySpell or {}
-    -- Only correct the character store if we actually have locked echo data.
-    -- If not loaded yet, skip -- the migration runs once so we must not
-    -- corrupt fingerprints with a partial locked set.
-    local anyLocked = false
-    for _ in pairs(lockedBySpell) do anyLocked = true; break end
-    if not anyLocked then return end
-    for _, category in ipairs({ "dummy", "lk" }) do
-        for _, row in pairs(character[category] or {}) do
-            local oldEchoes = row and NormalizeEchoes(row.echoes)
-            if oldEchoes then
-                local corrected = {}
-                for _, e in ipairs(oldEchoes) do
-                    local n = math.max(0, (tonumber(e.count) or 0) - (tonumber(lockedBySpell[e.spellId]) or 0))
-                    if n > 0 then corrected[#corrected + 1] = { spellId=e.spellId, count=n } end
-                end
-                corrected = NormalizeEchoes(corrected)
-                local newKey = EchoKey(corrected)
-                -- Only update if corrected is valid and different
-                if newKey and newKey ~= row.fingerprint then
-                    row.echoes, row.fingerprint = corrected, newKey
-                    row.loadoutHash = EchoHashFromKey(newKey)
+
+    -- Preserve an immutable source before any subtraction. An interrupted
+    -- pass restores this snapshot and recomputes instead of subtracting twice.
+    if type(db.lockedMigrationSource) ~= "table" then
+        db.lockedMigrationSource = {
+            personalBest=DeepCopy(PersonalBestStore()),
+            buildBest=DeepCopy(BuildBestStore()),
+            characterBest=DeepCopy(CharacterBestStore()),
+        }
+    else
+        db.personalBest = DeepCopy(db.lockedMigrationSource.personalBest or {})
+        db.buildBest = DeepCopy(db.lockedMigrationSource.buildBest or {})
+        db.characterBest = DeepCopy(db.lockedMigrationSource.characterBest
+            or { dummy={}, lk={} })
+    end
+
+    local ok = pcall(function()
+        CorrectLockedRows(PersonalBestStore(), lockedBySpell)
+        CorrectLockedRows(BuildBestStore(), lockedBySpell)
+        local character = CharacterBestStore()
+        local anyLocked = false
+        for _ in pairs(lockedBySpell) do anyLocked = true; break end
+        if anyLocked then
+            for _, category in ipairs({ "dummy", "lk" }) do
+                for _, row in pairs(character[category] or {}) do
+                    local oldEchoes = row and NormalizeEchoes(row.echoes)
+                    if oldEchoes then
+                        local corrected = {}
+                        for _, e in ipairs(oldEchoes) do
+                            local n = math.max(0, (tonumber(e.count) or 0)
+                                - (tonumber(lockedBySpell[e.spellId]) or 0))
+                            if n > 0 then
+                                corrected[#corrected + 1] = {
+                                    spellId=e.spellId, count=n }
+                            end
+                        end
+                        corrected = NormalizeEchoes(corrected)
+                        local newKey = EchoKey(corrected)
+                        if newKey and newKey ~= row.fingerprint then
+                            row.echoes, row.fingerprint = corrected, newKey
+                            row.loadoutHash = EchoHashFromKey(newKey)
+                        end
+                    end
                 end
             end
         end
-    end
+    end)
+    if not ok then return end
+    db.lockedMigrationSource = nil
+    db.lockedMigrationVersion = LOCKED_MIGRATION_VERSION
+    migratedLockedBaseline = true
 end
 
 local function BuildSnapshot(build)
@@ -625,6 +755,26 @@ function DPS.GetLeaderboard(buildId, category)
     return key and SortedEntries(GlobalForBuild(buildId, key, category)) or {}
 end
 
+-- A build is Details-verified only when a valid public record exists for its
+-- exact loadout and the capture met the shared 30-second evidence floor.
+function DPS.GetBuildVerification(buildId)
+    local key = BuildKey(buildId)
+    if not key then return nil end
+    local best
+    for _, category in ipairs({ "dummy", "lk" }) do
+        local row = GlobalForKey(key, category)
+        if row and (tonumber(row.duration) or 0) >= MIN_DUMMY_SESSION_SECS then
+            if not best or (tonumber(row.dps) or 0) > (tonumber(best.dps) or 0) then
+                best = {
+                    category=category, dps=tonumber(row.dps) or 0,
+                    duration=tonumber(row.duration) or 0, player=row.player,
+                }
+            end
+        end
+    end
+    return best
+end
+
 function DPS.GetPersonalBest(buildId, category)
     local key = BuildKey(buildId)
     return key and PersonalForBuild(buildId, key, category) or nil
@@ -699,6 +849,8 @@ function DPS.BroadcastBestForBuild(buildId)
                     category = category, dps = math.floor(tonumber(row.dps) or 0),
                     duration = tonumber(row.duration) or 0, ts = tonumber(row.ts) or 0,
                     player = row.player or "?", level = tonumber(row.level) or 0, buildId = buildId,
+                    class = row.class, ownerKey = row.ownerKey, realm = row.realm,
+                    echoes = row.echoes or BuildSnapshot(build),
                     lockedEchoes = row.lockedEchoes,
                 }
                 local ok, result = pcall(Sync.BroadcastDpsRecord, record)
@@ -728,6 +880,8 @@ function DPS.BroadcastAllBuildBests(peerHash, onlyBucket)
                     category=category, dps=math.floor(tonumber(row.dps) or 0),
                     duration=tonumber(row.duration) or 0, ts=tonumber(row.ts) or 0,
                     player=row.player or "?", level=tonumber(row.level) or 0, buildId=row.buildId,
+                    class=row.class, ownerKey=row.ownerKey, realm=row.realm,
+                    echoes=row.echoes,
                     lockedEchoes=row.lockedEchoes,
                 }
                 local ok, result=pcall(Sync.BroadcastDpsRecord,record)
@@ -753,6 +907,7 @@ function DPS.GetDpsBoard(category)
     if category ~= "dummy" and category ~= "lk" then return {} end
     MigrateLocalLockedBaseline()
     MigrateLegacyLeaderboard()
+    RepairCurrentCharacterClass()
     BackfillLocalLockedRows()
     local out = {}
     local seenPlayer = {}   -- dedup by lowercase player name
@@ -767,6 +922,7 @@ function DPS.GetDpsBoard(category)
                 local pkey = PlayerKey(row.player or "?")
                 local entry = {
                     player = row.player or "?", dps = math.floor(tonumber(row.dps) or 0),
+                    class = row.class, ownerKey = row.ownerKey, realm = row.realm,
                     level = tonumber(row.level) or 0, ts = tonumber(row.ts) or 0,
                     duration = tonumber(row.duration) or 0, category = category,
                     fingerprint = row.fingerprint, echoes = NormalizeEchoes(row.echoes) or BuildSnapshot(build),
@@ -986,6 +1142,7 @@ local function CommitSession(category)
             buildId = buildId, echoes = snap, fingerprint = key,
             lockedEchoes = lockedSnap,
             class = localClass,
+            ownerKey = OwnerKey(player), realm = CurrentRealm(),
             protocolVersion = PROTOCOL_VERSION,
         }
         SetStoreRow(PersonalBestStore(), key, category, personalRow)
@@ -1041,6 +1198,8 @@ local function CommitSession(category)
                 echoes = snap, category = category, dps = dpsFloor,
                 duration = elapsed, ts = stamp, player = player,
                 level = level, buildId = buildId, lockedEchoes = lockedSnap,
+                class = localClass, ownerKey = personalRow.ownerKey,
+                realm = personalRow.realm,
             })
         end
     end
@@ -1065,7 +1224,42 @@ local function IsBetterPublicRecord(candidate, existing)
     return BetterRow(candidate, existing)
 end
 
-function DPS.ReceiveRecord(record)
+local function FiniteNumber(value)
+    return type(value) == "number" and value == value
+        and value < math.huge and value > -math.huge
+end
+
+local function ShortIdentity(value)
+    local name = tostring(value or ""):gsub("%s+", "")
+    name = name:match("^([^-]+)") or name
+    return name:lower()
+end
+
+local function ValidWireEchoList(source)
+    if type(source) ~= "table" then return false end
+    local entries, maxIndex, total = 0, 0, 0
+    for index, echo in pairs(source) do
+        if type(index) ~= "number" or index < 1
+            or index ~= math.floor(index) or type(echo) ~= "table" then
+            return false
+        end
+        local spellId = tonumber(echo.spellId or echo.id)
+        local count = tonumber(echo.count or echo.stacks or echo.stack) or 1
+        if not FiniteNumber(spellId) or spellId < 1
+            or spellId ~= math.floor(spellId) or spellId > 2147483647
+            or not FiniteNumber(count) or count < 1
+            or count ~= math.floor(count) or count > 120 then
+            return false
+        end
+        entries = entries + 1
+        if index > maxIndex then maxIndex = index end
+        total = total + count
+        if entries > 120 or total > 120 then return false end
+    end
+    return entries > 0 and entries == maxIndex
+end
+
+function DPS.ReceiveRecord(record, transportSender)
     if type(record) ~= "table" then return false end
     local version = tonumber(record.v or record.protocolVersion)
     local category = record.c or record.category
@@ -1074,26 +1268,61 @@ function DPS.ReceiveRecord(record)
     local ts = tonumber(record.t or record.ts) or 0
     local player = tostring(record.p or record.player or "")
     local level = tonumber(record.l or record.level) or 0
-    local echoes = NormalizeEchoes(record.e or record.echoes)
+    local playerClass = record.k or record.class
+    local ownerKey = record.o or record.ownerKey
+    local realm = record.r or record.realm
+    local rawEchoes = record.e or record.echoes
+    if not ValidWireEchoList(rawEchoes) then return false end
+    local echoes = NormalizeEchoes(rawEchoes)
     local computed = EchoKey(echoes)
     local claimed = record.f or record.fingerprint
     local hash = record.h or record.loadoutHash
     local fingerprint = computed or (type(claimed)=="string" and claimed or nil) or (type(hash)=="string" and ("@"..hash) or nil)
+    local ownerName, ownerRealm
+    if ownerKey ~= nil then
+        if type(ownerKey) ~= "string" or #ownerKey > 160
+            or ownerKey:find("[%c|]") then return false end
+        ownerName, ownerRealm = ownerKey:match("^([^@]+)@([^@]+)$")
+        if not ownerName or not ownerRealm
+            or ShortIdentity(ownerName) ~= ShortIdentity(player) then
+            return false
+        end
+    end
+    if realm ~= nil and (type(realm) ~= "string" or #realm > 96
+        or realm:find("[%c|]")) then return false end
+    if ownerRealm and realm
+        and ownerRealm:gsub("%s+", ""):lower()
+            ~= tostring(realm):gsub("%s+", ""):lower() then
+        return false
+    end
 
     -- Schema validation
-    if (version ~= 2 and version ~= 3 and version ~= 4 and version ~= 5 and version ~= PROTOCOL_VERSION)
+    if (version ~= 2 and version ~= 3 and version ~= 4 and version ~= 5
+            and version ~= 6 and version ~= PROTOCOL_VERSION)
         or (category ~= "dummy" and category ~= "lk")
-        or not dps or dps <= 0 or dps > 1000000000
-        or duration < 0 or ts < 0 or player == "" or not fingerprint
+        or not FiniteNumber(dps) or dps <= 0 or dps > 500000000
+        or not FiniteNumber(duration) or duration < 30
+        or not FiniteNumber(ts) or ts <= 0
+        or player == "" or #player > 64 or player:find("[%c|]")
+        or not FiniteNumber(level) or level < 1 or level > 80
+        or level ~= math.floor(level)
+        or type(playerClass) ~= "string"
+        or not VALID_CLASS[playerClass:upper()]
+        or not echoes or #echoes < 1 or #echoes > 120
+        or not computed or not fingerprint
         or (computed and claimed and claimed ~= computed)
-        or (computed and hash and EchoHashFromKey(computed) ~= hash) then return false end
+        or (computed and hash and EchoHashFromKey(computed) ~= hash)
+        or (transportSender ~= nil
+            and ShortIdentity(player) ~= ShortIdentity(transportSender)) then
+        return false
+    end
 
     -- Integrity checks (deliberately silent -- legitimate clients never trip these)
     -- DPS floor: no real build produces under 1k active-time DPS
     if dps < 1000 then return false end
     -- Session duration floor must match local capture: dummy 30s, LK 20s.
-    local minDur = (category == "dummy") and MIN_DUMMY_SESSION_SECS or MIN_LK_SESSION_SECS
-    if duration > 0 and duration < minDur then return false end
+    local minDur = 30
+    if duration < minDur then return false end
     -- Hard DPS ceiling: set high to accommodate extreme builds while
     -- still blocking obviously fabricated absurd values.
     if dps > 500000000 then return false end
@@ -1101,15 +1330,21 @@ function DPS.ReceiveRecord(record)
     local nowTs = (time and time()) or 0
     if nowTs > 1000000000 and ts > 0 and ts > nowTs + 300 then return false end
     -- Echo count sanity
-    if echoes and (#echoes < 1 or #echoes > 120) then return false end
+    if #echoes < 1 or #echoes > 120 then return false end
 
     MigrateLegacyLeaderboard()
     local bucket = CharacterBestStore()[category]
     local existing = bucket[PlayerKey(player)]
-    local incomingLocked = NormalizeEchoes(record.lk or record.lockedEchoes)
+    local rawLocked = record.lk or record.lockedEchoes
+    if rawLocked ~= nil and not ValidWireEchoList(rawLocked) then return false end
+    local incomingLocked = NormalizeEchoes(rawLocked)
     local row = {
         dps = math.floor(dps), level = level, ts = ts, duration = duration,
-        player = player, buildId = record.b or record.buildId,
+        player = player,
+        class = playerClass and tostring(playerClass):upper() or nil,
+        ownerKey = ownerKey and tostring(ownerKey):lower() or nil,
+        realm = realm and tostring(realm):lower() or ownerRealm,
+        buildId = record.b or record.buildId,
         echoes = echoes, fingerprint = fingerprint, loadoutHash = hash or EchoHashFromKey(fingerprint),
         lockedEchoes = incomingLocked,
         protocolVersion = PROTOCOL_VERSION,
@@ -1122,9 +1357,26 @@ function DPS.ReceiveRecord(record)
             and math.floor(tonumber(existing.dps) or 0) == math.floor(dps)
             and tonumber(existing.ts or 0) == tonumber(ts or 0)
             and tostring(existing.fingerprint or "") == tostring(fingerprint or "")
-        if sameRecord and incomingLocked and not NormalizeEchoes(existing.lockedEchoes) then
-            existing.lockedEchoes = incomingLocked
-            return true
+        if sameRecord then
+            local enriched = false
+            local normalizedClass = NormalizeClass(playerClass)
+            if normalizedClass and existing.class ~= normalizedClass then
+                existing.class = normalizedClass
+                enriched = true
+            end
+            if ownerKey and not existing.ownerKey then
+                existing.ownerKey = tostring(ownerKey):lower()
+                enriched = true
+            end
+            if realm and not existing.realm then
+                existing.realm = tostring(realm):lower()
+                enriched = true
+            end
+            if incomingLocked and not NormalizeEchoes(existing.lockedEchoes) then
+                existing.lockedEchoes = incomingLocked
+                enriched = true
+            end
+            if enriched then return true end
         end
         return false
     end
@@ -1187,8 +1439,9 @@ end
 
 function DPS.Init(adapter, sync)
     Adapter, Sync = adapter, sync
-    migratedLockedBaseline = false
     MigrateLocalLockedBaseline()
+    MigrateLegacyLeaderboard()
+    RepairCurrentCharacterClass()
     Debug("initialized; current tracked key=" .. tostring(DPS.GetCurrentEchoKey()))
 end
 

--- a/core/DpsCapture.lua
+++ b/core/DpsCapture.lua
@@ -694,9 +694,13 @@ end
 
 local function RowMatchesBuild(row, buildId, key, hash)
     if type(row) ~= "table" then return false end
-    if buildId and row.buildId == buildId then return true end
     local rowKey = row.fingerprint
     local rowHash = row.loadoutHash or (rowKey and EchoHashFromKey(rowKey))
+    if buildId and row.buildId == buildId then
+        if key and rowKey and rowKey ~= key then return false end
+        if hash and rowHash and rowHash ~= hash then return false end
+        return true
+    end
     return (key and rowKey == key) or (hash and rowHash == hash)
 end
 
@@ -1385,7 +1389,17 @@ function DPS.ReceiveRecord(record, transportSender)
     local C = Nexus.CommunityBuilds
     if echoes and C and C.EnsureDpsBuildForEchoes then
         local ok, ensuredId = pcall(C.EnsureDpsBuildForEchoes, echoes, category, row)
-        if ok and ensuredId then row.buildId = ensuredId end
+        if ok and ensuredId then
+            row.buildId = ensuredId
+        elseif row.buildId then
+            -- The claimed opaque ID collided with a different loadout or
+            -- owner. Retry without it so the exact evidence receives a safe,
+            -- deterministic record page instead of attaching to that build.
+            row.buildId = nil
+            local safeOk, safeId = pcall(
+                C.EnsureDpsBuildForEchoes, echoes, category, row)
+            if safeOk and safeId then row.buildId = safeId end
+        end
     end
     bucket[PlayerKey(player)] = row
     if Nexus.CommunityBuilds and Nexus.CommunityBuilds.Refresh then

--- a/core/GameAdapter.lua
+++ b/core/GameAdapter.lua
@@ -27,11 +27,15 @@ local lastBuildOpAt = -10
 local ownedSyncedFlag, ownedRequestAt, ownedRetries = false, nil, 0
 local selfCalling = false
 local ownedSeen = false
+local ownedGeneration, ownedConfirmedGeneration = 0, -1
+local ownedRequestGeneration = -1
+local ownedBaselineRef, ownedBaselineSig = nil, nil
 local boundaryAt = 0     -- time of last run boundary / PEW (owned-sync settle)
 local GHOST_OWNED = 25   -- level-1 owned count at/above which we suspect a dead-run ghost
 local pewDone = false
 local externalActionSeen = false
 local hooksInstalled = false
+local tomeMutationPausedUntil = 0
 -- per-latch watchdog: a client latch stuck >10s with no reply is DEAD for
 -- the session (per-action, like the client itself); never a whole-loop stall
 local latchSince, deadLatch = {}, {}
@@ -351,7 +355,8 @@ function A.LockedOwned()
         local fam = FamilyOf(id) or id
         byFamily[fam] = (byFamily[fam] or 0) + n
     end
-    return { bySpell = bySpell, byFamily = byFamily }
+    return { bySpell = bySpell, byFamily = byFamily,
+        synced = type(locked) == "table" }
 end
 
 -- Confirmed live via /nexus sniff, 2026-08-01: the server exposes the real
@@ -359,6 +364,28 @@ end
 function A.MaxPermanentEchoes()
     local svc = PS()
     return tonumber(svc and SafeCall(svc.GetMaximumPermanentEchoes)) or 6
+end
+
+local function GrantedSignature(granted)
+    if type(granted) ~= "table" then return nil end
+    local counts = {}
+    for _, entries in pairs(granted) do
+        if type(entries) == "table" then
+            for i = 1, #entries do
+                local id = type(entries[i]) == "table"
+                    and tonumber(entries[i].spellId) or nil
+                if id then counts[id] = (counts[id] or 0) + 1 end
+            end
+        end
+    end
+    local ids = {}
+    for id in pairs(counts) do ids[#ids + 1] = id end
+    table.sort(ids)
+    local out = {}
+    for i = 1, #ids do
+        out[#out + 1] = tostring(ids[i]) .. ":" .. tostring(counts[ids[i]])
+    end
+    return table.concat(out, ",")
 end
 
 function A.Owned()
@@ -394,32 +421,27 @@ function A.Owned()
         distinct = distinct + 1
         total = total + (tonumber(n) or 0)
     end
-    if distinct > 0 then ownedSeen = true end
-
-    -- Sync/trust model. MUST NOT DEADLOCK -- an earlier change-detection
-    -- version could stick "unsynced" for the whole run until /reload:
-    --  * distinct == 0  -> data not loaded yet (empty {} right after a
-    --    reset/reload). Always arrives within ~1s -> not synced, but transient.
-    --  * level >= 2      -> granted reflects the CURRENT run (the dead-run
-    --    ghost is a level-1-only artifact) -> trust it.
-    --  * level 1         -> a HUGE owned set is the dead run's ghost still
-    --    cached; a small set is the fresh run. Level-1 sync gates nothing
-    --    critical (ARM does not read owned.synced), so this is advisory only.
+    -- A response belongs to this run only when it changes the pre-request
+    -- table/reference or content snapshot. A successful prior run must not
+    -- satisfy a later generation, and elapsed time alone never makes an empty
+    -- snapshot authoritative. Replacing the granted table with a fresh empty
+    -- table is the supported confirmed-empty signal.
     local level = A.Level()
     local ghost = (level <= 1 and distinct >= GHOST_OWNED)
-    local synced
-    if level >= 2 then
-        -- trust once granted has loaded (distinct>0); or after a short
-        -- settle window since the last reset/reload, so a run that
-        -- genuinely owns nothing yet is not blocked forever (the empty-{}
-        -- reload window is covered without a deadlock)
-        synced = (distinct > 0) or ((GetTime() - (boundaryAt or 0)) > 4)
-    else
-        synced = not ghost   -- level 1 gates nothing critical
+    local currentResponse = ownedRequestGeneration == ownedGeneration
+        and type(granted) == "table"
+        and (granted ~= ownedBaselineRef
+            or GrantedSignature(granted) ~= ownedBaselineSig)
+    if (currentResponse or (ownedGeneration == 0 and distinct > 0))
+        and not ghost then
+        ownedConfirmedGeneration = ownedGeneration
     end
+    ownedSeen = ownedConfirmedGeneration == ownedGeneration
+    local synced = ownedSeen and not ghost
     return { bySpell = bySpell, byFamily = byFamily,
              synced = synced, ghostSuspect = ghost,
-             distinct = distinct, total = total }
+             distinct = distinct, total = total,
+             generation = ownedGeneration }
 end
 
 -- Run boundary (each visit to level 1): the previous run's recorded picks
@@ -428,6 +450,13 @@ end
 function A.RunBoundaryReset()
     recordedPicks = {}
     pendingOwnPick = nil
+    ownedGeneration = ownedGeneration + 1
+    ownedConfirmedGeneration = -1
+    ownedRequestGeneration = -1
+    ownedBaselineRef, ownedBaselineSig = nil, nil
+    ownedSeen = false
+    ownedSyncedFlag = false
+    ownedRequestAt = nil
     ownedRetries = 0
     boundaryAt = GetTime()
     A.RequestGranted()
@@ -436,6 +465,12 @@ end
 function A.RequestGranted()
     local svc = PS()
     if svc and svc.RequestGrantedPerks then
+        if ownedRequestGeneration ~= ownedGeneration then
+            local before = SafeCall(svc.GetGrantedPerks)
+            ownedBaselineRef = before
+            ownedBaselineSig = GrantedSignature(before)
+            ownedRequestGeneration = ownedGeneration
+        end
         SafeCall(svc.RequestGrantedPerks)
         ownedRequestAt = GetTime()
         ownedRetries = ownedRetries + 1
@@ -1076,6 +1111,9 @@ end
 
 function A.ToggleLever(leverId, wantDisabled)
     if A.DIAGNOSTIC_PASSIVE then return false, "internal.6 passive diagnostic: write blocked" end
+    if A.TomeMutationPaused and A.TomeMutationPaused() then
+        return false, "Tome of Echo transaction settling"
+    end
     local cat = A.Catalog()
     local svc = PS()
     if not cat or not svc or not svc.ToggleTomeEcho then return false, "no api" end
@@ -1314,7 +1352,12 @@ function A.Freeze(index0)
     if A.DIAGNOSTIC_PASSIVE then return false, "internal.6 passive diagnostic: write blocked" end
     if A.InFlight() then return false, "in flight" end
     if deadLatch.freeze then return false, "freeze dead this session" end
-    if (UnitLevel("player") or 0) >= 80 then return false, "no next board" end
+    if (UnitLevel("player") or 0) >= 80 then
+        local horizon = A.Horizon()
+        if type(horizon) ~= "number" or horizon <= 1 then
+            return false, "no trustworthy next board"
+        end
+    end
     local board = A.Board()
     if not board then return false, "no board" end
     local card = board.cards[index0 + 1]
@@ -1404,7 +1447,12 @@ function A.UploadWishlist(slot, name, echoes)
             else
                 family = "s:" .. tostring(spellId)
             end
-            local maxStack = math.max(1, tonumber(row and row.maxStack) or 1)
+            local requestedStacks = math.max(1, tonumber(e.stacks) or 1)
+            -- Unknown-but-well-formed Echoes come from newer server data. Do
+            -- not silently collapse their requested stack count to one merely
+            -- because this client's catalog has not learned the row yet.
+            local maxStack = row and math.max(1, tonumber(row.maxStack) or 1)
+                or requestedStacks
             -- Catalog first -- a known spellId's quality is fixed, not a
             -- variable roll result, so it's always authoritative once the
             -- catalog has the row. e.quality is only a fallback for a
@@ -1414,7 +1462,7 @@ function A.UploadWishlist(slot, name, echoes)
             -- below) needs the real value to pick the right survivor.
             local candidate = { spellId = spellId,
                 quality = tonumber(row and row.quality) or tonumber(e.quality) or 0,
-                stacks = math.min(maxStack, math.max(1, tonumber(e.stacks) or 1)) }
+                stacks = math.min(maxStack, requestedStacks) }
             local prior = byFamily[family]
             if not prior or candidate.quality > prior.quality then
                 byFamily[family] = candidate
@@ -1536,7 +1584,8 @@ function A.Horizon()
     if (UnitLevel("player") or 0) < 2 then return nil end
     local svc = PS()
     local n = svc and SafeCall(svc.GetPendingRollsCount)
-    return tonumber(n)
+    if type(n) ~= "number" then return nil end
+    return n
 end
 
 function A.ExternalActionSeen()
@@ -1557,6 +1606,65 @@ end
 ------------------------------------------------------------------------
 -- Hooks + events + poll
 ------------------------------------------------------------------------
+
+-- Rare Tome of Echo items use the stock bind-on-use popup. Pause only
+-- Nexus's automatic ToggleTomeEcho traffic before the first click and for a
+-- settling window after the item disappears. The popup remains stock-owned;
+-- inspection below is read-only and secondary to carried-bag detection.
+local BIND_SETTLE_SECONDS = 20
+
+local function IsBindConfirmation(which, popupText)
+    local key = tostring(which or ""):upper()
+    local lower = tostring(popupText or ""):lower()
+    if key:find("BIND", 1, true) then return true end
+    return lower:find("using this item will bind it to you", 1, true) ~= nil
+end
+
+local function HoldTomeMutations()
+    tomeMutationPausedUntil = math.max(tomeMutationPausedUntil,
+        (GetTime and GetTime() or 0) + BIND_SETTLE_SECONDS)
+end
+
+local function EchoTomeInBags()
+    if type(GetContainerNumSlots) ~= "function"
+        or type(GetContainerItemLink) ~= "function" then
+        return false
+    end
+    for bag = 0, 4 do
+        local slots = tonumber(SafeCall(GetContainerNumSlots, bag)) or 0
+        for slot = 1, slots do
+            local link = SafeCall(GetContainerItemLink, bag, slot)
+            if type(link) == "string" then
+                local name = SafeCall(GetItemInfo, link)
+                    or link:match("%[(.-)%]")
+                if tostring(name or ""):lower():find(
+                    "tome of echo", 1, true) then
+                    return true
+                end
+            end
+        end
+    end
+    return false
+end
+
+local function VisibleBindConfirmation()
+    for i = 1, 4 do
+        local frame = _G["StaticPopup" .. i]
+        if frame and frame.IsShown and frame:IsShown() then
+            local popupText = frame.text and frame.text.GetText
+                and frame.text:GetText() or nil
+            if IsBindConfirmation(frame.which, popupText) then return true end
+        end
+    end
+    return false
+end
+
+function A.TomeMutationPaused()
+    if EchoTomeInBags() or VisibleBindConfirmation() then
+        HoldTomeMutations()
+    end
+    return (GetTime and GetTime() or 0) < tomeMutationPausedUntil
+end
 
 local function InstallHooks()
     if hooksInstalled then return end

--- a/core/Main.lua
+++ b/core/Main.lua
@@ -51,8 +51,8 @@ local fillerFishState = {
 -- Reset at the same run boundary as fillerFishState (level == 1, below).
 local forcedTakesBySpell = {}
 local frozeThisBoard = nil       -- board signature we already spent a freeze on
-local refusedFinalBanishSig = nil
-local refusedFinalRerollSig = nil
+local refusedBanishSig = nil
+local refusedRerollSig = nil
 local externalPauseUntil = 0
 
 -- SAVE state
@@ -1283,11 +1283,11 @@ local function StepRun(level, plan, slots, owned, flags, disabledLevers)
         return
     end
 
-    if refusedFinalBanishSig and refusedFinalBanishSig ~= board.signature then
-        refusedFinalBanishSig = nil
+    if refusedBanishSig and refusedBanishSig ~= board.signature then
+        refusedBanishSig = nil
     end
-    if refusedFinalRerollSig and refusedFinalRerollSig ~= board.signature then
-        refusedFinalRerollSig = nil
+    if refusedRerollSig and refusedRerollSig ~= board.signature then
+        refusedRerollSig = nil
     end
 
     if armTargetSlot and not armedConfirmed then
@@ -1336,8 +1336,8 @@ local function StepRun(level, plan, slots, owned, flags, disabledLevers)
         params = DefaultProfile.params,
         allowBanish = settings.autoBanish ~= false,
         searchRefused = {
-            banish = refusedFinalBanishSig == board.signature,
-            reroll = refusedFinalRerollSig == board.signature,
+            banish = refusedBanishSig == board.signature,
+            reroll = refusedRerollSig == board.signature,
         },
         rerollBudget = {
             consecutive = fillerFishState.consecutive,
@@ -1545,10 +1545,12 @@ local function StepRun(level, plan, slots, owned, flags, disabledLevers)
         local ok, err = Adapter.Banish(action.index - 1)
         if ok then
             SetStatus(string.format("|cffff6666Banished|r echo #%d", action.index))
-        elseif action.endgame then
-            refusedFinalBanishSig = board.signature
+        else
+            refusedBanishSig = board.signature
             lastDecidedSig = nil
-            SetStatus("final-search Banish refused -- re-evaluating")
+            SetStatus(action.endgame
+                and "final-search Banish refused -- re-evaluating"
+                or "Banish refused -- trying another action")
         end
     elseif action.type == "freeze" then
         fillerFishState.consecutive = 0
@@ -1572,10 +1574,12 @@ local function StepRun(level, plan, slots, owned, flags, disabledLevers)
             else
                 fillerFishState.consecutive = 0
             end
-        elseif action.endgame then
-            refusedFinalRerollSig = board.signature
+        else
+            refusedRerollSig = board.signature
             lastDecidedSig = nil
-            SetStatus("final-search Reroll refused -- taking held Echo")
+            SetStatus(action.endgame
+                and "final-search Reroll refused -- taking held Echo"
+                or "Reroll refused -- taking the least-harmful Echo")
         end
     end
 end
@@ -1822,7 +1826,7 @@ local function Step()
             lastLoggedSig = nil
             lastBoardForRerollWatch = nil
             frozeThisBoard = nil
-            refusedFinalBanishSig, refusedFinalRerollSig = nil, nil
+            refusedBanishSig, refusedRerollSig = nil, nil
             Adapter.RunBoundaryReset()   -- void the dead run's picks/trust
         end
         if level ~= 80 then savedThisVisit = false end

--- a/core/Main.lua
+++ b/core/Main.lua
@@ -51,6 +51,8 @@ local fillerFishState = {
 -- Reset at the same run boundary as fillerFishState (level == 1, below).
 local forcedTakesBySpell = {}
 local frozeThisBoard = nil       -- board signature we already spent a freeze on
+local refusedFinalBanishSig = nil
+local refusedFinalRerollSig = nil
 local externalPauseUntil = 0
 
 -- SAVE state
@@ -109,7 +111,7 @@ Nexus.AppendAudit = AppendAudit
 -- TryAutoLock) is rebuilt every poll tick and only ever holds the MOST
 -- RECENT tick's reasoning -- fine for "why isn't this firing right now",
 -- useless for reconstructing what happened over an entire test run, since
--- whatever a "Full AI Log" export captures is only whatever the last tick
+-- whatever a full diagnostic export captures is only whatever the last tick
 -- before the export happened to look like. This keeps every actual write
 -- attempt (not the far more frequent no-op ticks) so a full run's lock/
 -- unlock sequence survives to be reviewed after the fact.
@@ -813,6 +815,8 @@ local function StepArm(level, plan, owned, slots, disabledLevers)
     -- (b) disable off-wishlist conformant tome levers (one send per 0.5s)
     if settings.autoDisable and plan and not plan.advisorOnly
         and Adapter.DiscoverySynced()
+        and not (Adapter.TomeMutationPaused
+            and Adapter.TomeMutationPaused())
         and (GetTime() - lastLeverSendAt) > 0.5 then
         local optOut = settings.leverOptOut or {}
         for _, lever in ipairs(plan.leverPlan.disable) do
@@ -1243,7 +1247,7 @@ local function LogText_AutoLock()
     out[#out + 1] = ""
 
     -- lastAutoLockTrace above is a single-tick snapshot, overwritten every
-    -- poll -- by the time a "Full AI Log" export is taken, it only reflects
+    -- poll -- by the time a full diagnostic export is taken, it only reflects
     -- whatever the last tick looked like. This is the durable history: every
     -- actual LockPerk/UnlockPerk attempt this session, oldest first.
     out[#out + 1] = "LOCK/UNLOCK EVENT HISTORY (actual write attempts only, oldest first):"
@@ -1279,6 +1283,13 @@ local function StepRun(level, plan, slots, owned, flags, disabledLevers)
         return
     end
 
+    if refusedFinalBanishSig and refusedFinalBanishSig ~= board.signature then
+        refusedFinalBanishSig = nil
+    end
+    if refusedFinalRerollSig and refusedFinalRerollSig ~= board.signature then
+        refusedFinalRerollSig = nil
+    end
+
     if armTargetSlot and not armedConfirmed then
         boardsSinceArm = boardsSinceArm + 1
         if board.guaranteedIndex then
@@ -1312,14 +1323,22 @@ local function StepRun(level, plan, slots, owned, flags, disabledLevers)
         owned, plan, flags, disabledLevers, catalog)
     local charges = Adapter.Charges()
     local locked = Adapter.LockedOwned and Adapter.LockedOwned() or nil
+    local horizon = Adapter.Horizon()
     local state = {
         board = board, owned = owned, locked = locked, charges = charges, plan = plan,
         activeEchoes = activeRow and activeRow.echoes or {},
         queue = queue, flags = flags, level = level, catalog = catalog,
-        horizon = Adapter.Horizon(),
-        canFreeze = (level < 80) and (frozeThisBoard ~= board.signature),
+        horizon = horizon,
+        canFreeze = (level < 80
+            or (type(horizon) == "number" and horizon > 1))
+            and (frozeThisBoard ~= board.signature),
         support = Model.Support(catalog, owned, level, disabledLevers, plan, DefaultProfile.params),
         params = DefaultProfile.params,
+        allowBanish = settings.autoBanish ~= false,
+        searchRefused = {
+            banish = refusedFinalBanishSig == board.signature,
+            reroll = refusedFinalRerollSig == board.signature,
+        },
         rerollBudget = {
             consecutive = fillerFishState.consecutive,
             -- Bracket 1 (RerollBracket above) spans levels 1-34 and the
@@ -1365,11 +1384,13 @@ local function StepRun(level, plan, slots, owned, flags, disabledLevers)
             local entry = {
                 t = date and date("%H:%M:%S") or "",
                 level = level,
+                horizon = horizon,
                 gIndex = board.guaranteedIndex,
                 charges = { b = charges.banish, r = charges.reroll,
                             f = charges.freeze, ok = charges.trustworthy },
                 proposal = { type = action.type, spellId = action.spellId,
-                             index = action.index, reason = action.reason },
+                             index = action.index, reason = action.reason,
+                             endgame = action.endgame },
                 cards = {},
                 pending = (function()
                     local out = {}
@@ -1524,6 +1545,10 @@ local function StepRun(level, plan, slots, owned, flags, disabledLevers)
         local ok, err = Adapter.Banish(action.index - 1)
         if ok then
             SetStatus(string.format("|cffff6666Banished|r echo #%d", action.index))
+        elseif action.endgame then
+            refusedFinalBanishSig = board.signature
+            lastDecidedSig = nil
+            SetStatus("final-search Banish refused -- re-evaluating")
         end
     elseif action.type == "freeze" then
         fillerFishState.consecutive = 0
@@ -1538,14 +1563,20 @@ local function StepRun(level, plan, slots, owned, flags, disabledLevers)
             frozeThisBoard = board.signature   -- refused: do not retry this board
         end
     elseif action.type == "reroll" then
-        lastBoardForRerollWatch = board
-        if action.reason == "bracket fishing: reroll filler guarantee" then
-            fillerFishState.consecutive = fillerFishState.consecutive + 1
-            fillerFishState.bracketSpent = fillerFishState.bracketSpent + 1
-        else
-            fillerFishState.consecutive = 0
+        local ok = Adapter.Reroll()
+        if ok then
+            lastBoardForRerollWatch = board
+            if action.reason == "bracket fishing: reroll filler guarantee" then
+                fillerFishState.consecutive = fillerFishState.consecutive + 1
+                fillerFishState.bracketSpent = fillerFishState.bracketSpent + 1
+            else
+                fillerFishState.consecutive = 0
+            end
+        elseif action.endgame then
+            refusedFinalRerollSig = board.signature
+            lastDecidedSig = nil
+            SetStatus("final-search Reroll refused -- taking held Echo")
         end
-        Adapter.Reroll()
     end
 end
 
@@ -1648,7 +1679,7 @@ local function StepSave(level, plan, slots, owned)
             -- Translate the raw Ratchet detail into something readable
             local readableDetail
             if tostring(detail):find("no net gain") then
-                readableDetail = "no new wishlist Echoes this run — bad RNG, not a bug"
+                readableDetail = "wishlist coverage unchanged this run"
             elseif tostring(detail):find("progress regressed")
                 or tostring(detail):find("coverage lost") then
                 readableDetail = "this run finished farther from the wishlist than your saved snapshot"
@@ -1760,7 +1791,12 @@ end
 
 local function Step()
     local level = Adapter.Level()
-    if lastLevelSeen ~= level then
+    local levelChanged = lastLevelSeen ~= level
+    if levelChanged then
+        -- A short user-action pause belongs to the board/level where it was
+        -- observed. Never let it suppress the first actionable board after a
+        -- genuine progression transition.
+        externalPauseUntil = 0
         if level == 1 then
             if seedVerify and saveVerifySlot then
                 Print("|cffff9040Nexus:|r the first-run Saved Build write was not confirmed before the reset. "
@@ -1782,12 +1818,17 @@ local function Step()
             fillerFishState.bracket = nil
             fillerFishState.bracketSpent = 0
             forcedTakesBySpell = {}
+            lastDecidedSig, lastDecision, decidedAt = nil, nil, nil
+            lastLoggedSig = nil
+            lastBoardForRerollWatch = nil
+            frozeThisBoard = nil
+            refusedFinalBanishSig, refusedFinalRerollSig = nil, nil
             Adapter.RunBoundaryReset()   -- void the dead run's picks/trust
         end
         if level ~= 80 then savedThisVisit = false end
         lastLevelSeen = level
     end
-    if Adapter.ExternalActionSeen() then
+    if Adapter.ExternalActionSeen() and not levelChanged then
         externalPauseUntil = GetTime() + 3
     end
 
@@ -2038,8 +2079,10 @@ local function LogText_Boards()
     end
     for i = first, #log do
         local e = log[i]
-        out[#out + 1] = string.format("== #%d [%s] L%s  charges B:%s R:%s F:%s%s",
+        out[#out + 1] = string.format("== #%d [%s] L%s H:%s%s  charges B:%s R:%s F:%s%s",
             i, tostring(e.t), tostring(e.level),
+            tostring(e.horizon),
+            (e.proposal and e.proposal.endgame) and " [FINAL]" or "",
             tostring(e.charges and e.charges.b),
             tostring(e.charges and e.charges.r),
             tostring(e.charges and e.charges.f),
@@ -2090,7 +2133,7 @@ local function UserMatchesProposal(u, p)
     return false
 end
 
--- Complete, compact export for AI review.  The normal Boards/Mismatch tabs stay
+-- Complete, compact diagnostic export. The normal Boards/Mismatch tabs stay
 -- bounded so opening /nexus log is cheap; this export includes every decision
 -- still retained in SavedVariables (currently up to 200) in one copy operation.
 -- Strings are dictionary-encoded to keep the single EditBox comfortably below
@@ -2135,10 +2178,10 @@ local function NewAIExportCoroutine()
         end
 
         local out = {
-            "NEXUS_AI_DIAGNOSTIC_LOG_3",
+            "NEXUS_DIAGNOSTIC_LOG_4",
             "version=" .. Esc(Nexus.VERSION) .. "|boards=" .. #log .. "|audits=" .. #audits .. "|probes=" .. #probes,
             "B=board|C=card|U=user action|Q=predicted guarantee queue head|A=run/save audit|D=dictionary",
-            "B|i|time|level|guaranteedIndex|banish|reroll|freeze|trusted|actionRef|spellId|cardIndex|reasonRef|pendingRef|mismatch|activeSlot|run|queueN",
+            "B|i|time|level|horizon|endgame|guaranteedIndex|banish|reroll|freeze|trusted|actionRef|spellId|cardIndex|reasonRef|pendingRef|mismatch|activeSlot|run|queueN",
             "C|board|card|spellId|familyRef|cardQ|catalogQ|wishQ|maxStack|owned|delta|annotationRef|flags(G,F,W)",
             "Q|board|position|spellId|familyRef|wished",
             "A|kindRef|time|run|level|activeSlot|targetSlot|resultRef|reasonRef|incumbentCounts|candidateCounts|summaryRef|exactRef|exactGained|exactLost|excessForced|excessAvoidable|excessShed|wrongQForced|wrongQAvoidable|wrongQShed|wrongQDetailRef|pollutionScoreRef",
@@ -2148,7 +2191,7 @@ local function NewAIExportCoroutine()
         }
         for i, e in ipairs(log) do
             local p = e.proposal or {}; local ch = e.charges or {}
-            out[#out + 1] = table.concat({"B",i,Esc(e.t),V(e.level),V(e.gIndex),V(ch.b),V(ch.r),V(ch.f),B(ch.ok),Ref(p.type),V(p.spellId),V(p.index),Ref(p.reason),Ref(e.pending),Mismatch(e),N(e.activeSlot),N(e.run),N(e.queueN)}, "|")
+            out[#out + 1] = table.concat({"B",i,Esc(e.t),V(e.level),V(e.horizon),B(p.endgame),V(e.gIndex),V(ch.b),V(ch.r),V(ch.f),B(ch.ok),Ref(p.type),V(p.spellId),V(p.index),Ref(p.reason),Ref(e.pending),Mismatch(e),N(e.activeSlot),N(e.run),N(e.queueN)}, "|")
             for ci, c in ipairs(e.cards or {}) do
                 local flags = (c.g and "G" or "-") .. (c.frozen and "F" or "-") .. (c.wished and "W" or "-")
                 out[#out + 1] = table.concat({"C",i,ci,V(c.id),Ref(c.fam),V(c.cardQ),V(c.catQ),V(c.wishQ),V(c.maxStack),V(c.owned),V(c.delta),Ref(c.ann),flags}, "|")
@@ -2173,7 +2216,7 @@ local function NewAIExportCoroutine()
             out[#out + 1] = table.concat({"P",Esc(p.t),Ref(p.event),Ref(p.detail)}, "|")
             if i % 10 == 0 then coroutine.yield("Encoding UI probes " .. i .. "/" .. #probes) end
         end
-        -- Include every human-readable /nexus log page in the same AI export.
+        -- Include every human-readable /nexus log page in the same export.
         -- This makes the export self-contained: compact event rows plus the exact
         -- State/Wishlist/Sync/DPS pages the player can see in the log window.
         local pageKeys = {"state", "wishlist", "boards", "mismatch", "sync", "dps", "autolock"}
@@ -2208,7 +2251,7 @@ function Nexus.NewAIExportCoroutine()
 end
 
 local function LogText_AIExport()
-    return "Press Copy Full AI Log. Nexus builds the complete export gradually to avoid a frame hitch."
+    return "Press Copy Full Diagnostic Log. Nexus builds the complete export gradually to avoid a frame hitch."
 end
 
 local function LogText_Mismatch()
@@ -2575,7 +2618,7 @@ local function LogViewerProvider(tabKey)
     return "unknown tab: " .. tostring(tabKey)
 end
 
--- Public read-only provider used by the comprehensive AI export. It returns
+-- Public read-only provider used by the comprehensive diagnostic export. It returns
 -- exactly the same text shown on each /nexus log page.
 function Nexus.GetDiagnosticPageText(tabKey)
     return LogViewerProvider(tabKey)

--- a/core/Sync.lua
+++ b/core/Sync.lua
@@ -278,6 +278,13 @@ local function TombAuthor(value)
     return type(value) == "table" and tostring(value.author or "") or ""
 end
 
+local function BucketContainsTombstone(bucket)
+    for id in pairs(tombstones or {}) do
+        if BuildBucket(id) == bucket then return true end
+    end
+    return false
+end
+
 local function LibraryHash(builds)
     local buckets = {}
     for i = 1, BUILD_BUCKETS do buckets[i] = {} end
@@ -1242,10 +1249,16 @@ local function HandleRequest(requester, peerBuildHash, peerDpsHash, requestId)
     local entry={key=key,requester=requester,requestId=requestId,peerBuildHash=peerBuildHash,peerDpsHash=peerDpsHash,buckets={}}
     for i=1,BUILD_BUCKETS do
         if tostring(peerB[i] or "") ~= tostring(myB[i] or "") then
-            entry.buckets["B"..i]={kind="B",bucket=i,hash=tostring(myB[i] or "0"),phase="wait",remaining=BucketDelay(key,"B",i)}
+            entry.buckets["B"..i]={kind="B",bucket=i,hash=tostring(myB[i] or "0"),
+                claimable=not BucketContainsTombstone(i),phase="wait",
+                remaining=BucketDelay(key,"B",i)}
         end
         if tostring(peerD[i] or "") ~= tostring(myD[i] or "") then
-            entry.buckets["D"..i]={kind="D",bucket=i,hash=tostring(myD[i] or "0"),phase="wait",remaining=BucketDelay(key,"D",i)}
+            -- Exact DPS evidence is owner-only. A peer that merely holds the
+            -- same row cannot retransmit it, so DPS buckets are never elected
+            -- through suppressible claims.
+            entry.buckets["D"..i]={kind="D",bucket=i,hash=tostring(myD[i] or "0"),
+                claimable=false,phase="wait",remaining=BucketDelay(key,"D",i)}
         end
     end
     if next(entry.buckets) then pendingResponses[key]=entry end
@@ -1254,10 +1267,13 @@ end
 
 local function HandleClaim(responder, requester, requestId, buildHash, dpsHash)
     local key=tostring(requester)..":"..tostring(requestId)
-    local pending=pendingResponses[key]
-    if pending and responder~=MyName() and tostring(buildHash)==tostring(CurrentBuildHash()) and tostring(dpsHash)==tostring(CurrentDpsHash()) then
-        pendingResponses[key]=nil
-        LogEvent("RX","suppressed duplicate legacy whole-state response; %s claimed",tostring(responder))
+    if pendingResponses[key] and responder~=MyName() then
+        -- Legacy whole-state claims cannot prove that the claimant owns every
+        -- DPS row or tombstone represented by the hashes. Keep the packet
+        -- readable for older peers, but never let it suppress an authoritative
+        -- owner response.
+        LogEvent("RX","ignored legacy whole-state claim from %s for owner-only safety",
+            tostring(responder))
     end
 end
 
@@ -1267,7 +1283,8 @@ local function HandleBucketClaim(responder, requester, requestId, kind, bucket, 
     local entry=pendingResponses[key]; if not entry then return end
     local id=tostring(kind)..tostring(tonumber(bucket) or 0)
     local b=entry.buckets and entry.buckets[id]
-    if b and tostring(b.hash)==tostring(bucketHash) then
+    if b and b.claimable ~= false
+        and tostring(b.hash)==tostring(bucketHash) then
         entry.buckets[id]=nil
         LogEvent("RX","mesh bucket %s claimed by %s for %s",id,tostring(responder),tostring(requester))
         if not next(entry.buckets) then pendingResponses[key]=nil end
@@ -1281,7 +1298,7 @@ local function ProcessPendingResponses(elapsed)
         for id,b in pairs(entry.buckets or {}) do
             b.remaining=(tonumber(b.remaining) or 0)-elapsed
             if b.remaining<=0 then
-                if b.phase=="wait" then
+                if b.phase=="wait" and b.claimable ~= false then
                     EnqueueControl(string.format("%s|%s|%s|%s|%s|%d|%s",CODE_BUCKET_CLAIM,MyName(),entry.requester,entry.requestId,b.kind,b.bucket,b.hash))
                     b.phase="settle"; b.remaining=BUCKET_SETTLE
                 else

--- a/core/Sync.lua
+++ b/core/Sync.lua
@@ -48,9 +48,20 @@ local CODE_DELETE     = "WLRD"
 local CODE_DPS        = "WLDS" -- legacy build-id DPS
 local CODE_DPS2       = "WLD2" -- exact-set DPS chunks
 local CODE_PRESENCE   = "WLNP" -- lightweight Nexus peer/version presence
+local PEER_PROTOCOL_CODES = {
+    [CODE_BUILD]=true, [CODE_INDEX]=true, [CODE_LOADOUT_REQ]=true,
+    [CODE_LOADOUT_CLAIM]=true, [CODE_REQUEST]=true, [CODE_CLAIM]=true,
+    [CODE_BUCKET_CLAIM]=true, [CODE_DELETE]=true, [CODE_DPS]=true,
+    [CODE_DPS2]=true, [CODE_PRESENCE]=true,
+}
 local CHAT_LIMIT      = 255    -- WoW SendChatMessage hard cap
 local CHAT_SAFETY     = 8      -- conservative margin
 local MAX_BYTES       = 32768  -- refuse builds larger than this
+local MAX_CHUNKS      = 999
+local MAX_CHUNK_BYTES = CHAT_LIMIT
+local MAX_ENCODED_BYTES = math.ceil(MAX_BYTES * 4 / 3) + 32
+local MAX_INFLIGHT_GLOBAL = 24
+local MAX_INFLIGHT_PER_SENDER = 4
 local SEND_INTERVAL   = 1.10   -- conservative channel pacing; avoids server chat spam/mutes
 local RECEIVE_WINDOW  = 60     -- compatibility/status timer; receiving is always enabled
 local INFLIGHT_GRACE  = 30     -- seconds to finish an interrupted chunk transfer
@@ -107,11 +118,45 @@ local autoSyncElapsed = 0
 local autoConverge = { active=false, pass=0, stable=0, started=0, lastInbound=0, buildHash=nil, dpsHash=nil }
 local Now, MyName
 local knownPeers = {} -- normalized player name -> { name, version, lastSeen }
+local CleanExpiredInflight
 
 local function NormalizePeerName(name)
     name = tostring(name or ""):gsub("%s+", "")
     name = name:match("^([^%-]+)") or name
     return name:lower()
+end
+
+local function SamePeer(a, b)
+    local ak = NormalizePeerName(a)
+    local bk = NormalizePeerName(b)
+    return ak ~= "" and ak == bk
+end
+
+local function OwnerKeyMatchesAuthor(ownerKey, author)
+    if ownerKey == nil then return true end
+    if type(ownerKey) ~= "string" or #ownerKey > 160
+        or ownerKey:find("[%c|]") then return false end
+    local ownerName, realm = ownerKey:match("^([^@]+)@([^@]+)$")
+    return ownerName ~= nil and realm ~= nil and SamePeer(ownerName, author)
+end
+
+local function TransferCount(map, sender)
+    local total, perSender = 0, 0
+    local senderKey = NormalizePeerName(sender)
+    for _, entry in pairs(map) do
+        total = total + 1
+        if NormalizePeerName(entry.sender) == senderKey then
+            perSender = perSender + 1
+        end
+    end
+    return total, perSender
+end
+
+local function CanStartTransfer(map, sender)
+    local buildTotal, buildSender = TransferCount(inflight, sender)
+    local dpsTotal, dpsSender = TransferCount(dpsInflight, sender)
+    return (buildTotal + dpsTotal) < MAX_INFLIGHT_GLOBAL
+        and (buildSender + dpsSender) < MAX_INFLIGHT_PER_SENDER
 end
 
 local function MarkPeer(name, version)
@@ -142,6 +187,24 @@ local stats = {
     malformedRejected=0, ignoredOutsideWindow=0,
     oversizeDropped=0, updated=0, skippedUpToDate=0,
 }
+
+function Sync.WorkState()
+    local buildCount, buildBytes, dpsCount, dpsBytes = 0, 0, 0, 0
+    for _, entry in pairs(inflight) do
+        buildCount = buildCount + 1
+        buildBytes = buildBytes + (tonumber(entry.bytes) or 0)
+    end
+    for _, entry in pairs(dpsInflight) do
+        dpsCount = dpsCount + 1
+        dpsBytes = dpsBytes + (tonumber(entry.bytes) or 0)
+    end
+    return {
+        buildInflight=buildCount, buildBytes=buildBytes,
+        dpsInflight=dpsCount, dpsBytes=dpsBytes,
+        maxGlobal=MAX_INFLIGHT_GLOBAL, maxPerSender=MAX_INFLIGHT_PER_SENDER,
+        maxEncodedBytes=MAX_ENCODED_BYTES,
+    }
+end
 
 ------------------------------------------------------------------------
 -- Diagnostic log
@@ -182,6 +245,11 @@ MyName = function() return (UnitName and UnitName("player")) or "?" end
 
 local function EscapedLen(s)
     return #s + select(2, s:gsub("|", ""))
+end
+
+local function FiniteNumber(value)
+    return type(value) == "number" and value == value
+        and value < math.huge and value > -math.huge
 end
 
 -- djb2 hash of the caller's library so peers can skip sends when already
@@ -248,6 +316,12 @@ local function CurrentDpsHash()
     return "0"
 end
 
+-- Read-only compatibility surface used by diagnostics and deterministic tests.
+-- It exposes the exact hashes placed on WLRQ without mutating sync state.
+function Sync.GetCompatibilityHashes()
+    return CurrentBuildHash(), CurrentDpsHash()
+end
+
 local function StableDelay(text)
     local h = 5381
     text = tostring(text or "")
@@ -275,6 +349,7 @@ local function CompactEncode(build)
         id = build.id,
         t  = build.title,
         a  = build.author,
+        o  = build.ownerKey,
         c  = build.class,
         m  = tonumber(build.lastModified) or tonumber(build.postedAt) or 0,
         d  = (type(build.description) == "string" and build.description ~= "")
@@ -292,10 +367,12 @@ local function CompactDecode(data)
     -- Support both compact (t/a/c/m/e) and legacy verbose (title/author/...)
     local title  = data.t or data.title
     local author = data.a or data.author
+    local ownerKey = data.o or data.ownerKey
     local class  = data.c or data.class
     local lastMod = tonumber(data.m or data.lastModified or data.postedAt) or 0
     local rawE   = data.e or data.echoes
     if not (data.id and title and type(rawE) == "table") then return nil end
+    if not OwnerKeyMatchesAuthor(ownerKey, author) then return nil end
     local echoes = {}
     for _, e in ipairs(rawE) do
         local spellId, quality, stacks, locked
@@ -323,6 +400,7 @@ local function CompactDecode(data)
         id          = tostring(data.id),
         title       = tostring(title):sub(1, 120),
         author      = type(author) == "string" and author:sub(1, 80) or "Unknown",
+        ownerKey    = type(ownerKey) == "string" and ownerKey:lower() or nil,
         class       = type(class) == "string" and class or nil,
         description = type(data.d or data.description) == "string"
                       and (data.d or data.description):sub(1, 4000) or "",
@@ -536,9 +614,11 @@ end
 
 local function SummaryEncode(build)
     return {
-        id=build.id, t=build.title, a=build.author, c=build.class,
+        id=build.id, t=build.title, a=build.author, o=build.ownerKey,
+        c=build.class,
         m=tonumber(build.lastModified) or tonumber(build.postedAt) or 0,
         h=build.fingerprintHash or HashText(BuildFingerprint(build)),
+        lh=HashText(build.link),
         n=(function()
             if type(build.echoes)=="table" then
                 local t=0; for _,e in ipairs(build.echoes) do t=t+(tonumber(e.stacks or e.count) or 1) end; return t
@@ -563,11 +643,18 @@ Sync.BroadcastBuildSummary = BroadcastSummary
 
 local QueueLegacyRecovery
 
-local function StoreSummary(data)
+local function StoreSummary(data, transportSender)
     if type(data)~="table" or not data.id or not data.t or not data.h then return false end
+    if not SamePeer(data.a, transportSender)
+        or not OwnerKeyMatchesAuthor(data.o or data.ownerKey, data.a) then
+        return false
+    end
     NexusDB.communityBuilds = NexusDB.communityBuilds or {}
     local id = tostring(data.id)
     local old = NexusDB.communityBuilds[id]
+    if old and old.isMine then return false end
+    if old and old.ownerVerified ~= false
+        and not SamePeer(old.author, data.a) then return false end
     local stamp = tonumber(data.m) or 0
     local tomb = tombstones[id]
     if tomb and stamp <= TombStamp(tomb) then
@@ -583,21 +670,27 @@ local function StoreSummary(data)
         stats.duplicatesSkipped = stats.duplicatesSkipped + 1
         if old and (type(old.echoes) ~= "table" or #old.echoes == 0) then
             QueueLegacyRecovery(id)
-            LogEvent("RX","legacy summary '%s' matched metadata; queued missing full loadout", tostring(data.t))
+            LogEvent("RX","DUPLICATE legacy summary '%s'; queued missing full loadout", tostring(data.t))
         else
             LogEvent("RX","skip summary '%s': DUPLICATE", tostring(data.t))
         end
         return false
     end
     local newHash = tostring(data.h)
+    local newLinkHash = type(data.lh) == "string" and data.lh or nil
+    local oldLinkHash = old and (old.linkHash or HashText(old.link)) or nil
+    local linkChanged = old ~= nil and newLinkHash ~= oldLinkHash
     local keepEchoes = old and old.fingerprintHash == newHash and old.echoes or nil
     NexusDB.communityBuilds[id] = {
         id=id, title=tostring(data.t):sub(1,120), author=tostring(data.a or "Unknown"):sub(1,80),
+        ownerKey=type(data.o)=="string" and data.o:lower() or nil,
         class=data.c, description=old and old.description or "",
         lastModified=stamp, postedAt=old and old.postedAt or stamp, isMine=old and old.isMine or false,
         autoDps=data.x==1, fingerprint=keepEchoes and old.fingerprint or nil,
         fingerprintHash=newHash, echoCount=tonumber(data.n) or 0,
         echoes=keepEchoes, loadoutAvailable=type(keepEchoes)=="table" and #keepEchoes>0,
+        linkHash=newLinkHash, needsFullBuild=linkChanged or nil,
+        ownerVerified=true,
     }
     seenRemoteIds[id] = stamp
     stats.received = stats.received + 1
@@ -610,7 +703,7 @@ local function StoreSummary(data)
         LogEvent("RX","STORED legacy summary '%s' by %s (%d Echo entries pending full sync)",
             tostring(data.t), tostring(data.a or "Unknown"), tonumber(data.n) or 0)
     end
-    if not keepEchoes then QueueLegacyRecovery(id) end
+    if not keepEchoes or linkChanged then QueueLegacyRecovery(id) end
     return true
 end
 
@@ -751,7 +844,8 @@ local function BroadcastMineFiltered(peerHash, onlyBucket)
     local n = 0
     for id, b in pairs(myMine) do
         local bucket = BuildBucket(id)
-        if (not onlyBucket or bucket == onlyBucket) and (legacyPeer or tostring(peerBuckets[bucket] or "") ~= tostring(myBuckets[bucket] or "")) then
+        if (not onlyBucket or bucket == onlyBucket)
+            and (legacyPeer or tostring(peerBuckets[bucket] or "") ~= tostring(myBuckets[bucket] or "")) then
             -- Send the complete build during reconciliation so receivers never
             -- need to click a menu item to fetch its Echo list. Summary is only
             -- a compatibility fallback for legacy/incomplete local rows.
@@ -766,7 +860,9 @@ local function BroadcastMineFiltered(peerHash, onlyBucket)
     end
     for id, tomb in pairs(tombstones or {}) do
         local bucket = BuildBucket(id)
-        if (not onlyBucket or bucket == onlyBucket) and (legacyPeer or tostring(peerBuckets[bucket] or "") ~= tostring(myBuckets[bucket] or "")) then
+        if SamePeer(TombAuthor(tomb), MyName())
+            and (not onlyBucket or bucket == onlyBucket)
+            and (legacyPeer or tostring(peerBuckets[bucket] or "") ~= tostring(myBuckets[bucket] or "")) then
             Enqueue(string.format("%s|%s|%s|%s|%s", CODE_DELETE, MyName(), id,
                 tostring(TombStamp(tomb)), TombAuthor(tomb)))
             n=n+1
@@ -812,19 +908,51 @@ end
 -- chunked using the same 255-byte-safe discipline as build sync.
 function Sync.BroadcastDpsRecord(record)
     if type(record) ~= "table" or type(record.fingerprint) ~= "string"
-        or not tonumber(record.dps) then return false end
-    local loadoutHash = record.loadoutHash
-    if not loadoutHash then
-        local fp = tostring(record.fingerprint)
-        loadoutHash = fp:sub(1,1) == "@" and fp:sub(2) or HashText(fp)
+        or type(record.echoes) ~= "table" then return false end
+    local dps = tonumber(record.dps)
+    local duration = tonumber(record.duration)
+    local stamp = tonumber(record.ts)
+    local level = tonumber(record.level)
+    local player = tostring(record.player or "")
+    local playerClass = type(record.class) == "string"
+        and record.class:upper() or nil
+    local validClass = playerClass == "WARRIOR" or playerClass == "PALADIN"
+        or playerClass == "HUNTER" or playerClass == "ROGUE"
+        or playerClass == "PRIEST" or playerClass == "DEATHKNIGHT"
+        or playerClass == "SHAMAN" or playerClass == "MAGE"
+        or playerClass == "WARLOCK" or playerClass == "DRUID"
+    local D = Nexus.DpsCapture
+    local computed = D and D.GetEchoKey and D.GetEchoKey(record.echoes) or nil
+    if not FiniteNumber(dps) or dps <= 0 or dps > 500000000
+        or not FiniteNumber(duration) or duration < 30
+        or not FiniteNumber(stamp) or stamp <= 0
+        or not FiniteNumber(level) or level < 1 or level > 80
+        or level ~= math.floor(level) or not validClass
+        or player == "" or #player > 64 or player:find("[%c|]")
+        or (record.category ~= "dummy" and record.category ~= "lk")
+        or not SamePeer(player, MyName())
+        or not OwnerKeyMatchesAuthor(record.ownerKey, player)
+        or not computed or computed ~= record.fingerprint then
+        return false
     end
-    if not loadoutHash then return false end
+    local loadoutHash = record.loadoutHash
+    if not loadoutHash and D and D.GetEchoHash then
+        loadoutHash = D.GetEchoHash(record.echoes)
+    end
+    local computedHash = D and D.GetEchoHash and D.GetEchoHash(record.echoes)
+        or nil
+    if not loadoutHash or (computedHash and loadoutHash ~= computedHash) then
+        return false
+    end
     local payload = {
         v = tonumber(record.protocolVersion) or 5,
         h = loadoutHash,
-        c = record.category, d = math.floor(tonumber(record.dps) or 0),
-        u = tonumber(record.duration) or 0, t = tonumber(record.ts) or 0,
-        p = tostring(record.player or "?"), l = tonumber(record.level) or 0,
+        f = record.fingerprint,
+        e = record.echoes,
+        c = record.category, d = math.floor(dps),
+        u = duration, t = stamp,
+        p = player, l = level,
+        k = record.class, o = record.ownerKey, r = record.realm,
         b = record.buildId,
         lk = (type(record.lockedEchoes)=="table" and #record.lockedEchoes>0)
              and record.lockedEchoes or nil,
@@ -858,19 +986,10 @@ function Sync.BroadcastDps(buildId, player, dps, level, category)
 end
 
 local function HandleDps(parts)
-    local sender = parts[2] or ""
-    local buildId, player = parts[3], parts[4]
-    local dps, level = tonumber(parts[5]), tonumber(parts[6]) or 0
-    local category = parts[7] or "dummy"
-    -- Direct submission: player field must match the wire sender
-    if player and player ~= "" and player:lower() ~= sender:lower() then
-        LogEvent("RX","DROP direct DPS: player='%s' != sender='%s'", tostring(player), tostring(sender))
-        return
-    end
-    if Nexus.DpsCapture and Nexus.DpsCapture.ReceiveSubmission then
-        pcall(Nexus.DpsCapture.ReceiveSubmission,
-            buildId, player, dps, level, category)
-    end
+    -- The legacy format has no duration, timestamp, or exact Echo evidence.
+    -- Keep the code recognized so old traffic fails cleanly, but never admit
+    -- it to a verified leaderboard.
+    LogEvent("RX", "DROP legacy DPS submission without required evidence")
 end
 
 local function HandleDps2(parts)
@@ -879,22 +998,44 @@ local function HandleDps2(parts)
     if not (sender and transferId and spec and data) then return end
     local idx, total = spec:match("^(%d+)/(%d+)$")
     idx, total = tonumber(idx), tonumber(total)
-    if not (idx and total and idx >= 1 and idx <= total and total <= 999) then return end
+    if not (idx and total and idx >= 1 and idx <= total
+        and total >= 1 and total <= MAX_CHUNKS
+        and #data <= MAX_CHUNK_BYTES) then return end
     local key = sender .. ":" .. transferId
     local e = dpsInflight[key]
     if not e then
-        e = { chunks = {}, total = total, t0 = Now() }
+        CleanExpiredInflight()
+        if not CanStartTransfer(dpsInflight, sender) then return end
+        e = { chunks = {}, total = total, t0 = Now(), lastSeen = Now(),
+            sender = sender, bytes = 0, received = 0 }
         dpsInflight[key] = e
     end
     if e.total ~= total then dpsInflight[key] = nil; return end
+    e.lastSeen = Now()
+    local prior = e.chunks[idx]
+    if prior ~= nil then
+        if prior ~= data then dpsInflight[key] = nil end
+        return
+    end
+    if e.bytes + #data > MAX_ENCODED_BYTES then
+        dpsInflight[key] = nil
+        return
+    end
     e.chunks[idx] = data
-    for i = 1, total do if not e.chunks[i] then return end end
+    e.bytes = e.bytes + #data
+    e.received = e.received + 1
+    if e.received ~= total then return end
     dpsInflight[key] = nil
     local raw = Codec.Base64Decode(table.concat(e.chunks, "", 1, total))
     local record = raw and Codec.JSONDecode(raw)
     if type(record) ~= "table" then return end
     if Nexus.DpsCapture and Nexus.DpsCapture.ReceiveRecord then
-        local ok, accepted = pcall(Nexus.DpsCapture.ReceiveRecord, record)
+        if not SamePeer(record.p or record.player, sender) then
+            LogEvent("RX", "DROP DPS owner mismatch from %s", tostring(sender))
+            return
+        end
+        local ok, accepted = pcall(
+            Nexus.DpsCapture.ReceiveRecord, record, sender)
         if ok and accepted then
             -- Mesh redistribution: relay the record so peers learn about it.
             Sync.BroadcastDpsRecord(record)
@@ -914,6 +1055,7 @@ function Sync.BroadcastDelete(build)
     if not build or not build.id then return false end
     local stamp = tostring((time and time()) or 0)
     local author = tostring(build.author or MyName())
+    if not SamePeer(author, MyName()) then return false end
     tombstones[build.id] = { stamp=tonumber(stamp) or 0, author=author }
     Enqueue(string.format("%s|%s|%s|%s|%s",
         CODE_DELETE, MyName(), build.id, stamp, author))
@@ -925,10 +1067,17 @@ end
 -- Incoming
 ------------------------------------------------------------------------
 
-local function CleanExpiredInflight()
+CleanExpiredInflight = function()
     local now = Now()
     for key, v in pairs(inflight) do
-        if now - (v.t0 or now) > INFLIGHT_GRACE then inflight[key] = nil end
+        if now - (v.lastSeen or v.t0 or now) > INFLIGHT_GRACE then
+            inflight[key] = nil
+        end
+    end
+    for key, v in pairs(dpsInflight) do
+        if now - (v.lastSeen or v.t0 or now) > INFLIGHT_GRACE then
+            dpsInflight[key] = nil
+        end
     end
 end
 
@@ -948,14 +1097,15 @@ local function ShouldStore(id, lastMod)
         seenRemoteIds[id] = known
     end
     if known == nil then return true, "new" end
-    if existing and (type(existing.echoes) ~= "table" or #existing.echoes == 0) then
+    if existing and (existing.needsFullBuild
+        or type(existing.echoes) ~= "table" or #existing.echoes == 0) then
         return true, "loadout"
     end
     if (tonumber(lastMod) or 0) > known then return true, "updated" end
     return false, "duplicate"
 end
 
-local function StoreReceivedBuild(payload)
+local function StoreReceivedBuild(payload, ownerVerified, relaySender)
     NexusDB.communityBuilds = NexusDB.communityBuilds or {}
     local existing = NexusDB.communityBuilds[payload.id]
     local mine = (existing and existing.isMine) or false
@@ -963,12 +1113,17 @@ local function StoreReceivedBuild(payload)
     local link = payload.link or (existing and existing.link) or nil
     NexusDB.communityBuilds[payload.id] = {
         id=payload.id, title=payload.title, description=payload.description,
-        author=payload.author, class=payload.class, echoes=payload.echoes,
+        author=payload.author,
+        ownerKey=ownerVerified and payload.ownerKey or nil,
+        class=payload.class, echoes=payload.echoes,
         postedAt=payload.postedAt, lastModified=payload.lastModified, isMine=mine,
         autoDps=payload.autoDps, fingerprint=BuildFingerprint(payload), fingerprintHash=HashText(BuildFingerprint(payload)),
         echoCount=(function() local t=0; for _,e in ipairs(payload.echoes) do t=t+(tonumber(e.stacks or e.count) or 1) end; return t end)(),
         loadoutAvailable=true,
         link=link,
+        linkHash=HashText(link), needsFullBuild=nil,
+        ownerVerified=ownerVerified and true or false,
+        relaySender=ownerVerified and nil or relaySender,
     }
     seenRemoteIds[payload.id] = payload.lastModified
     requestedLoadouts[payload.id] = nil
@@ -976,7 +1131,7 @@ local function StoreReceivedBuild(payload)
     lastSyncNewCount = lastSyncNewCount + 1
 end
 
-local function HandleComplete(buildId, lastMod, fullData)
+local function HandleComplete(buildId, lastMod, fullData, transportSender)
     local json = Codec.Base64Decode(fullData)
     if not json then
         stats.malformedRejected = stats.malformedRejected + 1
@@ -1003,7 +1158,17 @@ local function HandleComplete(buildId, lastMod, fullData)
         LogEvent("RX","REJECT id mismatch: envelope='%s' payload='%s'",
             tostring(buildId), tostring(payload.id)); return
     end
-    local allowed, why = ShouldStore(payload.id, payload.lastModified)
+    local directOwner = SamePeer(payload.author, transportSender)
+    local existing = NexusDB and NexusDB.communityBuilds
+        and NexusDB.communityBuilds[payload.id]
+    local replacingUnverified = existing and existing.ownerVerified == false
+        and directOwner
+    local allowed, why
+    if replacingUnverified then
+        allowed, why = true, "owner-verified"
+    else
+        allowed, why = ShouldStore(payload.id, payload.lastModified)
+    end
     if not allowed then
         if why == "deleted" then
             LogEvent("RX","skip '%s': tombstoned", tostring(payload.title))
@@ -1012,6 +1177,21 @@ local function HandleComplete(buildId, lastMod, fullData)
             LogEvent("RX","skip '%s': DUPLICATE (have stamp %s)",
                 tostring(payload.title), tostring(seenRemoteIds[payload.id]))
         end
+        return
+    end
+    if existing and not directOwner then
+        LogEvent("RX", "REJECT relayed overwrite of '%s' from %s",
+            tostring(payload.id), tostring(transportSender))
+        return
+    end
+    if existing and existing.isMine then
+        LogEvent("RX", "REJECT remote overwrite of local build '%s'",
+            tostring(payload.id))
+        return
+    end
+    if existing and existing.ownerVerified ~= false
+        and not SamePeer(existing.author, payload.author) then
+        LogEvent("RX", "REJECT owner change for '%s'", tostring(payload.id))
         return
     end
     if why == "updated" then
@@ -1026,7 +1206,7 @@ local function HandleComplete(buildId, lastMod, fullData)
         LogEvent("RX","STORED (new) '%s' by %s (%d echoes)",
             tostring(payload.title), tostring(payload.author), #payload.echoes)
     end
-    StoreReceivedBuild(payload)
+    StoreReceivedBuild(payload, directOwner, transportSender)
     if Nexus.CommunityBuilds and Nexus.CommunityBuilds.Refresh then
         pcall(Nexus.CommunityBuilds.Refresh)
     end
@@ -1136,19 +1316,24 @@ local function HandleDelete(sender, buildId, stamp, originAuthor)
     local existing = db and db[buildId]
     -- originAuthor is an optional 5th field; treat empty string same as nil
     local author = tostring((originAuthor and originAuthor ~= "") and originAuthor or sender or "")
+    if not SamePeer(sender, author) then
+        LogEvent("RX", "REJECT relayed delete for '%s' from %s",
+            tostring(buildId), tostring(sender))
+        return
+    end
     local tomb = { stamp=tonumber(stamp) or 0, author=author }
     local prior = tombstones[buildId]
     if prior and TombStamp(prior) >= tomb.stamp then return end
     if not existing then
-        tombstones[buildId] = tomb
-        LogEvent("RX","delete for '%s' relayed by %s (origin %s; tombstoned)",
-            tostring(buildId), tostring(sender), author); return
+        LogEvent("RX", "REJECT unprovable tombstone for unknown build '%s'",
+            tostring(buildId))
+        return
     end
     if existing.isMine then
         LogEvent("RX","ignoring delete for MY build '%s' relayed by %s",
             tostring(existing.title), tostring(sender)); return
     end
-    if tostring(existing.author) ~= author then
+    if not SamePeer(existing.author, sender) then
         LogEvent("RX","REJECT delete of '%s': origin %s is not the author (%s)",
             tostring(existing.title), author, tostring(existing.author)); return
     end
@@ -1175,7 +1360,16 @@ function Sync.HandleIncoming(text, sender)
     end
     local code = parts[1]
     local protocolSender = parts[2] or sender
-    if code and code ~= "" and protocolSender and protocolSender ~= "" then
+    local actualSender = sender or protocolSender
+    if protocolSender and actualSender
+        and not SamePeer(protocolSender, actualSender) then
+        LogEvent("RX", "DROP sender mismatch: wire=%s transport=%s",
+            tostring(protocolSender), tostring(actualSender))
+        return
+    end
+    if actualSender and parts[2] then parts[2] = actualSender end
+    protocolSender = actualSender
+    if PEER_PROTOCOL_CODES[code] and protocolSender and protocolSender ~= "" then
         MarkPeer(protocolSender, code == CODE_REQUEST and parts[6] or nil)
     end
 
@@ -1203,7 +1397,8 @@ function Sync.HandleIncoming(text, sender)
         autoConverge.lastInbound = Now()
         local raw = parts[3] and Codec.Base64Decode(parts[3])
         local data = raw and Codec.JSONDecode(raw)
-        if StoreSummary(data) and Nexus.CommunityBuilds and Nexus.CommunityBuilds.Refresh then
+        if StoreSummary(data, protocolSender)
+            and Nexus.CommunityBuilds and Nexus.CommunityBuilds.Refresh then
             pcall(Nexus.CommunityBuilds.Refresh)
         end
         return
@@ -1249,7 +1444,8 @@ function Sync.HandleIncoming(text, sender)
     if not (msgSender and buildId and lastMod and chunkSpec and data) then return end
     local idx, total = chunkSpec:match("^(%d+)/(%d+)$")
     idx, total = tonumber(idx), tonumber(total)
-    if not (idx and total and idx >= 1 and total >= 1 and idx <= total) then return end
+    if not (idx and total and idx >= 1 and total >= 1 and idx <= total
+        and total <= MAX_CHUNKS and #data <= MAX_CHUNK_BYTES) then return end
 
     autoConverge.lastInbound = Now()
     local key   = msgSender..":"..buildId
@@ -1260,27 +1456,43 @@ function Sync.HandleIncoming(text, sender)
         -- caused permanently incomplete rows and menu-triggered request spam.
         autoConverge.lastInbound = Now()
         if total == 1 then
+            if #data > MAX_ENCODED_BYTES then return end
             LogEvent("RX","single-chunk build '%s' from %s", tostring(buildId), tostring(msgSender))
-            HandleComplete(buildId, lastMod, data)
+            HandleComplete(buildId, lastMod, data, msgSender)
             return
         end
         CleanExpiredInflight()
+        if not CanStartTransfer(inflight, msgSender) then return end
         LogEvent("RX","starting %d-chunk build '%s' from %s",
             total, tostring(buildId), tostring(msgSender))
-        entry = { chunks={}, total=total, t0=Now(), lastMod=lastMod }
+        entry = { chunks={}, total=total, t0=Now(), lastSeen=Now(),
+            lastMod=lastMod, sender=msgSender, bytes=0, received=0 }
         inflight[key] = entry
     end
 
-    if total ~= entry.total then return end  -- inconsistent chunk spec
+    if total ~= entry.total or tostring(lastMod) ~= tostring(entry.lastMod) then
+        inflight[key] = nil
+        return
+    end
+    entry.lastSeen = Now()
+    local prior = entry.chunks[idx]
+    if prior ~= nil then
+        if prior ~= data then inflight[key] = nil end
+        return
+    end
+    if entry.bytes + #data > MAX_ENCODED_BYTES then
+        inflight[key] = nil
+        return
+    end
     entry.chunks[idx] = data
-    local have = 0
-    for i = 1, entry.total do if entry.chunks[i] then have=have+1 end end
-    if have == entry.total then
+    entry.bytes = entry.bytes + #data
+    entry.received = entry.received + 1
+    if entry.received == entry.total then
         local full = table.concat(entry.chunks, "", 1, entry.total)
         inflight[key] = nil
         LogEvent("RX","transfer '%s' complete (%d/%d chunks, %d bytes)",
-            tostring(buildId), have, entry.total, #full)
-        HandleComplete(buildId, entry.lastMod, full)
+            tostring(buildId), entry.received, entry.total, #full)
+        HandleComplete(buildId, entry.lastMod, full, msgSender)
     end
 end
 
@@ -1424,6 +1636,7 @@ function Sync.TombstoneCount()
 end
 
 function Sync.OnUpdate(elapsed)
+    CleanExpiredInflight()
     ProcessPendingResponses(elapsed)
     PumpLegacyRecovery(elapsed)
     PumpQueue(elapsed)
@@ -1526,6 +1739,20 @@ end
 
 function Sync.Init(codec, adapter)
     Codec, Adapter = codec, adapter
+    sendQueue, sendQueueHead = {}, 1
+    controlQueue, controlQueueHead = {}, 1
+    inflight, dpsInflight = {}, {}
+    ticker = 0
+    throttlePauseUntil, throttleSlowUntil = 0, 0
+    lastTransportAttempt = -math.huge
+    joinRetryTicker, joinAttempts = 0, 0
+    receiveWindowUntil = 0
+    lastRequestAt, lastAnsweredAt = -math.huge, -math.huge
+    lastSyncNewCount = 0
+    for key in pairs(stats) do stats[key] = 0 end
+    stats.sent, stats.received, stats.duplicatesSkipped = 0, 0, 0
+    stats.malformedRejected, stats.ignoredOutsideWindow = 0, 0
+    stats.oversizeDropped, stats.updated, stats.skippedUpToDate = 0, 0, 0
     hotBuilds    = {}  -- clear on init
     pendingResponses = {}
     pendingLoadouts = {}

--- a/logic/Model.lua
+++ b/logic/Model.lua
@@ -94,11 +94,11 @@ local function Param(params, key)
     return DEFAULT_PARAMS[key]
 end
 
--- Marginal value of taking one copy of spellId given the plan and the
--- owned state. Coverage/duplicate/filler are decided at FAMILY
--- granularity (any quality variant of a wished family covers it);
--- exhaustion inputs stay per-spellId. Pure; returns a single number,
--- 0 on malformed input.
+-- Marginal value of taking one copy of spellId given the plan and the owned
+-- state. Guarantee subtraction remains family-granular, but wishlist value is
+-- quality-qualified: only a requested tier can advance a multi-quality target.
+-- Exhaustion inputs stay per-spellId. Pure; returns a single number, 0 on
+-- malformed input.
 function Model.Delta(plan, owned, spellId, catalog, params)
     plan = type(plan) == "table" and plan or {}
     owned = type(owned) == "table" and owned or {}
@@ -114,74 +114,60 @@ function Model.Delta(plan, owned, spellId, catalog, params)
     local bySpell = type(owned.bySpell) == "table" and owned.bySpell or {}
     local byFamily = type(owned.byFamily) == "table" and owned.byFamily or {}
     local ownedFam = tonumber(byFamily[family]) or 0
-    local ownedSpell = tonumber(bySpell[spellId]) or 0
+    local ownedSpell = tonumber(bySpell[spellId])
+        or tonumber(bySpell[tostring(spellId)]) or 0
     local maxStack = tonumber(row.maxStack) or 1
     if maxStack < 1 then maxStack = 1 end
+    local wishedFamilies = type(plan.wishedFamilies) == "table"
+        and plan.wishedFamilies or {}
+    local familyWanted = wishedFamilies[family] and true or false
+    local qualifiedOwned, targetTotal = 0, 1
+    local offeredNeeded = false
+    if familyWanted then
+        qualifiedOwned, targetTotal = Model.TargetProgress(
+            plan, catalog, family, owned)
+        offeredNeeded = Model.QualityOfferNeeded(
+            plan, catalog, family, tonumber(row.quality) or 0, owned)
+    end
 
     -- Duplicate: family full at maxStack, this exact spellId exhausted,
     -- or any owned maxStack==1 family member (one owned quality variant
     -- of a unique echo exhausts the whole family for value purposes,
     -- even though pool removal stays per-spellId).
-    local isDuplicate = (ownedFam >= maxStack and ownedFam > 0)
-        or ownedSpell >= maxStack
-    if not isDuplicate then
+    local isDuplicate = ownedSpell >= maxStack
+    if not isDuplicate and not (familyWanted and offeredNeeded) then
+        isDuplicate = (ownedFam >= maxStack and ownedFam > 0)
         local members = type(catalog.familyMembers) == "table"
             and catalog.familyMembers[family] or nil
-        for i = 1, #(members or {}) do
-            local m = (members or {})[i]
-            local mr = rows[m]
-            if type(mr) == "table" and (tonumber(mr.maxStack) or 1) == 1
-                and (tonumber(bySpell[m]) or 0) > 0 then
-                isDuplicate = true
-                break
+        if not isDuplicate then
+            for i = 1, #(members or {}) do
+                local m = (members or {})[i]
+                local mr = rows[m]
+                if type(mr) == "table" and (tonumber(mr.maxStack) or 1) == 1
+                    and (tonumber(bySpell[m])
+                        or tonumber(bySpell[tostring(m)]) or 0) > 0 then
+                    isDuplicate = true
+                    break
+                end
             end
         end
     end
     if isDuplicate then return Param(params, "duplicate") end
 
-    local wishedFamilies = type(plan.wishedFamilies) == "table"
-        and plan.wishedFamilies or {}
-    local targets = type(plan.targets) == "table" and plan.targets or {}
-
     local v
-    if wishedFamilies[family] then
-        if ownedFam <= 0 then
-            local quality = tonumber(row.quality) or 0
-            -- Quality gate (multi-quality families -- the stat echoes):
-            -- quality variants are DISTINCT spellIds in one family, and
-            -- taking a below-wished-quality copy covers the family at the
-            -- wrong quality for the run AND poisons the saved loadout
-            -- (next run's guarantee re-serves the low copy). Worse than
-            -- filler -- filler is merely useless, this actively damages
-            -- the end build. Applies REGARDLESS of maxStack: stat echoes
-            -- are stackable in the server catalog even when the wishlist
-            -- wants a single copy (live 2026-07-24: a gray guaranteed
-            -- Iron Constitution scored full coverage because the old gate
-            -- required maxStack == 1).
-            local wishedQuality = Model.EffectiveWishedQuality(plan, catalog, family, 0, bySpell)
-            if quality < wishedQuality
-                and Model.FamilyMultiQuality(catalog, family) then
-                return Param(params, "qualityMiss")
-            end
+    if familyWanted then
+        if not offeredNeeded then
+            return Model.FamilyMultiQuality(catalog, family)
+                and Param(params, "qualityMiss")
+                or Param(params, "duplicate")
+        end
+        local quality = tonumber(row.quality) or 0
+        if qualifiedOwned <= 0 then
             v = Param(params, "coverage")
                 + Param(params, "qualityBonus") * quality
         else
-            local target = targets[family]
-            local targetStacks = type(target) == "table"
-                and tonumber(target.targetStacks) or nil
-            targetStacks = targetStacks or 1
-            if ownedFam < targetStacks then
-                local wishedQuality = Model.EffectiveWishedQuality(plan, catalog, family, ownedFam, bySpell)
-                local quality = tonumber(row.quality) or 0
-                if quality < wishedQuality
-                    and Model.FamilyMultiQuality(catalog, family) then
-                    return Param(params, "qualityMiss")
-                end
-                v = Param(params, "coverage")
-                    * ((targetStacks - ownedFam) / targetStacks)
-            else
-                v = 0 -- covered at target; extra copies are neutral
-            end
+            v = Param(params, "coverage")
+                * ((targetTotal - qualifiedOwned) / targetTotal)
         end
     else
         v = Param(params, "filler")
@@ -197,7 +183,8 @@ function Model.Delta(plan, owned, spellId, catalog, params)
         end
         local anchorFam = type(catalog.familyOf) == "table"
             and catalog.familyOf[anchor] or nil
-        local anchorOwned = (tonumber(bySpell[anchor]) or 0) > 0
+        local anchorOwned = (tonumber(bySpell[anchor])
+            or tonumber(bySpell[tostring(anchor)]) or 0) > 0
             or (anchorFam ~= nil and (tonumber(byFamily[anchorFam]) or 0) > 0)
         if anchorOwned then
             v = v + Param(params, "diversity")
@@ -253,6 +240,31 @@ end
 -- "we want the blue of each stat if possible" means the target is what's
 -- POSSIBLE, not what a lossy wire happened to store. The stored
 -- wishedQuality still acts as a floor for single-variant data.
+local function CountFamilyAtQuality(catalog, family, ownedBySpell, quality)
+    if type(ownedBySpell) ~= "table" then return 0 end
+    local members = type(catalog) == "table"
+        and type(catalog.familyMembers) == "table"
+        and catalog.familyMembers[family] or nil
+    local rows = type(catalog) == "table" and catalog.rows or nil
+    local count = 0
+    for i = 1, #(members or {}) do
+        local id = members[i]
+        local row = type(rows) == "table" and rows[id] or nil
+        if type(row) == "table"
+            and (tonumber(row.quality) or 0) == tonumber(quality) then
+            count = count + (tonumber(ownedBySpell[id])
+                or tonumber(ownedBySpell[tostring(id)]) or 0)
+        end
+    end
+    return count
+end
+
+local function MultiTierTarget(target)
+    return type(target) == "table"
+        and type(target.qualityTiers) == "table"
+        and #target.qualityTiers > 1
+end
+
 function Model.EffectiveWishedQuality(plan, catalog, family, ownedFamCount, ownedBySpell)
     local stored = 0
     local targets = type(plan) == "table" and plan.targets or nil
@@ -260,13 +272,19 @@ function Model.EffectiveWishedQuality(plan, catalog, family, ownedFamCount, owne
     if type(t) == "table" then stored = tonumber(t.wishedQuality) or 0 end
 
     -- Multi-tier wishlist (e.g. Quick Hands Common×5, Uncommon×50, Rare×20):
-    -- the player explicitly wants copies at EVERY listed quality tier.
-    -- Return the lowest quality on the wishlist so the gate accepts anything
-    -- at or above that level — a Common Quick Hands is not a quality miss
-    -- when Common is explicitly on the wishlist.
-    if type(t) == "table" and type(t.qualityTiers) == "table"
-        and #t.qualityTiers > 1 then
-        return stored  -- stored = wishedQuality = lowest tier quality
+    -- the player explicitly wants copies at EVERY listed quality tier. Return
+    -- the first tier whose exact quota remains incomplete. Callers validating
+    -- one offer use QualityOfferNeeded below.
+    if MultiTierTarget(t) then
+        for _, tier in ipairs(t.qualityTiers) do
+            local need = math.max(0, tonumber(tier.n) or 0)
+            if CountFamilyAtQuality(
+                catalog, family, ownedBySpell, tonumber(tier.q) or 0) < need then
+                return tonumber(tier.q) or stored
+            end
+        end
+        local last = t.qualityTiers[#t.qualityTiers]
+        return tonumber(last and last.q) or stored
     end
 
     -- Single-tier wishlist: escalate to catalog peak for multi-quality
@@ -279,12 +297,93 @@ function Model.EffectiveWishedQuality(plan, catalog, family, ownedFamCount, owne
     return stored
 end
 
+-- Quality-qualified progress for a wished family. Multi-tier targets count
+-- every exact tier independently; lower-tier surplus cannot satisfy a higher
+-- quota. Single-tier multi-quality targets count only acceptable variants.
+function Model.TargetProgress(plan, catalog, family, owned)
+    local targets = type(plan) == "table" and plan.targets or nil
+    local target = targets and targets[family]
+    local want = type(target) == "table"
+        and tonumber(target.targetStacks) or 1
+    if want < 1 then want = 1 end
+
+    local bySpell = type(owned) == "table"
+        and type(owned.bySpell) == "table" and owned.bySpell or {}
+    local byFamily = type(owned) == "table"
+        and type(owned.byFamily) == "table" and owned.byFamily or {}
+
+    if MultiTierTarget(target) then
+        local have, total = 0, 0
+        for _, tier in ipairs(target.qualityTiers) do
+            local need = math.max(0, tonumber(tier.n) or 0)
+            local count = CountFamilyAtQuality(
+                catalog, family, bySpell, tonumber(tier.q) or 0)
+            have = have + math.min(count, need)
+            total = total + need
+        end
+        if total > 0 then return have, total end
+    end
+
+    if Model.FamilyMultiQuality(catalog, family) then
+        local required = Model.EffectiveWishedQuality(
+            plan, catalog, family, nil, bySpell)
+        local members = type(catalog) == "table"
+            and type(catalog.familyMembers) == "table"
+            and catalog.familyMembers[family] or nil
+        local rows = type(catalog) == "table" and catalog.rows or nil
+        local have = 0
+        for i = 1, #(members or {}) do
+            local id = members[i]
+            local row = type(rows) == "table" and rows[id] or nil
+            if type(row) == "table"
+                and (tonumber(row.quality) or 0) >= required then
+                have = have + (tonumber(bySpell[id])
+                    or tonumber(bySpell[tostring(id)]) or 0)
+            end
+        end
+        return math.min(have, want), want
+    end
+
+    local have = tonumber(byFamily[family])
+        or tonumber(byFamily[tostring(family)]) or 0
+    return math.min(have, want), want
+end
+
+-- True while this exact offered quality can satisfy an unmet target quota.
+function Model.QualityOfferNeeded(plan, catalog, family, quality, owned)
+    local progress, want = Model.TargetProgress(plan, catalog, family, owned)
+    if progress >= want then return false end
+
+    local targets = type(plan) == "table" and plan.targets or nil
+    local target = targets and targets[family]
+    local bySpell = type(owned) == "table"
+        and type(owned.bySpell) == "table" and owned.bySpell or {}
+    quality = tonumber(quality) or 0
+
+    if MultiTierTarget(target) then
+        for _, tier in ipairs(target.qualityTiers) do
+            if (tonumber(tier.q) or 0) == quality then
+                local need = math.max(0, tonumber(tier.n) or 0)
+                return CountFamilyAtQuality(
+                    catalog, family, bySpell, quality) < need
+            end
+        end
+        return false
+    end
+
+    if Model.FamilyMultiQuality(catalog, family) then
+        return quality >= Model.EffectiveWishedQuality(
+            plan, catalog, family, nil, bySpell)
+    end
+    return true
+end
+
 -- A wished STACKING family still short of its wishlist stack target
 -- (own 0..target-1 of a want-9 echo). The guarantee only ever serves the
 -- FIRST copy of a family; every further stack is free-slot RNG, so a
 -- free-slot appearance of one of these is always worth banking with a
 -- freeze when it isn't this board's pick. Pure; false on malformed input.
-function Model.StackWishBelowTarget(plan, owned, family)
+function Model.StackWishBelowTarget(plan, owned, family, catalog)
     if family == nil then return false end
     local wishedFamilies = type(plan) == "table" and plan.wishedFamilies or nil
     if not (wishedFamilies and wishedFamilies[family]) then return false end
@@ -292,6 +391,10 @@ function Model.StackWishBelowTarget(plan, owned, family)
     local target = targets and targets[family]
     local targetStacks = (type(target) == "table" and tonumber(target.targetStacks)) or 1
     if targetStacks <= 1 then return false end
+    if type(Model.TargetProgress) == "function" and catalog then
+        local have, want = Model.TargetProgress(plan, catalog, family, owned)
+        return have < want
+    end
     local byFamily = type(owned) == "table" and owned.byFamily or nil
     local ownedFam = tonumber(byFamily and byFamily[family]) or 0
     return ownedFam < targetStacks

--- a/logic/Policy.lua
+++ b/logic/Policy.lua
@@ -109,6 +109,204 @@ local function Annotation(card, delta, plan, owned)
     return "junk"
 end
 
+local function IsFrozen(card)
+    return card.isFrozen or card.isCarried or card.justFrozen
+end
+
+local function IsWanted(model, card, delta, plan, owned, catalog)
+    if not (delta and delta > 0 and Wished(plan, card.family)) then
+        return false
+    end
+    if type(model.FamilyMultiQuality) == "function"
+        and model.FamilyMultiQuality(catalog, card.family) then
+        if type(model.QualityOfferNeeded) == "function" then
+            return model.QualityOfferNeeded(
+                plan, catalog, card.family,
+                tonumber(card.quality) or 0, owned)
+        end
+        local bySpell = type(owned) == "table" and owned.bySpell or nil
+        local required = type(model.EffectiveWishedQuality) == "function"
+            and model.EffectiveWishedQuality(
+                plan, catalog, card.family, OwnedFam(owned, card.family), bySpell)
+            or WishedQuality(plan, card.family)
+        return (tonumber(card.quality) or 0) >= (tonumber(required) or 0)
+    end
+    return true
+end
+
+local function IsOneShot(model, card, plan, owned, catalog)
+    local have = OwnedFam(owned, card.family)
+    if type(model.TargetProgress) == "function" then
+        have = model.TargetProgress(plan, catalog, card.family, owned)
+    end
+    return have <= 0 and type(model.FamilyMultiQuality) == "function"
+        and model.FamilyMultiQuality(catalog, card.family)
+        and (type(model.QualityOfferNeeded) ~= "function"
+            or model.QualityOfferNeeded(
+                plan, catalog, card.family,
+                tonumber(card.quality) or 0, owned))
+end
+
+local function WantedTier(model, card, plan, owned, catalog)
+    if type(model.StackWishBelowTarget) == "function"
+        and model.StackWishBelowTarget(
+            plan, owned, card.family, catalog) then
+        return 1
+    end
+    if IsOneShot(model, card, plan, owned, catalog) then return 2 end
+    return 3
+end
+
+local function BetterWanted(model, cards, deltas, plan, owned, catalog,
+    candidate, incumbent)
+    if incumbent == nil then return true end
+    local ct = WantedTier(model, cards[candidate], plan, owned, catalog)
+    local it = WantedTier(model, cards[incumbent], plan, owned, catalog)
+    if ct ~= it then return ct < it end
+    if deltas[candidate] ~= deltas[incumbent] then
+        return deltas[candidate] > deltas[incumbent]
+    end
+    return candidate < incumbent
+end
+
+local function QueueCanDeliverWanted(model, state, card, plan, owned, catalog)
+    local queue = type(state.queue) == "table" and state.queue.entries or nil
+    if type(queue) ~= "table" or card.family == nil then return false end
+    for i = 1, #queue do
+        local entry = queue[i]
+        if type(entry) == "table" and entry.wanted == true
+            and entry.family == card.family then
+            if type(model.FamilyMultiQuality) ~= "function"
+                or not model.FamilyMultiQuality(catalog, card.family) then
+                return true
+            end
+            local rows = type(catalog) == "table" and catalog.rows or nil
+            local row = type(rows) == "table"
+                and rows[tonumber(entry.spellId)] or nil
+            local quality = type(row) == "table"
+                and tonumber(row.quality) or tonumber(entry.quality)
+            if quality and type(model.QualityOfferNeeded) == "function"
+                and model.QualityOfferNeeded(
+                    plan, catalog, card.family, quality, owned) then
+                return true
+            end
+        end
+    end
+    return false
+end
+
+local function FreezeWorthy(model, state, card, plan, owned, catalog)
+    if type(model.StackWishBelowTarget) == "function"
+        and model.StackWishBelowTarget(
+            plan, owned, card.family, catalog) then
+        return true
+    end
+    return not QueueCanDeliverWanted(
+        model, state, card, plan, owned, catalog)
+end
+
+local function TakeAction(cards, annotations, deltas, index, reason)
+    return {
+        type = "take", index = index, spellId = cards[index].spellId,
+        reason = reason, annotations = annotations, deltas = deltas,
+    }
+end
+
+local function Endgame(action)
+    action.endgame = true
+    return action
+end
+
+local function SafeBanishCandidate(cards, deltas, plan, gIndex)
+    local worst, worstDelta = nil, nil
+    for i = 1, #cards do
+        local card = cards[i]
+        if i ~= gIndex
+            and not (card.isGuaranteed or card.isFrozen or card.isCarried
+                or card.justFrozen)
+            and not Wished(plan, card.family)
+            and (worst == nil or deltas[i] < worstDelta
+                or (deltas[i] == worstDelta and i < worst)) then
+            worst, worstDelta = i, deltas[i]
+        end
+    end
+    return worst
+end
+
+local function LeastHarmfulSide(cards, annotations, deltas, gIndex)
+    local anyNonDuplicate = false
+    for i = 1, #cards do
+        if i ~= gIndex and not cards[i].isGuaranteed
+            and not cards[i].justFrozen
+            and annotations[i] ~= "duplicate" then
+            anyNonDuplicate = true
+            break
+        end
+    end
+    local pick = nil
+    for i = 1, #cards do
+        local eligible = i ~= gIndex and not cards[i].isGuaranteed
+            and not cards[i].justFrozen
+            and ((not anyNonDuplicate) or annotations[i] ~= "duplicate")
+        if eligible and (pick == nil
+            or deltas[i] > deltas[pick]
+            or (deltas[i] == deltas[pick]
+                and annotations[pick] == "filler"
+                and annotations[i] ~= "filler")
+            or (deltas[i] == deltas[pick]
+                and (annotations[i] == "filler")
+                    == (annotations[pick] == "filler")
+                and (tonumber(cards[i].quality) or 0)
+                    < (tonumber(cards[pick].quality) or 0))
+            or (deltas[i] == deltas[pick]
+                and (tonumber(cards[i].quality) or 0)
+                    == (tonumber(cards[pick].quality) or 0)
+                and i < pick)) then
+            pick = i
+        end
+    end
+    return pick
+end
+
+local function MissingAfterFallback(plan, owned, fallbackCard, catalog)
+    local simulated = { byFamily = {}, bySpell = {} }
+    for family, count in pairs(type(owned) == "table" and owned.byFamily or {}) do
+        simulated.byFamily[family] = tonumber(count) or 0
+    end
+    for spellId, count in pairs(type(owned) == "table" and owned.bySpell or {}) do
+        simulated.bySpell[spellId] = tonumber(count) or 0
+    end
+    if type(fallbackCard) == "table" then
+        local family = fallbackCard.family
+            or (type(catalog) == "table"
+                and type(catalog.familyOf) == "table"
+                and catalog.familyOf[tonumber(fallbackCard.spellId)])
+        local count = tonumber(fallbackCard.stacks or fallbackCard.count) or 1
+        if family ~= nil then
+            simulated.byFamily[family] =
+                (tonumber(simulated.byFamily[family]) or 0) + count
+        end
+        local spellId = tonumber(fallbackCard.spellId)
+        if spellId then
+            simulated.bySpell[spellId] =
+                (tonumber(simulated.bySpell[spellId]) or 0) + count
+        end
+    end
+    for family in pairs(type(plan) == "table" and plan.wishedFamilies or {}) do
+        local have, want
+        local model = GetModel()
+        if type(model.TargetProgress) == "function" then
+            have, want = model.TargetProgress(plan, catalog, family, simulated)
+        else
+            local target = type(plan.targets) == "table" and plan.targets[family]
+            want = type(target) == "table" and tonumber(target.targetStacks) or 1
+            have = tonumber(simulated.byFamily[family]) or 0
+        end
+        if have < math.max(1, tonumber(want) or 1) then return true end
+    end
+    return false
+end
+
 -- state = { board, owned, charges, plan, queue, flags, level, horizon,
 --           support, params, canFreeze, rerollBudget [, catalog] }
 -- Returns { type = "take"|"freeze"|"reroll"|"banish"|"wait", spellId=?,
@@ -205,8 +403,8 @@ function Policy.Decide(state)
         local total = 0
         local activeEchoes = state.activeEchoes
         if type(activeEchoes) == "table" then
-            for ai = 1, #activeEchoes do
-                local ae = activeEchoes[ai]
+            for activeIndex = 1, #activeEchoes do
+                local ae = activeEchoes[activeIndex]
                 if type(ae) == "table"
                     and tonumber(ae.spellId) == tonumber(spellId) then
                     total = total
@@ -222,7 +420,7 @@ function Policy.Decide(state)
         return tonumber(ownedSafe.bySpell[spellId]) or 0
     end
 
-    local deltas, eff = {}, {}
+    local deltas, eff, wanted = {}, {}, {}
     local precious = {}   -- [i]=true: one-shot quality catch (see loop)
     local deferFactor = tonumber(params.deferFactor) or 0.35
     local bankedWantedOnBoard = false
@@ -231,6 +429,7 @@ function Policy.Decide(state)
         local d = Model.Delta(plan, ownedSafe, card.spellId, catalog, params)
         d = tonumber(d) or 0
         deltas[i] = d
+        wanted[i] = IsWanted(Model, card, d, plan, ownedSafe, catalog)
         annotations[i] = Annotation(card, d, plan, ownedSafe)
         eff[i] = d
 
@@ -248,7 +447,7 @@ function Policy.Decide(state)
                 >= Model.EffectiveWishedQuality(plan, catalog, fam) then
             precious[i] = true
         end
-        if frozenish and d > 0 then
+        if frozenish and wanted[i] then
             -- Banked: already secured with a freeze. Rule C only ever
             -- freezes a family whose own guarantee was already exhausted
             -- (see header), so holding it costs that family nothing
@@ -258,7 +457,7 @@ function Policy.Decide(state)
             -- no eff[] suppression is needed here.
             annotations[i] = "banked"
             bankedWantedOnBoard = true
-        elseif i ~= gIndex and not frozenish and d > 0
+        elseif i ~= gIndex and not frozenish and wanted[i]
             and Wished(plan, fam) and OwnedFam(ownedSafe, fam) <= 0
             and pendingFam[fam] then
             -- Pending guarantee: it comes back. Unless this roll is a
@@ -287,14 +486,411 @@ function Policy.Decide(state)
     end
 
     local gDelta = gIndex and deltas[gIndex] or nil
-    local gWanted = false
-    if gIndex and gDelta and gDelta > 0 then
-        gWanted = Wished(plan, cards[gIndex].family)
-    end
+    local gWanted = gIndex ~= nil and wanted[gIndex] == true
     -- The quality gate makes a wrong-quality guaranteed head score
     -- negative, so gWanted is false for it and every "Taking guaranteed echo"
     -- path below is naturally skipped -- exactly the gray-Armor-Pen case.
 
+    -- The end of a pending-roll batch is not the end of the run until level
+    -- 80.  At that point the last selectable Echo needs a separate search
+    -- policy so a safe frozen fallback survives Banish/Reroll attempts.
+    local finalSelection = (level or 0) >= 80
+        and type(state.horizon) == "number"
+        and state.horizon == 1
+    local unusableGuarantee = gIndex ~= nil and not gWanted
+
+    -- Reject an off-wishlist guarantee during ordinary leveling. Prefer a
+    -- useful side offer, otherwise spend only trustworthy search actions and
+    -- never loop an action the adapter already reported as refused.
+    if unusableGuarantee and not finalSelection then
+        local bestWantedSide, wantedFreezeResolving = nil, false
+        for i = 1, n do
+            if i ~= gIndex and wanted[i] then
+                if not FreezeWorthy(
+                    Model, state, cards[i], plan, ownedSafe, catalog) then
+                    annotations[i] = "returns later"
+                elseif cards[i].justFrozen then
+                    wantedFreezeResolving = true
+                elseif BetterWanted(
+                    Model, cards, deltas, plan, ownedSafe, catalog,
+                    i, bestWantedSide) then
+                    bestWantedSide = i
+                end
+            end
+        end
+        if bestWantedSide then
+            return TakeAction(cards, annotations, deltas, bestWantedSide,
+                "Reject off-wishlist guarantee; take missing wishlist side Echo")
+        end
+        if wantedFreezeResolving then
+            return {
+                type = "wait",
+                reason = "Wanted side Freeze is resolving before rejecting "
+                    .. "off-wishlist guarantee",
+                annotations = annotations,
+                deltas = deltas,
+            }
+        end
+
+        local refused = type(state.searchRefused) == "table"
+            and state.searchRefused or {}
+        if state.allowBanish ~= false and not refused.banish
+            and (tonumber(charges.banish) or 0) > 0
+            and charges.trustworthy == true
+            and not charges.banishSpentThisPush then
+            local worst = SafeBanishCandidate(cards, deltas, plan, gIndex)
+            if worst then
+                return {
+                    type = "banish",
+                    index = worst,
+                    spellId = cards[worst].spellId,
+                    reason = "Replace off-wishlist guarantee: Banish safe "
+                        .. "side to search for a missing wishlist Echo",
+                    annotations = annotations,
+                    deltas = deltas,
+                }
+            end
+        end
+        if not refused.reroll and (tonumber(charges.reroll) or 0) > 0
+            and charges.trustworthy == true then
+            return {
+                type = "reroll",
+                reason = "Replace off-wishlist guarantee: Reroll side choices "
+                    .. "for a missing wishlist Echo",
+                annotations = annotations,
+                deltas = deltas,
+            }
+        end
+
+        local side = LeastHarmfulSide(cards, annotations, deltas, gIndex)
+        if side then
+            return TakeAction(cards, annotations, deltas, side,
+                "Reject off-wishlist guarantee; take least-harmful side")
+        end
+        return {
+            type = "wait",
+            reason = "Off-wishlist guarantee has no selectable side",
+            annotations = annotations,
+            deltas = deltas,
+        }
+    end
+
+    -- Below level 80, spend at most one safe Banish per fresh run-data push.
+    -- Never pre-empt a wanted side offer that still needs protection.
+    if level and level < 80 then
+        local hasWantedSide, hasUnbankedWantedSide = false, false
+        for i = 1, n do
+            if i ~= gIndex and wanted[i] then
+                hasWantedSide = true
+                if not IsFrozen(cards[i]) then
+                    hasUnbankedWantedSide = true
+                    break
+                end
+            end
+        end
+        local wantedSideBlocksBanish
+        if gIndex then
+            wantedSideBlocksBanish = hasUnbankedWantedSide
+        else
+            wantedSideBlocksBanish = hasWantedSide
+        end
+        local refused = type(state.searchRefused) == "table"
+            and state.searchRefused or {}
+        if not wantedSideBlocksBanish and state.allowBanish ~= false
+            and not refused.banish
+            and (tonumber(charges.banish) or 0) > 0
+            and charges.trustworthy == true
+            and not charges.banishSpentThisPush then
+            local worst = SafeBanishCandidate(cards, deltas, plan, gIndex)
+            if worst then
+                return {
+                    type = "banish",
+                    index = worst,
+                    spellId = cards[worst].spellId,
+                    reason = "Early search: Banish safe off-wishlist side "
+                        .. "before normal roll sequencing",
+                    annotations = annotations,
+                    deltas = deltas,
+                }
+            end
+        end
+    end
+
+    if finalSelection then
+        local bestFrozen, bestVisible = nil, nil
+        for i = 1, n do
+            local card = cards[i]
+            if wanted[i] and not card.justFrozen then
+                if card.isFrozen or card.isCarried then
+                    if BetterWanted(
+                        Model, cards, deltas, plan, ownedSafe, catalog,
+                        i, bestFrozen) then
+                        bestFrozen = i
+                    end
+                elseif i ~= gIndex and not card.isGuaranteed
+                    and BetterWanted(
+                        Model, cards, deltas, plan, ownedSafe, catalog,
+                        i, bestVisible) then
+                    bestVisible = i
+                end
+            end
+        end
+
+        if bestVisible and (not bestFrozen
+            or BetterWanted(
+                Model, cards, deltas, plan, ownedSafe, catalog,
+                bestVisible, bestFrozen)) then
+            return Endgame(TakeAction(
+                cards, annotations, deltas, bestVisible,
+                bestFrozen
+                    and ("Final selection: better remaining wishlist Echo "
+                        .. "replaces frozen target")
+                    or "Final selection: take wanted side Echo before search"))
+        end
+
+        local protectedIndex = bestFrozen or gIndex
+        local protectedWanted = bestFrozen ~= nil
+            or (gIndex ~= nil and wanted[gIndex] == true)
+        local fallbackCard = protectedWanted and cards[protectedIndex] or nil
+        local searchPending = protectedIndex ~= nil
+            and MissingAfterFallback(plan, ownedSafe, fallbackCard, catalog)
+        if searchPending then
+            local refused = type(state.searchRefused) == "table"
+                and state.searchRefused or {}
+            if state.allowBanish ~= false and not refused.banish
+                and (tonumber(charges.banish) or 0) > 0
+                and charges.trustworthy == true
+                and not charges.banishSpentThisPush then
+                local worst = SafeBanishCandidate(cards, deltas, plan, gIndex)
+                if worst then
+                    return Endgame({
+                        type = "banish",
+                        index = worst,
+                        spellId = cards[worst].spellId,
+                        reason = "Final selection: safe Banish searches for "
+                            .. "another missing wanted Echo",
+                        annotations = annotations,
+                        deltas = deltas,
+                    })
+                end
+            end
+
+            local rerollSafe = bestFrozen ~= nil
+                or gIndex == nil
+                or wanted[gIndex] ~= true
+                or flags.REROLL_HOLDS_GUARANTEED == true
+            if not refused.reroll
+                and (tonumber(charges.reroll) or 0) > 0
+                and charges.trustworthy == true
+                and rerollSafe then
+                local reason
+                if bestFrozen then
+                    reason = "Final selection: Reroll searches while "
+                        .. "the frozen wanted Echo remains protected"
+                elseif gIndex and wanted[gIndex] then
+                    reason = "Final selection: Reroll searches while "
+                        .. "the guaranteed wanted Echo is held"
+                else
+                    reason = "Final selection: Reroll searches past "
+                        .. "a non-wanted guaranteed Echo"
+                end
+                return Endgame({
+                    type = "reroll",
+                    reason = reason,
+                    annotations = annotations,
+                    deltas = deltas,
+                })
+            end
+        end
+
+        if bestFrozen then
+            local reason = "Final selection: search exhausted or unavailable; "
+                .. "take frozen wanted Echo"
+            local refused = type(state.searchRefused) == "table"
+                and state.searchRefused or {}
+            if refused.banish or refused.reroll then
+                reason = "Final selection: search action refused; "
+                    .. "take frozen wanted Echo"
+            end
+            return Endgame(TakeAction(
+                cards, annotations, deltas, bestFrozen, reason))
+        end
+    end
+
+    if finalSelection and unusableGuarantee then
+        local side = LeastHarmfulSide(cards, annotations, deltas, gIndex)
+        if side then
+            return Endgame(TakeAction(cards, annotations, deltas, side,
+                "Final selection: reject off-wishlist guarantee"))
+        end
+        return Endgame({
+            type = "wait",
+            reason = "Final off-wishlist guarantee has no selectable side",
+            annotations = annotations,
+            deltas = deltas,
+        })
+    end
+
+    -- Phase A: protect one useful side offer, then drain the guaranteed queue.
+    if gIndex then
+        local bestUnbanked, hasBankedWanted = nil, false
+        for i = 1, n do
+            if i ~= gIndex and wanted[i] then
+                if IsFrozen(cards[i]) then
+                    hasBankedWanted = true
+                elseif FreezeWorthy(
+                    Model, state, cards[i], plan, ownedSafe, catalog) then
+                    if BetterWanted(
+                        Model, cards, deltas, plan, ownedSafe, catalog,
+                        i, bestUnbanked) then
+                        bestUnbanked = i
+                    end
+                else
+                    annotations[i] = "returns later"
+                end
+            end
+        end
+
+        if hasBankedWanted then
+            return TakeAction(cards, annotations, deltas, gIndex,
+                "Take guaranteed; wanted side Echo is safely frozen")
+        end
+
+        if bestUnbanked then
+            local freezeAvailable = (tonumber(charges.freeze) or 0) > 0
+                and charges.trustworthy == true
+                and state.canFreeze ~= false
+                and not cards[bestUnbanked].isGuaranteed
+            if freezeAvailable then
+                return {
+                    type = "freeze",
+                    index = bestUnbanked,
+                    spellId = cards[bestUnbanked].spellId,
+                    reason = "Freeze wanted side Echo; take guaranteed after it resolves",
+                    steps = {
+                        { type = "freeze", index = bestUnbanked,
+                          spellId = cards[bestUnbanked].spellId },
+                        { type = "take", index = gIndex,
+                          spellId = cards[gIndex].spellId },
+                    },
+                    annotations = annotations,
+                    deltas = deltas,
+                }
+            end
+
+            local why
+            if (tonumber(charges.freeze) or 0) <= 0 then
+                why = "Freeze unavailable"
+            elseif charges.trustworthy ~= true then
+                why = "Freeze count untrusted"
+            else
+                why = "Freeze unavailable or refused on this board"
+            end
+            return TakeAction(cards, annotations, deltas, bestUnbanked,
+                why .. ": taking wanted side Echo to prevent its loss")
+        end
+
+        return TakeAction(cards, annotations, deltas, gIndex,
+            "Drain guaranteed queue")
+    end
+
+    -- Phase B: consume the bank first, then any other wanted offer.
+    local bestFrozen, bestWanted = nil, nil
+    local protectedWanted = false
+    for i = 1, n do
+        if wanted[i] then
+            if cards[i].justFrozen then
+                protectedWanted = true
+            elseif cards[i].isFrozen or cards[i].isCarried then
+                if BetterWanted(
+                    Model, cards, deltas, plan, ownedSafe, catalog,
+                    i, bestFrozen) then
+                    bestFrozen = i
+                end
+            elseif BetterWanted(
+                Model, cards, deltas, plan, ownedSafe, catalog,
+                i, bestWanted) then
+                bestWanted = i
+            end
+        end
+    end
+    if bestFrozen then
+        return TakeAction(cards, annotations, deltas, bestFrozen,
+            "Take frozen wanted Echo before searching")
+    end
+    if bestWanted then
+        return TakeAction(cards, annotations, deltas, bestWanted,
+            "Take wanted Echo")
+    end
+
+    local refused = type(state.searchRefused) == "table"
+        and state.searchRefused or {}
+    if not protectedWanted and state.allowBanish ~= false
+        and not refused.banish
+        and (tonumber(charges.banish) or 0) > 0
+        and charges.trustworthy == true
+        and not charges.banishSpentThisPush then
+        local worst = SafeBanishCandidate(cards, deltas, plan, gIndex)
+        if worst then
+            local action = {
+                type = "banish", index = worst, spellId = cards[worst].spellId,
+                reason = "No wanted Echo: banish worst safe off-wishlist card",
+                annotations = annotations, deltas = deltas,
+            }
+            return finalSelection and Endgame(action) or action
+        end
+    end
+
+    if not protectedWanted and not refused.reroll
+        and (tonumber(charges.reroll) or 0) > 0
+        and charges.trustworthy == true then
+        local action = {
+            type = "reroll",
+            reason = "No wanted Echo or useful safe Banish: reroll",
+            annotations = annotations,
+            deltas = deltas,
+        }
+        return finalSelection and Endgame(action) or action
+    end
+
+    local anyNonDuplicate, anySelectable = false, false
+    for i = 1, n do
+        if annotations[i] ~= "duplicate" then anyNonDuplicate = true end
+        if not cards[i].justFrozen then anySelectable = true end
+    end
+    local convergencePick = nil
+    for i = 1, n do
+        local eligible = ((not anyNonDuplicate)
+                or annotations[i] ~= "duplicate")
+            and ((not anySelectable) or not cards[i].justFrozen)
+        if eligible and (convergencePick == nil
+            or deltas[i] > deltas[convergencePick]
+            or (deltas[i] == deltas[convergencePick]
+                and annotations[convergencePick] == "filler"
+                and annotations[i] ~= "filler")
+            or (deltas[i] == deltas[convergencePick]
+                and (annotations[i] == "filler")
+                    == (annotations[convergencePick] == "filler")
+                and (tonumber(cards[i].quality) or 0)
+                    < (tonumber(cards[convergencePick].quality) or 0))
+            or (deltas[i] == deltas[convergencePick]
+                and (tonumber(cards[i].quality) or 0)
+                    == (tonumber(cards[convergencePick].quality) or 0)
+                and i < convergencePick)) then
+            convergencePick = i
+        end
+    end
+    convergencePick = convergencePick or 1
+    local convergenceAction = TakeAction(
+        cards, annotations, deltas, convergencePick,
+        annotations[convergencePick] == "duplicate"
+            and "Forced take: every selectable Echo is already owned"
+            or "Forced least-harmful selection")
+    return finalSelection and Endgame(convergenceAction) or convergenceAction
+end
+
+--[[ Legacy 1.19.3 heuristic retained as design history. The convergence
+decision above is exhaustive for every well-formed board and replaces it.
     -- Presumptive take: best effective value among selectable cards
     -- (justFrozen excluded -- the client refuses same-board select of a
     -- just-frozen card). Ties go to the guaranteed head (one-shot).
@@ -862,3 +1458,4 @@ function Policy.Decide(state)
         forced = true,
         annotations = annotations, deltas = deltas }
 end
+--]]

--- a/logic/Policy.lua
+++ b/logic/Policy.lua
@@ -886,6 +886,9 @@ function Policy.Decide(state)
         annotations[convergencePick] == "duplicate"
             and "Forced take: every selectable Echo is already owned"
             or "Forced least-harmful selection")
+    -- Every executable search path has already returned. This selection is
+    -- mandatory, so preserve that fact for the save gate's pollution model.
+    convergenceAction.forced = true
     return finalSelection and Endgame(convergenceAction) or convergenceAction
 end
 

--- a/logic/Ratchet.lua
+++ b/logic/Ratchet.lua
@@ -33,6 +33,41 @@ local function FamName(catalog, fam)
     return (names and names[fam]) or tostring(fam)
 end
 
+local function OwnedFromEchoes(echoes, catalog)
+    local owned = { byFamily = {}, bySpell = {} }
+    for i = 1, #(echoes or {}) do
+        local entry = echoes[i]
+        local family = FamOf(entry, catalog)
+        local spellId = type(entry) == "table" and tonumber(entry.spellId) or nil
+        local count = type(entry) == "table"
+            and (tonumber(entry.stacks or entry.count) or 1) or 0
+        if family ~= nil and count > 0 then
+            owned.byFamily[family] =
+                (tonumber(owned.byFamily[family]) or 0) + count
+        end
+        if spellId and count > 0 then
+            owned.bySpell[spellId] =
+                (tonumber(owned.bySpell[spellId]) or 0) + count
+        end
+    end
+    return owned
+end
+
+local function TargetProgress(plan, catalog, family, owned)
+    local Model = Nexus.Model
+    if type(Model) == "table" and type(Model.TargetProgress) == "function" then
+        return Model.TargetProgress(plan, catalog, family, owned)
+    end
+    local target = type(plan) == "table"
+        and type(plan.targets) == "table" and plan.targets[family] or nil
+    local want = type(target) == "table"
+        and tonumber(target.targetStacks) or 1
+    if want < 1 then want = 1 end
+    local byFamily = type(owned) == "table" and owned.byFamily or nil
+    local have = tonumber(byFamily and byFamily[family]) or 0
+    return math.min(have, want), want
+end
+
 -- Distinct coverage/filler family sets of a slot-echoes array.
 local function EchoFamilySets(echoes, wished, catalog)
     local cov, fill = {}, {}
@@ -69,6 +104,13 @@ function M.PredictQueue(activeEchoes, owned, plan, flags, disabledLevers, catalo
     local byFamily = (type(owned) == "table" and owned.byFamily) or {}
     local bySpell = (type(owned) == "table" and owned.bySpell) or {}
     local wished = (type(plan) == "table" and plan.wishedFamilies) or {}
+    local queueOwned = { byFamily = {}, bySpell = {} }
+    for family, count in pairs(byFamily) do
+        queueOwned.byFamily[family] = tonumber(count) or 0
+    end
+    for id, count in pairs(bySpell) do
+        queueOwned.bySpell[id] = tonumber(count) or 0
+    end
     local suppress = type(flags) == "table"
         and flags.DISABLE_SUPPRESSES_GUARANTEE == true
     local rows = catalog and catalog.rows
@@ -110,11 +152,29 @@ function M.PredictQueue(activeEchoes, owned, plan, flags, disabledLevers, catalo
                     consumedFamily[fam] = famConsumed + consume
                 end
                 for _ = 1, count - consume do
+                    local row = rows and rows[spellId]
+                    local quality = type(row) == "table"
+                        and tonumber(row.quality) or tonumber(e.quality)
+                    local wanted = not not wished[fam]
+                    local model = Nexus.Model
+                    if wanted and type(model) == "table"
+                        and type(model.QualityOfferNeeded) == "function"
+                        and quality ~= nil then
+                        wanted = model.QualityOfferNeeded(
+                            plan, catalog, fam, quality, queueOwned)
+                    end
                     out.entries[#out.entries + 1] = {
                         spellId = spellId,
                         family = fam,
-                        wanted = not not wished[fam],
+                        quality = quality,
+                        wanted = wanted,
                     }
+                    if wanted then
+                        queueOwned.byFamily[fam] =
+                            (tonumber(queueOwned.byFamily[fam]) or 0) + 1
+                        queueOwned.bySpell[spellId] =
+                            (tonumber(queueOwned.bySpell[spellId]) or 0) + 1
+                    end
                 end
             end
         end
@@ -412,6 +472,16 @@ function M.Dominates(candidateOwned, incumbentEchoes, plan, catalog, forcedBySpe
             or wrongQForced > 0 or wrongQAvoidable > 0 then
             return false, "cleanup-only save added new excess/wrong-quality pollution", diag
         end
+        -- A clean one-for-one wishlist rotation advances convergence even
+        -- though aggregate exact progress is unchanged: the next run can
+        -- guarantee the newly acquired target and search for the rotated-out
+        -- target. New filler or persistence pollution still blocks the save.
+        if gainedStacks > 0 and lostStacks > 0
+            and fillerDelta <= 0 and unrelatedFillerDelta <= 0 then
+            return true, string.format(
+                "wishlist rotation (gained %d, shed %d wished stacks, filler %+d)",
+                gainedStacks, lostStacks, fillerDelta), diag
+        end
         if hadExactExcess and excessDecrease <= 0 and wrongQShed <= 0 then
             return false, "filler improved but existing exact excess was not reduced", diag
         end
@@ -435,9 +505,9 @@ end
 function M.ScoreSlot(slotEchoes, plan, catalog)
     local wished  = (type(plan) == "table" and plan.wishedFamilies) or {}
     local targets = (type(plan) == "table" and plan.targets) or {}
-    local cov, fill = EchoFamilySets(slotEchoes, wished, catalog)
+    local _, fill = EchoFamilySets(slotEchoes, wished, catalog)
+    local owned = OwnedFromEchoes(slotEchoes, catalog)
     local nc, nf = 0, 0
-    for _ in pairs(cov) do nc = nc + 1 end
     for _ in pairs(fill) do nf = nf + 1 end
 
     -- Stack bonus: for each wished stacking family, add fractional credit
@@ -446,21 +516,15 @@ function M.ScoreSlot(slotEchoes, plan, catalog)
     -- calls for 67×Rend.  Weight < 1 so a stack bonus never outweighs a
     -- genuinely new echo family.
     local stackBonus = 0
-    if type(slotEchoes) == "table" then
-        local stacksByFam = {}
-        for _, e in ipairs(slotEchoes) do
-            local fam = FamOf(e, catalog)
-            if fam and wished[fam] then
-                stacksByFam[fam] = (stacksByFam[fam] or 0)
-                    + (tonumber(e.stacks or e.count) or 1)
-            end
+    for family in pairs(wished) do
+        local have, want = TargetProgress(plan, catalog, family, owned)
+        if have > 0 then nc = nc + 1 end
+        if have <= 0
+            and (tonumber(owned.byFamily[family]) or 0) > 0 then
+            nf = nf + 1
         end
-        for fam, count in pairs(stacksByFam) do
-            local t = targets[fam]
-            local target = (type(t) == "table" and tonumber(t.targetStacks)) or 1
-            if target > 1 then
-                stackBonus = stackBonus + 0.9 * math.min(count, target) / target
-            end
+        if want > 1 then
+            stackBonus = stackBonus + 0.9 * math.min(have, want) / want
         end
     end
 
@@ -498,15 +562,15 @@ end
 -- count: unknown stays true and the text reports only what is known.
 ------------------------------------------------------------------------
 
-function M.RunsEstimate(plan, owned, queue, support)
+function M.RunsEstimate(plan, owned, queue, support, catalog)
     local wished = type(plan) == "table" and plan.wishedFamilies or nil
     if not wished or not next(wished) then
         return { text = "no wishlist target - advisor mode", unknown = true }
     end
-    local byFamily = (type(owned) == "table" and owned.byFamily) or {}
     local pending = 0
     for fam in pairs(wished) do
-        if not Pos(byFamily[fam]) then pending = pending + 1 end
+        local have, want = TargetProgress(plan, catalog, fam, owned)
+        if have < want then pending = pending + 1 end
     end
     local queued, seen = 0, {}
     local entries = type(queue) == "table" and queue.entries or nil

--- a/tests/harness.lua
+++ b/tests/harness.lua
@@ -380,6 +380,11 @@ function H.ResolveSelect(ok)
 end
 
 function Service.BanishPerk(idx)
+    H.banishAttempts = (H.banishAttempts or 0) + 1
+    if H.refuseNextBanish then
+        H.refuseNextBanish = nil
+        return false
+    end
     if Perks.pendingBanishIndex then return false end
     if not idx or idx < 0 or idx > 2 then return false end
     local c = Perks.currentChoice and Perks.currentChoice[idx + 1]
@@ -411,6 +416,11 @@ function Service.FreezePerk(idx)
 end
 
 function Service.RequestReroll()
+    H.rerollAttempts = (H.rerollAttempts or 0) + 1
+    if H.refuseNextReroll then
+        H.refuseNextReroll = nil
+        return false
+    end
     if Perks.pendingReroll then return false end
     Perks.pendingReroll = true
     H.rerollCalls = H.rerollCalls + 1

--- a/tests/harness.lua
+++ b/tests/harness.lua
@@ -1,0 +1,535 @@
+-- Nexus offline harness: stubs the WoW 3.3.5 API + ProjectEbonhold
+-- with the AUDITED client semantics (latches with no timeout, silent banish
+-- refusal on guaranteed cards, latch-less ToggleTomeEcho with 530-delayed
+-- mirror, in-place SS-103 board mutation via UpdateSinglePerk, live tables
+-- returned by reference, nil-until-540 slots, run-data table identity
+-- replacement) and boots the REAL addon files under LuaJIT.
+-- Loaded by run_integration.lua.
+
+local H = {}
+
+-- Simulated clock ---------------------------------------------------------
+H.now = 1000
+function GetTime() return H.now end
+function H.Advance(seconds, step)
+    step = step or 0.1
+    local t = 0
+    while t < seconds - 1e-9 do
+        H.now = H.now + step
+        t = t + step
+        for _, f in ipairs(H.updateHandlers) do f(nil, step) end
+    end
+end
+
+-- Chat capture ------------------------------------------------------------
+H.chat = {}
+DEFAULT_CHAT_FRAME = {
+    AddMessage = function(_, msg) H.chat[#H.chat + 1] = msg end,
+}
+function H.ChatContains(pattern)
+    for _, line in ipairs(H.chat) do
+        if line:find(pattern, 1, true) then return line end
+    end
+    return nil
+end
+
+-- Frame stub (forked from EchoOptimizer's harness) -------------------------
+H.updateHandlers = {}
+H.eventHandlers = {}
+H.frames = {}
+
+local function NewRegion()
+    local r = { shown = false, text = "", scripts = {}, events = {}, points = {} }
+    local meta
+    meta = {
+        __index = function(t, k)
+            if k == "SetText" then
+                return function(self, txt) self.text = txt or "" end
+            elseif k == "GetText" then
+                return function(self) return self.text end
+            elseif k == "SetTexture" then
+                return function(self, tex) self.texture = tex end
+            elseif k == "GetTexture" then
+                return function(self) return self.texture end
+            elseif k == "SetChecked" then
+                return function(self, v) self.checked = v and true or false end
+            elseif k == "GetChecked" then
+                return function(self) return self.checked end
+            elseif k == "SetFrameStrata" then
+                return function(self, s) self.strata = s end
+            elseif k == "GetFrameStrata" then
+                return function(self) return self.strata end
+            elseif k == "SetFrameLevel" then
+                return function(self, l) self.level = l end
+            elseif k == "GetFrameLevel" then
+                return function(self) return rawget(self, "level") or 0 end
+            elseif k == "SetValue" then
+                return function(self, v) self.sliderValue = v end
+            elseif k == "GetValue" then
+                return function(self) return rawget(self, "sliderValue") or 0 end
+            elseif k == "SetMinMaxValues" then
+                return function(self, min, max) self.sliderMin, self.sliderMax = min, max end
+            elseif k == "GetMinMaxValues" then
+                return function(self)
+                    return rawget(self, "sliderMin") or 0,
+                        rawget(self, "sliderMax") or 1
+                end
+            elseif k == "SetValueStep" then
+                return function(self, s) self.sliderStep = s end
+            elseif k == "SetSize" then
+                return function(self, w2, h2) self.w, self.h = w2, h2 end
+            elseif k == "SetWidth" then
+                return function(self, w2) self.w = w2 end
+            elseif k == "SetHeight" then
+                return function(self, h2) self.h = h2 end
+            elseif k == "GetWidth" then
+                return function(self) return rawget(self, "w") or 100 end
+            elseif k == "GetHeight" then
+                return function(self) return rawget(self, "h") or 20 end
+            elseif k == "SetPoint" then
+                return function(self, point, relTo, relPoint, x, y)
+                    self.points[#self.points + 1] =
+                        { point = point, relTo = relTo, relPoint = relPoint, x = x, y = y }
+                end
+            elseif k == "GetPoint" then
+                return function(self, i)
+                    local p = self.points[i or 1]
+                    if not p then return nil end
+                    return p.point, p.relTo, p.relPoint, p.x, p.y
+                end
+            elseif k == "ClearAllPoints" then
+                return function(self) self.points = {} end
+            elseif k == "GetScript" then
+                return function(self, which) return self.scripts[which] end
+            elseif k == "Show" then
+                return function(self) self.shown = true end
+            elseif k == "Hide" then
+                return function(self) self.shown = false end
+            elseif k == "IsShown" then
+                return function(self) return self.shown end
+            elseif k == "GetEffectiveScale" then
+                return function() return 1 end
+            elseif k == "CreateFontString" then
+                return function() return NewRegion() end
+            elseif k == "CreateTexture" then
+                return function() return NewRegion() end
+            elseif k == "SetScript" then
+                return function(self, which, fn)
+                    self.scripts[which] = fn
+                    if which == "OnUpdate" and fn then
+                        H.updateHandlers[#H.updateHandlers + 1] = fn
+                    elseif which == "OnEvent" and fn then
+                        H.eventHandlers[#H.eventHandlers + 1] = fn
+                    end
+                end
+            elseif k == "RegisterEvent" then
+                return function(self, ev) self.events[ev] = true end
+            end
+            if type(k) == "string" and k:match("^[A-Z]") then
+                return function() end
+            end
+            return nil
+        end,
+    }
+    return setmetatable(r, meta)
+end
+H.NewRegion = NewRegion
+
+function CreateFrame(_, name)
+    local f = NewRegion()
+    if name then H.frames[name] = f; _G[name] = f end
+    return f
+end
+
+function H.FireEvent(event, ...)
+    for _, fn in ipairs(H.eventHandlers) do fn(nil, event, ...) end
+end
+
+-- Misc WoW API ------------------------------------------------------------
+UIParent = NewRegion()
+Minimap = NewRegion()
+GetCursorPosition = function() return 0, 0 end
+H.bags = {}
+H.bagSizes = {}
+function H.SetBagItem(bag, slot, name)
+    H.bags[bag] = H.bags[bag] or {}
+    H.bagSizes[bag] = math.max(H.bagSizes[bag] or 0, slot)
+    H.bags[bag][slot] = name and
+        ("|cffa335ee|Hitem:900001:0:0:0:0:0:0:0|h[" .. name .. "]|h|r")
+        or nil
+end
+function GetContainerNumSlots(bag)
+    return H.bagSizes[bag] or 0
+end
+function GetContainerItemLink(bag, slot)
+    return H.bags[bag] and H.bags[bag][slot] or nil
+end
+function GetItemInfo(link)
+    return type(link) == "string" and link:match("%[(.-)%]") or nil
+end
+NUM_CHAT_WINDOWS = 1
+_G.ChatFrame1 = NewRegion()
+H.joinedChannels = {}
+function JoinTemporaryChannel(name) H.joinedChannels[name:lower()] = (H.nextChannelIndex or 1) end
+function JoinChannelByName(name) H.joinedChannels[name:lower()] = (H.nextChannelIndex or 1) end
+function GetChannelList()
+    local out = {}
+    for name, idx in pairs(H.joinedChannels) do
+        out[#out + 1] = idx
+        out[#out + 1] = name
+    end
+    return unpack(out)
+end
+H.sentChatMessages = {}
+function SendChatMessage(text, kind, lang, target)
+    H.sentChatMessages[#H.sentChatMessages + 1] = { text = text, kind = kind, target = target }
+    return true
+end
+function ChatFrame_RemoveChannel() end
+ChatFontNormal = {}
+StaticPopupDialogs = {}
+H.lastStaticPopup = nil
+function StaticPopup_Show(which, arg1, arg2, data)
+    H.lastStaticPopup = { which = which, arg1 = arg1, arg2 = arg2, data = data }
+    return { which = which }
+end
+function H.AcceptLastStaticPopup()
+    local p = H.lastStaticPopup
+    if not p then return false end
+    local def = StaticPopupDialogs[p.which]
+    if def and def.OnAccept then def.OnAccept(nil, p.data) end
+    return true
+end
+SlashCmdList = {}
+UIErrorsFrame = { AddMessage = function() end }
+bit = bit or require("bit")
+
+function hooksecurefunc(tbl, name, hook)
+    if type(tbl) == "string" then tbl, name, hook = _G, tbl, name end
+    local orig = tbl[name]
+    tbl[name] = function(...)
+        local r = orig and orig(...)
+        hook(...)
+        return r
+    end
+end
+
+H.playerLevel = 1
+function UnitLevel() return H.playerLevel end
+function UnitClass() return "Boganic", "MAGE" end
+function UnitName() return "Boganic" end
+function GetNormalizedRealmName() return "Ebonhold" end
+
+-- Catalog fixture ----------------------------------------------------------
+-- comment carries "Name - Rarity"; GetSpellInfo serves echo + tome names.
+H.db = {}
+H.tomeNames = {}
+local RARITY = { [0] = "Common", [1] = "Uncommon", [2] = "Rare", [3] = "Epic" }
+function H.AddEcho(id, name, opts)
+    opts = opts or {}
+    H.db[id] = {
+        comment = name .. " - " .. (RARITY[opts.quality or 3]),
+        classMask = opts.classMask or 1535,
+        quality = opts.quality or 3,
+        maxStack = opts.maxStack or 1,
+        minLevel = opts.minLevel or 1,
+        groupId = opts.groupId or 0,
+        families = {},
+        requiredSpell = opts.requiredSpell or 0,
+    }
+    H.names = H.names or {}
+    H.names[id] = name
+    if opts.requiredSpell and opts.requiredSpell ~= 0 and not opts.garbageTome then
+        H.tomeNames[opts.requiredSpell] = "Tome of " .. name
+    end
+end
+
+function GetSpellInfo(id)
+    if H.tomeNames[id] then return H.tomeNames[id] end
+    if H.names and H.names[id] then return H.names[id] end
+    return nil
+end
+
+-- Wishlist families
+H.AddEcho(200100, "Alpha Strike", { quality = 3, requiredSpell = 300100 })
+H.AddEcho(200102, "Beta Guard", { quality = 2 })
+H.AddEcho(200104, "Double Strike", { quality = 2, maxStack = 5, requiredSpell = 300104 })
+-- multi-quality family (groupId 50 shared)
+H.AddEcho(200110, "Gamma Bolt", { quality = 0, groupId = 50, requiredSpell = 300110 })
+H.AddEcho(200112, "Gamma Bolt", { quality = 2, groupId = 50, requiredSpell = 300112 })
+-- filler
+H.AddEcho(200200, "Junk Aura", { quality = 1, requiredSpell = 300200 })
+H.AddEcho(200202, "Junk Wall", { quality = 1 })
+-- garbage shared lever 9 (non-conformant: GetSpellInfo(9) = nil)
+H.AddEcho(200300, "Ward A", { quality = 0, requiredSpell = 9, garbageTome = true })
+H.AddEcho(200302, "Ward B", { quality = 0, requiredSpell = 9, garbageTome = true })
+-- shared CONFORMANT lever (two members, same name, distinct groups)
+H.AddEcho(200400, "Temporal Echo", { quality = 3, groupId = 60, requiredSpell = 300400 })
+H.AddEcho(200402, "Temporal Echo", { quality = 3, groupId = 61, requiredSpell = 300400 })
+-- off-class echo (warrior-only mask)
+H.AddEcho(200500, "Blade Ward", { quality = 1, classMask = 1 })
+-- an off-wishlist CONFORMANT tome echo that the char has NOT discovered:
+-- its lever must be SKIPPED (nothing to disable), not toggled
+H.AddEcho(200700, "Lone Tome", { quality = 1, requiredSpell = 300700 })
+-- the anchor: Adaptive Power (scales with distinct echoes)
+H.AddEcho(200960, "Adaptive Power", { quality = 3 })
+
+-- ProjectEbonhold stub ------------------------------------------------------
+local Perks = {
+    currentChoice = nil,
+    pendingSelectSpellId = nil, pendingBanishIndex = nil,
+    pendingFreezeIndex = nil, pendingReroll = nil,
+    serverBuildSlots = nil, serverActiveSlot = 0,
+    discoveredEchoes = nil,
+}
+H.Perks = Perks
+
+H.wire = {}            -- ToggleTomeEcho sends: "lever|flag"
+H.selectCalls = {}
+H.banishCalls = {}
+H.freezeCalls = {}
+H.rerollCalls = 0
+H.activateCalls = {}
+H.saveCalls = {}
+H.pollutedCalls = 0
+H.pendingRollsCallsAtLowLevel = 0
+H.disabledEchoes = {}
+H.buildBusyUntil = -1
+H.banishBlackhole = false
+
+H.runDataTable = nil   -- nil/{} until first push; replace identity via PushRunData
+function H.PushRunData(t) H.runDataTable = t end
+
+H.granted = nil        -- name-keyed, one entry per stack (client shape)
+H.locked = nil
+H.wishlist = nil       -- raw client shape
+
+local PerkUI = {}
+H.shownBoards = {}
+function PerkUI.Show(choices)
+    H.shownBoards[#H.shownBoards + 1] = choices
+end
+function PerkUI.UpdateSinglePerk(idx, ...)
+    H.updateSingleCalls = (H.updateSingleCalls or 0) + 1
+end
+
+local EchoJournal = {}
+function EchoJournal.OnDataChanged() end
+function EchoJournal.NotifyNewEcho() end
+
+local Service = {}
+
+function Service.GetCurrentChoice() return Perks.currentChoice end -- BY REFERENCE
+
+function Service.GetGrantedPerks() return H.granted end
+function Service.GetLockedPerks() return H.locked end
+function Service.RequestGrantedPerks()
+    H.grantedRequests = (H.grantedRequests or 0) + 1
+    -- A completed server response replaces the client's granted table even
+    -- when the authoritative result is empty. This is the generation-aware
+    -- signal GameAdapter uses instead of trusting an elapsed timeout.
+    if type(H.granted) == "table" then
+        local fresh = {}
+        for key, value in pairs(H.granted) do fresh[key] = value end
+        H.granted = fresh
+    end
+end
+function Service.GetActiveEchoLoadout() return H.wishlist end       -- BY REFERENCE
+function Service.IsSpellInActiveEchoLoadout(id)
+    H.pollutedCalls = H.pollutedCalls + 1
+    return true -- deliberately poisoned: any use misclassifies
+end
+function Service.IsTomeEchoDisabled(id) return H.disabledEchoes[id] == true end
+function Service.GetDiscoveredEchoes() return H.discovered or {} end
+
+function Service.ToggleTomeEcho(spellId)
+    -- client semantics: requiredSpell row check, LEVEL 1 ONLY self-reject,
+    -- read-before-write from the (530-delayed) mirror, NO latch
+    local row = H.db[spellId]
+    if not row or not row.requiredSpell or row.requiredSpell == 0 then return false end
+    if H.playerLevel ~= 1 then return false end
+    local enable = Service.IsTomeEchoDisabled(spellId) and "1" or "0"
+    H.wire[#H.wire + 1] = tostring(row.requiredSpell) .. "|" .. enable
+    return true
+end
+
+-- Deliver the SS-530 reply: server-authoritative disabled set
+function H.DeliverDiscovery(disabledEchoIds)
+    Perks.discoveredEchoes = Perks.discoveredEchoes or {}
+    H.disabledEchoes = {}
+    for _, id in ipairs(disabledEchoIds or {}) do H.disabledEchoes[id] = true end
+    EchoJournal.OnDataChanged()
+end
+
+function Service.SelectPerk(spellId)
+    if Perks.pendingSelectSpellId then return false end
+    if not spellId or spellId == 0 then return false end
+    if not Perks.currentChoice then return false end
+    local found = false
+    for _, c in ipairs(Perks.currentChoice) do
+        if c.spellId == spellId then found = true break end
+    end
+    if not found then return false end
+    Perks.pendingSelectSpellId = spellId
+    H.selectCalls[#H.selectCalls + 1] = spellId
+    return true
+end
+function H.ResolveSelect(ok)
+    Perks.pendingSelectSpellId = nil
+    if ok then Perks.currentChoice = nil end
+end
+
+function Service.BanishPerk(idx)
+    if Perks.pendingBanishIndex then return false end
+    if not idx or idx < 0 or idx > 2 then return false end
+    local c = Perks.currentChoice and Perks.currentChoice[idx + 1]
+    if c and c.isGuaranteed then return false end     -- silent refusal
+    local rd = H.runDataTable or {}
+    if (rd.remainingBanishes or 0) <= 0 then return false end
+    Perks.pendingBanishIndex = idx
+    H.banishCalls[#H.banishCalls + 1] = idx
+    return true
+end
+function H.ResolveBanish(newId, newQ)
+    -- SS-103: in-place mutation + UpdateSinglePerk (NOT Show)
+    if H.banishBlackhole then return end
+    local idx = Perks.pendingBanishIndex
+    if idx == nil then return end
+    local c = Perks.currentChoice and Perks.currentChoice[idx + 1]
+    if c then c.spellId = newId; c.quality = newQ or 0 end
+    Perks.pendingBanishIndex = nil
+    ProjectEbonhold.PerkUI.UpdateSinglePerk(idx)
+end
+
+function Service.FreezePerk(idx)
+    if Perks.pendingFreezeIndex then return false end
+    local c = Perks.currentChoice and Perks.currentChoice[idx + 1]
+    if c and c.isGuaranteed then return false end
+    Perks.pendingFreezeIndex = idx
+    H.freezeCalls[#H.freezeCalls + 1] = idx
+    return true
+end
+
+function Service.RequestReroll()
+    if Perks.pendingReroll then return false end
+    Perks.pendingReroll = true
+    H.rerollCalls = H.rerollCalls + 1
+    return true
+end
+
+function Service.GetPendingRollsCount()
+    if H.playerLevel <= 1 then
+        H.pendingRollsCallsAtLowLevel = H.pendingRollsCallsAtLowLevel + 1
+    end
+    return H.pendingRolls or 40
+end
+
+-- Build slots: nil until DeliverSlots; 3s single-flight busy
+local function BuildBusy() return GetTime() < H.buildBusyUntil end
+function Service.GetServerBuildSlots() return Perks.serverBuildSlots end
+function Service.GetServerActiveSlot() return Perks.serverActiveSlot or 0 end
+function Service.GetServerMaxSlots() return 5 end
+function Service.GetServerUnlockedSlots() return H.unlockedSlots or 5 end
+function Service.AreServerBuildSlotsEnabled() return true end
+function Service.CanActivateServerBuildSlot()
+    return H.playerLevel == 1 or H.playerLevel == 80
+end
+function Service.RequestServerBuildSlots()
+    H.slotRequests = (H.slotRequests or 0) + 1
+    -- model the fresh SS-540: a pending save/seed becomes visible now
+    -- (unless H.saveBlackhole simulates an invisible SS-541 FAIL)
+    if H.pendingSnapshot and not H.saveBlackhole then
+        local ps = H.pendingSnapshot
+        Perks.serverBuildSlots = Perks.serverBuildSlots or {}
+        Perks.serverBuildSlots[ps.slot] =
+            { slot = ps.slot, name = ps.name, verified = true, echoes = ps.echoes }
+        H.pendingSnapshot = nil
+    end
+end
+function Service.ActivateServerBuildSlot(slot)
+    if not slot or slot < 0 then return false end
+    if BuildBusy() then return false end
+    H.buildBusyUntil = GetTime() + 3
+    H.activateCalls[#H.activateCalls + 1] = slot
+    return true
+end
+function Service.SaveServerBuildSlot(slot, name)
+    if BuildBusy() then return false end
+    H.buildBusyUntil = GetTime() + 3
+    H.saveCalls[#H.saveCalls + 1] = { slot = slot, name = name }
+    -- the server snapshots the whole granted+locked build into the slot;
+    -- it surfaces on the NEXT RequestServerBuildSlots (fresh SS-540)
+    local bySpell = {}
+    if type(H.granted) == "table" then
+        for _, entries in pairs(H.granted) do
+            if type(entries) == "table" then
+                for i = 1, #entries do
+                    local id = entries[i].spellId
+                    if id then bySpell[id] = (bySpell[id] or 0) + 1 end
+                end
+            end
+        end
+    end
+    if type(H.locked) == "table" then
+        for i = 1, #H.locked do
+            local e = H.locked[i]
+            if e.spellId then bySpell[e.spellId] = (bySpell[e.spellId] or 0) + (e.stack or 1) end
+        end
+    end
+    local echoes = {}
+    for id, st in pairs(bySpell) do
+        echoes[#echoes + 1] = { spellId = id, stacks = st, locked = false }
+    end
+    H.pendingSnapshot = { slot = slot, name = name, echoes = echoes }
+    H.lastSavedSlot = slot
+    return true
+end
+
+function H.DeliverSlots(bySlot, activeSlot)
+    Perks.serverBuildSlots = bySlot
+    Perks.serverActiveSlot = activeSlot or 0
+    EchoJournal.OnDataChanged()
+end
+
+-- Board delivery: sets the INTERNAL table (returned by reference), clears
+-- pendingReroll (the one self-healing latch), fires PerkUI.Show like the
+-- SS-16 handler does.
+function H.DeliverBoard(cards)
+    local choices = {}
+    for i, c in ipairs(cards) do
+        choices[i] = {
+            spellId = c.spellId, quality = c.quality or 0,
+            isFrozen = c.isFrozen or false, isCarried = c.isCarried or false,
+            isGuaranteed = c.isGuaranteed or false,
+        }
+        if c.justFrozen then choices[i].justFrozen = true end
+    end
+    Perks.currentChoice = choices
+    Perks.pendingReroll = nil
+    ProjectEbonhold.PerkUI.Show(choices)
+end
+
+local PlayerRunService = {
+    GetCurrentData = function() return H.runDataTable or {} end,
+}
+
+ProjectEbonhold = {
+    PerkDatabase = H.db,
+    PerkService = Service,
+    Perks = Perks,
+    PerkUI = PerkUI,
+    EchoJournal = EchoJournal,
+    PlayerRunService = PlayerRunService,
+    Constants = { ENABLE_BANISH_SYSTEM = true },
+}
+H.service = Service
+
+-- Options service (separate global, colon methods, persistent settings)
+local optSettings = { autoAcceptLoadoutEchoes = true }
+ProjectEbonholdOptionsService = {
+    GetSetting = function(self, k) return optSettings[k] end,
+    SetSetting = function(self, k, v) optSettings[k] = v end,
+}
+H.optSettings = optSettings
+
+return H

--- a/tests/run_build_edit_lock.lua
+++ b/tests/run_build_edit_lock.lua
@@ -1,0 +1,34 @@
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/CommunityBuilds.lua")
+
+NexusDB = { communityBuilds = {} }
+H.wishlist = { name="New Echoes", class="MAGE", entries={{spellId=200100,stacks=1}} }
+UnitName = function() return "Owner" end
+local CB = Nexus.CommunityBuilds
+CB.Init(Nexus.GameAdapter, Nexus.Model)
+NexusDB.communityBuilds.mine = {
+ id="mine", title="Recorded", description="old", author="Owner", isMine=true,
+ echoes={{spellId=200050,stacks=1}}, class="MAGE"
+}
+Nexus.DpsCapture = {
+ GetLeaderboard=function(id, category)
+   if id == "mine" and category == "dummy" then return {{dps=24000000,player="Owner"}} end
+   return {}
+ end
+}
+local ok, err = CB.UpdateFromWishlist("mine")
+assert(not ok and tostring(err):find("leaderboard record"), "recorded loadout must be immutable")
+assert(NexusDB.communityBuilds.mine.echoes[1].spellId == 200050, "locked Echo list changed")
+local meta = CB.EditBuild("mine", "Renamed", "new")
+assert(meta and NexusDB.communityBuilds.mine.title == "Renamed", "owner metadata edit should remain available")
+NexusDB.communityBuilds.remote = {id="remote",title="Remote",author="Other",isMine=false,echoes={}}
+local remote = CB.EditBuild("remote", "Bad", "Bad")
+assert(not remote, "non-owner edit must be rejected")
+print("build edit lock OK")

--- a/tests/run_builds_discoverability.lua
+++ b/tests/run_builds_discoverability.lua
@@ -1,0 +1,47 @@
+-- Confirms Nexus Builds is now reachable from both the repurposed editor
+-- button and the new panel button, and that the OLD best-effort
+-- Echo-Journal-guessing logic is genuinely gone, not just relabeled.
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+
+local allWidgets = {}
+local realCreateFrame = CreateFrame
+CreateFrame = function(...)
+    local f = realCreateFrame(...)
+    allWidgets[#allWidgets + 1] = f
+    return f
+end
+dofile("ui/Panel.lua")
+
+NexusDB = {}
+local shown = false
+Nexus.CommunityBuilds = { Show = function() shown = true end }
+Nexus.Panel.Init({ ToggleAuto = function() return true end })
+Nexus.Panel.Render({ status="t", cards={}, recommendation="", auto=true, version="v" })
+
+-- find the panel's new Builds button by behavior (clicking it calls Show)
+local found = false
+for _, f in ipairs(allWidgets) do
+    if f.scripts and f.scripts.OnClick then
+        shown = false
+        local ok = pcall(f.scripts.OnClick, f)
+        if ok and shown then found = true end
+    end
+end
+assert(found, "no button on the panel opens Nexus Builds")
+print("panel has a working Builds button -- OK")
+
+-- The editor's button must ALSO open Nexus Builds directly, and the old
+-- best-effort Echo-Journal-guessing logic must be genuinely gone.
+local src = io.open("ui/WishlistEditor.lua"):read("*a")
+assert(not src:find("ToggleEchoJournal"), "old best-effort Echo Journal guessing logic still present")
+assert(not src:find('"Community Loadouts"'), "old button label still present somewhere")
+assert(src:find("Nexus%.CommunityBuilds%.Show"),
+    "editor button does not call CommunityBuilds.Show()")
+print("old best-effort button logic fully removed; editor now opens Nexus Builds directly -- OK")

--- a/tests/run_builds_resilience.lua
+++ b/tests/run_builds_resilience.lua
@@ -1,0 +1,59 @@
+-- Regression for the live crash (2026-07-25): SetClipsChildren is
+-- retail-only and absent on this client; calling it without pcall aborted
+-- EnsureFrame before scrollFrame/scrollChild/scrollBar were created,
+-- permanently breaking the window for the session. Same bug class as
+-- SetColorTexture (2026-07-24).
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua"); dofile("core/Sync.lua")
+dofile("data/DefaultProfile.lua"); dofile("logic/Model.lua"); dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua"); dofile("logic/Policy.lua"); dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+
+-- Make every Frame reject SetClipsChildren, exactly as the live client
+local realCreateFrame = CreateFrame
+CreateFrame = function(kind, name, parent, ...)
+    local f = realCreateFrame(kind, name, parent, ...)
+    f.SetClipsChildren = function() error("SetClipsChildren not supported on this client") end
+    f.SetVertexColor = function() error("SetVertexColor not supported on this client") end
+    return f
+end
+
+dofile("ui/CommunityBuilds.lua")
+
+NexusDB = {}
+H.wishlist = { name="W", class="ROGUE", echoes={{spellId=200100,quality=3,stacks=1}} }
+H.playerLevel = 5
+
+local Adapter, Model = Nexus.GameAdapter, Nexus.Model
+local CB = Nexus.CommunityBuilds
+CB.Init(Adapter, Model)
+
+local ok, err = pcall(CB.Show)
+assert(ok, "Show() crashed when SetClipsChildren/SetVertexColor are unavailable: "..tostring(err))
+
+local frame = _G.NexusCommunityBuildsFrame
+assert(frame and frame:IsShown(), "frame did not open")
+
+local ok2, id = CB.PostCurrentWishlist("Test Build", "description", H.wishlist)
+assert(ok2, "PostCurrentWishlist failed after the API failure")
+
+local ok3 = pcall(CB.Select, id)
+assert(ok3, "Select() failed after the API failure -- scroll widgets missing?")
+
+local ok4 = pcall(CB.Refresh)
+assert(ok4, "Refresh() failed after the API failure")
+
+print("Nexus Builds survives SetClipsChildren/SetVertexColor being unavailable -- OK")
+
+-- Also verify scrollBar is now a plain Lua table (not a WoW Frame),
+-- so its SetValue/GetValue can never fire a template's OnValueChanged
+-- before scrollFrame is ready.
+local frame2 = _G.NexusCommunityBuildsFrame
+-- access the module-level scrollBar indirectly via a fresh boot
+_G.NexusCommunityBuildsFrame = nil
+dofile("ui/CommunityBuilds.lua")
+local CB2 = Nexus.CommunityBuilds
+CB2.Init(Nexus.GameAdapter, Nexus.Model)
+local ok5 = pcall(CB2.Show)
+assert(ok5, "Show() crashed with the new scroll implementation")
+print("Scroll implementation works without SetVerticalScroll or template issues -- OK")

--- a/tests/run_builds_sort_filter.lua
+++ b/tests/run_builds_sort_filter.lua
@@ -1,0 +1,135 @@
+-- Verifies the two filter controls: class dropdown and date-updated toggle.
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua"); dofile("core/Sync.lua")
+dofile("data/DefaultProfile.lua"); dofile("logic/Model.lua"); dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua"); dofile("logic/Relay.lua"); dofile("logic/Policy.lua"); dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/Readout.lua"); dofile("ui/Panel.lua")
+local provider
+Nexus.LogViewer = { Init = function(p) provider = p end,
+    Show = function() end, Toggle = function() end }
+dofile("ui/CommunityBuilds.lua")
+dofile("core/Main.lua")
+
+NexusDB = {}
+H.playerLevel = 5
+H.wishlist = { name = "W", class = "ROGUE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 } } }
+UnitName = function() return "Alice" end
+local wall = 1000; time = function() return wall end
+
+H.FireEvent("ADDON_LOADED", "Nexus")
+H.FireEvent("SPELLS_CHANGED"); H.FireEvent("PLAYER_ENTERING_WORLD"); H.Advance(2)
+
+local CB = Nexus.CommunityBuilds
+CB.Init(Nexus.GameAdapter, Nexus.Model)
+
+NexusDB.communityBuilds = {
+    z1 = { id="z1", title="Rogue Build A",   class="ROGUE",   echoes={{spellId=1,quality=3,stacks=1}},
+           postedAt=100, lastModified=100, isMine=true,  author="Alice", description="" },
+    z2 = { id="z2", title="Mage Build B",    class="MAGE",    echoes={{spellId=2,quality=3,stacks=1}},
+           postedAt=200, lastModified=200, isMine=false, author="Bob",   description="" },
+    z3 = { id="z3", title="Warrior Build C", class="WARRIOR", echoes={{spellId=3,quality=3,stacks=1}},
+           postedAt=50,  lastModified=300, isMine=false, author="Carol", description="" },
+}
+
+CB.Show()
+
+-- 1. Default class sort: MAGE < ROGUE < WARRIOR
+NexusDB.buildFilters = { sortMode = "class" }
+local ok1 = pcall(CB.Refresh)
+assert(ok1, "class sort crashed")
+local list = {}
+for _, b in pairs(NexusDB.communityBuilds) do list[#list + 1] = b end
+table.sort(list, function(a, b)
+    local ORDER = {DEATHKNIGHT=1,DRUID=2,HUNTER=3,MAGE=4,PALADIN=5,PRIEST=6,ROGUE=7,SHAMAN=8,WARLOCK=9,WARRIOR=10}
+    local ca = ORDER[(a.class or ""):upper()] or 99
+    local cb = ORDER[(b.class or ""):upper()] or 99
+    if ca ~= cb then return ca < cb end
+    return (a.title or "") < (b.title or "")
+end)
+assert(list[1].class == "MAGE",    "first should be MAGE, got " .. list[1].class)
+assert(list[2].class == "ROGUE",   "second should be ROGUE")
+assert(list[3].class == "WARRIOR", "third should be WARRIOR")
+print("class sort: MAGE < ROGUE < WARRIOR -- OK")
+
+-- 2. Date Updated sort: highest lastModified first
+NexusDB.buildFilters = { sortMode = "recent" }
+local recent = {}
+for _, b in pairs(NexusDB.communityBuilds) do recent[#recent + 1] = b end
+table.sort(recent, function(a, b) return (a.lastModified or 0) > (b.lastModified or 0) end)
+assert(recent[1].id == "z3", "newest-first: z3 has lastModified=300 (got " .. recent[1].id .. ")")
+assert(recent[#recent].id == "z1", "oldest: z1 has lastModified=100")
+print("date-updated sort: highest lastModified first -- OK")
+
+-- 3. Class filter: only the matching class
+NexusDB.buildFilters = { sortMode = "class", classFilter = "ROGUE" }
+local filtered = {}
+for _, b in pairs(NexusDB.communityBuilds) do
+    if (b.class or ""):upper() == "ROGUE" then filtered[#filtered + 1] = b end
+end
+assert(#filtered == 1, "expected 1 ROGUE build, got " .. #filtered)
+print("class filter correctly restricts to ROGUE -- OK")
+
+-- 4. Clearing filter restores all
+NexusDB.buildFilters = { sortMode = "class", classFilter = nil }
+local ok4 = pcall(CB.Refresh)
+assert(ok4, "refresh crashed after clearing filter")
+local all = {}
+for _ in pairs(NexusDB.communityBuilds) do all[#all+1] = true end
+assert(#all == 3, "all 3 builds should show after clearing filter")
+print("clearing class filter restores all builds -- OK")
+
+-- 5. Class dropdown opens a panel and selecting All Classes clears the filter.
+NexusDB.buildFilters = { classFilter = "MAGE" }
+local dropBtn = _G.NexusCommunityBuildsFrame
+    and _G.NexusCommunityBuildsFrame._classDropBtn
+assert(dropBtn, "class dropdown button not found")
+local dropPanel = _G.NexusClassDropPanel
+assert(dropPanel, "dropdown panel not found")
+
+-- open the panel
+dropBtn.scripts.OnClick(dropBtn)
+assert(dropPanel:IsShown(), "clicking the dropdown button should open the panel")
+print("dropdown panel opens on click -- OK")
+
+-- Instead verify behaviorally: drive the OnClick of the first dropdown row
+-- (which corresponds to All Classes in our ordered list)
+-- We need to walk all created frames to find ones with the right text
+local allRows = {}
+local realCreateFrame2 = CreateFrame
+CreateFrame = function(...)
+    local f = realCreateFrame2(...)
+    allRows[#allRows + 1] = f
+    return f
+end
+-- Close and re-create the panel by calling EnsureFrame fresh
+_G.WRBuildsClassDrop = nil
+_G.NexusCommunityBuildsFrame = nil
+dofile("ui/CommunityBuilds.lua")
+local CB2 = Nexus.CommunityBuilds
+CB2.Init(Nexus.GameAdapter, Nexus.Model)
+CB2.Show()
+NexusDB.buildFilters = { classFilter = "MAGE" }
+
+local allClassesRow = nil
+for _, f in ipairs(allRows) do
+    if f.scripts and f.scripts.OnClick then
+        -- find the row whose click clears the class filter
+        local savedFilter = "MAGE"
+        NexusDB.buildFilters.classFilter = "MAGE"
+        local ok = pcall(f.scripts.OnClick, f)
+        if ok and NexusDB.buildFilters.classFilter == nil then
+            allClassesRow = f; break
+        end
+        NexusDB.buildFilters.classFilter = savedFilter
+    end
+end
+assert(allClassesRow, "no dropdown row clears the class filter (All Classes row missing)")
+print("dropdown All Classes row correctly clears the filter -- OK")
+
+-- 7. Empty library never crashes
+NexusDB.communityBuilds = {}
+local ok7 = pcall(CB.Refresh)
+assert(ok7, "refresh crashed on empty library")
+print("empty library handled correctly -- OK")

--- a/tests/run_character_best_guard.lua
+++ b/tests/run_character_best_guard.lua
@@ -1,0 +1,41 @@
+-- A character may keep many exact-set personal bests locally, but only the
+-- highest encounter result creates/syncs a leaderboard build.
+local H=dofile("tests/harness.lua")
+dofile("core/Codec.lua"); dofile("core/Sync.lua"); dofile("core/DpsCapture.lua")
+dofile("data/DefaultProfile.lua"); dofile("logic/Model.lua"); dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua"); dofile("logic/Policy.lua"); dofile("core/Store.lua")
+dofile("core/GameAdapter.lua"); dofile("ui/CommunityBuilds.lua")
+local DPS=Nexus.DpsCapture
+local Adapter=Nexus.GameAdapter
+local clock,wall=1000,50000
+GetTime=function() return clock end; time=function() wall=wall+1 return wall end
+UnitName=function(unit) if unit=="target" then return "Training Dummy" end return "Guardmage" end
+UnitLevel=function() return 80 end; UnitClass=function() return "Mage","MAGE" end
+UnitExists=function(u) return u=="target" end
+UnitGUID=function() return "Creature-0-1-0-1-36476-ABC" end
+DETAILS_ATTRIBUTE_DAMAGE=1
+local dps=24000000
+Details={GetCurrentCombat=function() return {GetActor=function() return {total=dps*30,Tempo=function() return 30 end} end} end}
+NexusDB={communityBuilds={},syncTombstones={},dpsCapture={}}
+local sent={}
+DPS.Init(Adapter,{BroadcastDpsRecord=function(r) sent[#sent+1]=r return true end,BroadcastBuild=function() return true end,BroadcastDelete=function() return true end})
+local function setLoadout(ids)
+ H.wishlist={name="test",echoes={}}
+ H.granted={}
+ for i,id in ipairs(ids) do H.wishlist.echoes[i]={spellId=id,stacks=1}; H.granted[tostring(i)]={{spellId=id,stack=1,maxStack=1}} end
+end
+local function pull(value)
+ dps=value; DPS.OnCombatStart(); clock=clock+35; DPS.OnUpdate(10); DPS.OnCombatEnd()
+end
+setLoadout({200100,200102}); pull(24000000)
+local count=0; for _ in pairs(NexusDB.communityBuilds) do count=count+1 end
+assert(count==1 and #sent==1,"first character best should create and sync one build")
+setLoadout({200104,200110}); pull(22000000)
+count=0; for _ in pairs(NexusDB.communityBuilds) do count=count+1 end
+assert(count==1 and #sent==1,"weaker experimental loadout created leaderboard bloat")
+pull(26000000)
+count=0; for _ in pairs(NexusDB.communityBuilds) do count=count+1 end
+assert(count==1 and #sent==2,"new character best should replace the old automatic page, not accumulate it")
+local board=DPS.GetDpsBoard("dummy")
+assert(#board==1 and board[1].player=="Guardmage" and board[1].dps==26000000,"board should expose only the character's winning loadout")
+print("one synced winning loadout per character and encounter -- OK")

--- a/tests/run_codec.lua
+++ b/tests/run_codec.lua
@@ -1,0 +1,77 @@
+-- Verifies the base64+JSON codec round-trips correctly, matches known
+-- vectors, and safely rejects malformed/oversized/malicious input.
+dofile("tests/harness.lua")
+dofile("core/Codec.lua")
+local Codec = Nexus.Codec
+
+-- Base64 known vectors (standard RFC 4648 test vectors)
+assert(Codec.Base64Encode("") == "")
+assert(Codec.Base64Encode("f") == "Zg==")
+assert(Codec.Base64Encode("fo") == "Zm8=")
+assert(Codec.Base64Encode("foo") == "Zm9v")
+assert(Codec.Base64Encode("foobar") == "Zm9vYmFy")
+print("base64 encode matches known RFC 4648 vectors -- OK")
+
+assert(Codec.Base64Decode("Zg==") == "f")
+assert(Codec.Base64Decode("Zm9vYmFy") == "foobar")
+print("base64 decode matches known vectors -- OK")
+
+-- round trip on binary-ish and unicode-ish data
+for _, s in ipairs({ "", "a", "ab", "abc", "abcd", "Hello, World! 123",
+    string.rep("x", 500), "\1\2\3\0\255" }) do
+    local decoded = Codec.Base64Decode(Codec.Base64Encode(s))
+    assert(decoded == s, "round-trip failed for length " .. #s)
+end
+print("base64 round-trips correctly across a range of lengths -- OK")
+
+-- malformed base64 must return nil, never error
+assert(Codec.Base64Decode("not valid!!!") == nil)
+assert(Codec.Base64Decode("abc") == nil)  -- not a multiple of 4
+assert(Codec.Base64Decode(nil) == nil)
+assert(Codec.Base64Decode(12345) == nil)
+print("malformed base64 input safely rejected -- OK")
+
+-- JSON round trip
+local data = { title = "Fire Mage AoE", class = "MAGE", spec = 1,
+    comments = "Great build!\nLine two.", echoes = {
+        { spellId = 200100, quality = 3, stacks = 1 },
+        { spellId = 200104, quality = 2, stacks = 9 },
+    }, empty = {}, flag = true, nothing = nil }
+local json = Codec.JSONEncode(data)
+local back = Codec.JSONDecode(json)
+assert(back.title == "Fire Mage AoE")
+assert(back.class == "MAGE")
+assert(back.comments == "Great build!\nLine two.")
+assert(#back.echoes == 2)
+assert(back.echoes[1].spellId == 200100)
+assert(back.echoes[2].stacks == 9)
+assert(back.flag == true)
+print("JSON round-trips complex nested structures correctly -- OK")
+
+-- special characters that must survive encoding (quotes, backslashes, unicode escape)
+local special = { text = 'Quote " and backslash \\ and tab\tend' }
+local roundtrip = Codec.JSONDecode(Codec.JSONEncode(special))
+assert(roundtrip.text == special.text, "special characters did not survive JSON round-trip")
+print("special characters (quotes, backslashes, tabs) survive JSON round-trip -- OK")
+
+-- malformed/malicious JSON must never error, only return nil or garbage safely
+assert(Codec.JSONDecode("") == nil)
+assert(Codec.JSONDecode(nil) == nil)
+local ok1 = pcall(Codec.JSONDecode, "{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{")
+assert(ok1, "deeply nested garbage JSON should not error")
+local ok2 = pcall(Codec.JSONDecode, string.rep("[", 10000))
+assert(ok2, "pathologically deep nesting should not error/hang")
+print("malformed/malicious JSON safely handled without erroring -- OK")
+
+-- IsSafeTree bounds check
+assert(Codec.IsSafeTree({ a = 1, b = { c = 2 } }, 8, 5000) == true)
+local deep = {}
+local cursor = deep
+for i = 1, 20 do cursor.child = {}; cursor = cursor.child end
+assert(Codec.IsSafeTree(deep, 8, 5000) == false, "overly deep tree should fail the safety check")
+local wide = {}
+for i = 1, 10000 do wide[i] = i end
+assert(Codec.IsSafeTree(wide, 8, 5000) == false, "overly wide tree should fail the safety check")
+print("IsSafeTree correctly bounds depth and breadth -- OK")
+
+print("codec fully verified (encode/decode/round-trip/safety)")

--- a/tests/run_community_builds.lua
+++ b/tests/run_community_builds.lua
@@ -1,0 +1,110 @@
+-- Verifies the Nexus Builds tab end-to-end: posting your active wishlist,
+-- browsing the list, selecting a build to see its full echo list with
+-- owned/missing status, and locking one in via the real confirmed
+-- UploadWishlist path.
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/CommunityBuilds.lua")
+
+NexusDB = {}
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+    { spellId = 200104, quality = 2, stacks = 3 },
+} }
+H.playerLevel = 5
+H.granted = { ["Alpha Strike"] = { { spellId = 200100, stack = 1, maxStack = 1, quality = 3 } } }
+UnitName = function() return "Boganic" end
+
+local Adapter, Model = Nexus.GameAdapter, Nexus.Model
+local CB = Nexus.CommunityBuilds
+CB.Init(Adapter, Model)
+
+-- 1. Posting with no wishlist active must fail cleanly (edge case)
+H.wishlist = nil
+local ok0, err0 = CB.PostCurrentWishlist("Test", "desc")
+assert(not ok0 and err0, "posting with no active wishlist should fail cleanly")
+print("posting with no active wishlist fails cleanly -- OK")
+
+-- 2. Restore wishlist, post it for real
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+    { spellId = 200104, quality = 2, stacks = 3 },
+} }
+local ok1, id1 = CB.PostCurrentWishlist("Fire Mage AoE", "Great for farming, easy to play.", H.wishlist)
+assert(ok1, "PostCurrentWishlist should have succeeded")
+local stored = NexusDB.communityBuilds[id1]
+assert(stored, "posted build not found in the store")
+assert(stored.title == "Fire Mage AoE", "wrong title stored")
+assert(stored.description == "Great for farming, easy to play.", "wrong description stored")
+assert(#stored.echoes == 2, "expected 2 echoes captured, got " .. #stored.echoes)
+assert(stored.isMine == true, "own posted build should be tagged isMine")
+print("PostCurrentWishlist correctly snapshots the active wishlist -- OK")
+
+-- 3. Show the window, select the build, verify detail rendering
+CB.Show()
+local frame = _G.NexusCommunityBuildsFrame
+assert(frame and frame:IsShown(), "CommunityBuilds window did not open")
+
+-- select via the public API path (simulate clicking the list row)
+-- (Refresh populates row.buildId; we drive selection the same way the
+-- row's own OnClick would, then Refresh)
+CB.Select(id1)
+
+-- 4. Detail panel must show correct owned/missing counts. We granted
+-- Alpha Strike (200100, owns 1/1) but not Double Strike (200104, owns
+-- 0/3) -- expect 1 missing echo out of 2 total.
+local allTexts = {}
+local realCreateFrame = CreateFrame
+CreateFrame = function(...)
+    local f = realCreateFrame(...)
+    local realCFS = f.CreateFontString
+    f.CreateFontString = function(self, ...)
+        local fs = realCFS(self, ...)
+        allTexts[#allTexts + 1] = fs
+        return fs
+    end
+    return f
+end
+_G.NexusCommunityBuildsFrame = nil
+dofile("ui/CommunityBuilds.lua")
+local CB2 = Nexus.CommunityBuilds
+CB2.Init(Adapter, Model)
+CB2.Show()
+CB2.Select(id1)
+
+local foundMissingCount = false
+for _, fs in ipairs(allTexts) do
+    local t = fs.text
+    if type(t) == "string" then
+        -- New detail panel shows "N echoes -- M missing" as a missingText line
+        if t:find("1 missing") then foundMissingCount = true end
+    end
+end
+assert(foundMissingCount, "detail panel did not show the correct missing count (expected 1 missing)")
+print("detail panel shows correct owned/missing status -- OK")
+
+-- 5. Lock-in must go through confirmation, then call the REAL upload path
+local captured = nil
+ProjectEbonhold.PerkService.UploadServerBuildSlot = function(slot, name, echoes)
+    captured = { slot = slot, name = name, echoes = echoes }
+    return true
+end
+CB2.LockInSelected()
+assert(H.lastStaticPopup and H.lastStaticPopup.which == "NEXUS_LOCKIN_BUILD",
+    "Lock In did not show a confirmation popup")
+H.AcceptLastStaticPopup()
+assert(captured, "accepting the confirmation did not call the real upload function")
+assert(captured.name == "Fire Mage AoE", "wrong build name uploaded")
+assert(#captured.echoes == 2, "wrong echo count uploaded")
+print("Lock In goes through confirmation then calls the real, confirmed upload path -- OK")
+
+-- 6. Delete removes it from the store and the list
+CB2.DeleteBuild(id1)
+assert(NexusDB.communityBuilds[id1] == nil, "DeleteBuild did not remove the entry")
+print("DeleteBuild correctly removes a posted build -- OK")

--- a/tests/run_community_builds_resilience.lua
+++ b/tests/run_community_builds_resilience.lua
@@ -1,0 +1,46 @@
+-- Same defense-in-depth check applied to Panel.lua and WishlistEditor.lua
+-- after hitting this exact bug class twice: a cosmetic SetBackdrop
+-- failure must never prevent functional widgets (Lock In, Delete) from
+-- being created.
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/CommunityBuilds.lua")
+
+local realCreateFrame = CreateFrame
+CreateFrame = function(kind, name, parent, ...)
+    local f = realCreateFrame(kind, name, parent, ...)
+    if kind == "Frame" and name == "NexusCommunityBuildsFrame" then
+        f.SetBackdrop = function() error("SetBackdrop not supported on this client") end
+    end
+    return f
+end
+
+NexusDB = {}
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+} }
+H.playerLevel = 5
+
+local Adapter, Model = Nexus.GameAdapter, Nexus.Model
+local CB = Nexus.CommunityBuilds
+CB.Init(Adapter, Model)
+
+local ok, err = pcall(CB.Show)
+assert(ok, "Show() threw despite SetBackdrop failing: " .. tostring(err))
+
+local ok2, id = CB.PostCurrentWishlist("Test", "desc", H.wishlist)
+assert(ok2, "PostCurrentWishlist failed after the backdrop failure")
+local ok3 = pcall(CB.Select, id)
+assert(ok3, "Select() failed after the backdrop failure")
+
+local ok4 = pcall(CB.LockInSelected)
+assert(ok4, "LockInSelected() failed after the backdrop failure -- Lock In button must still exist")
+assert(H.lastStaticPopup, "Lock In button did not actually function after the backdrop failure")
+
+print("Nexus Builds survives a SetBackdrop-style failure with all functional widgets intact")

--- a/tests/run_discord_build_link.lua
+++ b/tests/run_discord_build_link.lua
@@ -1,0 +1,12 @@
+dofile('tests/harness.lua')
+NexusDB = NexusDB or {}
+NexusDB.communityBuilds = {}
+-- Static regression guard: Discord links must be carried by full build payloads
+-- and summary metadata must flag stale link metadata for on-demand refresh.
+local f=assert(io.open('ui/CommunityBuilds.lua','r')); local ui=f:read('*a'); f:close()
+assert(ui:find('discord%.com/channels/',1,false), 'Discord message link validation missing')
+assert(ui:find('BroadcastBuildSummary',1,true), 'link save must broadcast updated build summary')
+local s=assert(io.open('core/Sync.lua','r')); local sync=s:read('*a'); s:close()
+assert(sync:find('needsFullBuild',1,true), 'summary link-change refresh flag missing')
+assert(sync:find('linkHash',1,true), 'link hash metadata missing')
+print('discord build link tests passed')

--- a/tests/run_discord_build_link_ui.lua
+++ b/tests/run_discord_build_link_ui.lua
@@ -1,0 +1,9 @@
+local f = assert(io.open("ui/CommunityBuilds.lua", "r"))
+local s = f:read("*a"); f:close()
+assert(s:find('DISCORD BUILD LINK', 1, true), 'Discord field label missing')
+assert(s:find('linkSaveBtn', 1, true), 'owner link-save button missing')
+assert(s:find('M.EditBuild%(%s*selectedId, build.title, build.description, link%)'),
+    'link not saved atomically through EditBuild')
+assert(s:find('link:match("^https://discord%.com/channels/(%d+)/(%d+)/(%d+)/?$")', 1, true) and s:find('link:match("^https://discord%.com/channels/(%d+)/(%d+)/?$")', 1, true), 'Discord channel-link validator missing')
+assert(s:find('https://discord.com/channels/%s/%s', 1, true), 'Discord channel-link normalization missing')
+print('discord build link UI tests passed')

--- a/tests/run_dps_auto_build.lua
+++ b/tests/run_dps_auto_build.lua
@@ -1,0 +1,56 @@
+-- Personal-best workflow: capture -> exact loadout -> auto build -> single public record.
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua"); dofile("core/Sync.lua"); dofile("core/DpsCapture.lua")
+dofile("data/DefaultProfile.lua"); dofile("logic/Model.lua"); dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua"); dofile("logic/Policy.lua"); dofile("core/Store.lua")
+dofile("core/GameAdapter.lua"); dofile("ui/CommunityBuilds.lua")
+
+local DPS = Nexus.DpsCapture
+local Adapter = Nexus.GameAdapter
+local CB = Nexus.CommunityBuilds
+local clock, wall = 1000, 50000
+GetTime=function() return clock end; time=function() wall=wall+1 return wall end
+UnitName=function() return "Recordmage" end
+UnitLevel=function() return 80 end
+UnitClass=function() return "Mage", "MAGE" end
+local stubDps=24000000
+Details={GetCurrentCombat=function() return {GetActor=function() return {total=stubDps*30,Tempo=function() return 30 end} end} end}
+DETAILS_ATTRIBUTE_DAMAGE=1
+UnitExists=function(u) return u=="target" end
+UnitGUID=function(u) return u=="target" and "Creature-0-1-0-1-36476-ABC" or nil end
+UnitName=function(unit) if unit=="player" then return "Recordmage" elseif unit=="target" then return "Training Dummy" end end
+
+NexusDB={communityBuilds={},syncTombstones={},dpsCapture={}}
+H.playerLevel=5
+H.wishlist={name="Record Set",class="MAGE",echoes={{spellId=200100,quality=3,stacks=2},{spellId=200101,quality=3,stacks=1}}}
+H.granted={A={{spellId=200100,stack=2,maxStack=2,quality=3}},B={{spellId=200101,stack=1,maxStack=1,quality=3}}}
+H.FireEvent("SPELLS_CHANGED"); H.FireEvent("PLAYER_ENTERING_WORLD"); H.Advance(2)
+local sent={}
+local sync={BroadcastDpsRecord=function(r) sent[#sent+1]=r return true end,BroadcastBuild=function() return true end}
+DPS.Init(Adapter,sync)
+
+DPS.OnCombatStart(); clock=clock+35; DPS.OnUpdate(10); DPS.OnCombatEnd()
+local count, buildId, build=0
+for id,b in pairs(NexusDB.communityBuilds) do count=count+1; buildId=id; build=b end
+assert(count==1 and build and build.autoDps, "a new exact loadout should create one automatic shareable build")
+assert(buildId:find("^dps%-"), "automatic build id should be deterministic")
+local lb=DPS.GetLeaderboard(buildId,"dummy")
+assert(#lb==1 and lb[1].dps==24000000 and lb[1].player=="Recordmage", "captured personal best should become the public build record")
+assert(#sent==1 and sent[1].fingerprint==DPS.GetEchoKey(build.echoes), "the exact record should be broadcast once")
+
+-- Lower pull: no new build, no public update, no additional broadcast.
+stubDps=20000000; DPS.OnCombatStart(); clock=clock+35; DPS.OnUpdate(10); DPS.OnCombatEnd()
+local n=0; for _ in pairs(NexusDB.communityBuilds) do n=n+1 end
+assert(n==1 and DPS.GetLeaderboard(buildId,"dummy")[1].dps==24000000 and #sent==1, "lower pull must change nothing")
+
+-- Higher pull: same build, replacement record.
+stubDps=26000000; DPS.OnCombatStart(); clock=clock+35; DPS.OnUpdate(10); DPS.OnCombatEnd()
+assert(DPS.GetLeaderboard(buildId,"dummy")[1].dps==26000000 and #sent==2, "higher pull should replace and rebroadcast the same build record")
+
+-- Higher remote record replaces; lower stale data is rejected.
+local echoes=build.echoes; local fp=DPS.GetEchoKey(echoes)
+assert(DPS.ReceiveRecord({v=3,f=fp,e=echoes,c="dummy",d=27000000,u=65,t=60000,p="Othermage",k="MAGE",l=80,b=buildId}), "higher remote record should be accepted")
+assert(DPS.ReceiveRecord({v=3,f=fp,e=echoes,c="dummy",d=25000000,u=65,t=60001,p="Oldmage",k="MAGE",l=80,b=buildId}), "a different character should keep its own best entry")
+assert(not DPS.ReceiveRecord({v=3,f=fp,e=echoes,c="dummy",d=24000000,u=65,t=60002,p="Oldmage",k="MAGE",l=80,b=buildId}), "a lower record for the same character should be rejected")
+assert(DPS.GetLeaderboard(buildId,"dummy")[1].player=="Othermage", "highest exact-loadout holder should remain authoritative")
+print("automatic exact-loadout build and single-record DPS workflow -- OK")

--- a/tests/run_dps_boards.lua
+++ b/tests/run_dps_boards.lua
@@ -1,0 +1,26 @@
+-- Public boards: one highest winning loadout per character, ranked separately by encounter.
+local H=dofile("tests/harness.lua")
+dofile("core/Codec.lua"); dofile("core/Sync.lua"); dofile("core/DpsCapture.lua")
+dofile("data/DefaultProfile.lua"); dofile("logic/Model.lua"); dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua"); dofile("logic/Policy.lua"); dofile("core/Store.lua")
+dofile("core/GameAdapter.lua"); dofile("ui/CommunityBuilds.lua")
+local DPS=Nexus.DpsCapture
+UnitName=function(unit) return unit=="player" and "Viewer" or nil end
+UnitClass=function() return "Mage","MAGE" end
+NexusDB={communityBuilds={},syncTombstones={},dpsCapture={}}
+DPS.Init({}, {BroadcastBuild=function() return true end})
+local a={{spellId=200001,stacks=2},{spellId=200002,stacks=1}}
+local b={{spellId=200010,stacks=1},{spellId=200011,stacks=3}}
+local fa,fb=DPS.GetEchoKey(a),DPS.GetEchoKey(b)
+assert(DPS.ReceiveRecord({v=4,f=fa,e=a,c="dummy",d=24000000,u=65,t=100,p="Alpha",k="MAGE",l=80}),"dummy A rejected")
+assert(DPS.ReceiveRecord({v=4,f=fb,e=b,c="dummy",d=28000000,u=65,t=101,p="Bravo",k="MAGE",l=80}),"dummy B rejected")
+assert(DPS.ReceiveRecord({v=4,f=fa,e=a,c="lk",d=19000000,u=240,t=102,p="Alpha",k="MAGE",l=80}),"LK A rejected")
+assert(not DPS.ReceiveRecord({v=4,f=fb,e=b,c="dummy",d=23000000,u=65,t=103,p="Alpha",k="MAGE",l=80}),"lower second loadout for the same character accepted")
+local dummy=DPS.GetDpsBoard("dummy")
+assert(#dummy==2,"dummy board should contain one row per character")
+assert(dummy[1].player=="Bravo" and dummy[1].dps==28000000,"dummy board not DPS-ranked")
+assert(dummy[1].build and dummy[1].buildId and #dummy[1].echoes==2,"board row lacks copyable exact build")
+local lk=DPS.GetDpsBoard("lk")
+assert(#lk==1 and lk[1].player=="Alpha" and lk[1].category=="lk","LK board not separate")
+assert(DPS.GetDpsBoard("bad")[1]==nil,"invalid category should be empty")
+print("separate Dummy/Lich boards, one row per character, exact loadout, and stale rejection -- OK")

--- a/tests/run_dps_capture.lua
+++ b/tests/run_dps_capture.lua
@@ -1,0 +1,122 @@
+-- DPS capture: always-on, two categories (dummy / LK), target detection,
+-- personal best tracking, leaderboard sorting, peer submission.
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua"); dofile("core/Sync.lua"); dofile("core/DpsCapture.lua")
+dofile("data/DefaultProfile.lua"); dofile("logic/Model.lua"); dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua"); dofile("logic/Policy.lua"); dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+
+local DPS = Nexus.DpsCapture
+local Adapter = Nexus.GameAdapter
+local clock = 1000; GetTime = function() return clock end
+local wall = 50000; time = function() return wall end
+UnitName = function() return "Solkr" end
+UnitLevel = function() return 80 end
+
+-- Stub Details!
+local stubDps = 0
+Details = {
+    GetCurrentCombat = function()
+        return {
+            GetActor = function(_, attr, name)
+                if stubDps <= 0 then return nil end
+                return { total = stubDps * 30, Tempo = function(_) return 30 end }
+            end,
+            GetCombatTime = function(_) return 30 end,
+        }
+    end
+}
+DETAILS_ATTRIBUTE_DAMAGE = 1
+
+-- Training dummy GUID
+local DUMMY_GUID = "Creature-0-1823-0-28-36476-000095AF5E"  -- NPC 36476
+local LK_GUID    = "Creature-0-631-0-28-36597-0000ABCDEF"   -- NPC 36597
+UnitGUID = function(unit) return unit == "target" and DUMMY_GUID or nil end
+UnitExists = function(unit) return unit == "target" end
+
+NexusDB = { communityBuilds={}, syncTombstones={}, dpsCapture={} }
+H.playerLevel = 5
+H.wishlist = { name="W", class="ROGUE", echoes={{spellId=200100,quality=3,stacks=1}} }
+H.granted = { ["Alpha Strike"]={{spellId=200100,stack=1,maxStack=1,quality=3}} }
+H.FireEvent("SPELLS_CHANGED"); H.FireEvent("PLAYER_ENTERING_WORLD"); H.Advance(2)
+
+local buildId = "test-build-1"
+NexusDB.communityBuilds[buildId] = {
+    id=buildId, title="Rogue Test", author="explore", class="ROGUE",
+    echoes={{spellId=200100,quality=3,stacks=1}},
+    postedAt=50000, lastModified=50000, isMine=false,
+}
+DPS.Init(Adapter, nil)
+assert(DPS.IsEnabled(), "DPS capture should always be enabled")
+print("DPS capture is always-on -- OK")
+
+-- 1. Short dummy session: not committed
+stubDps = 50000
+UnitGUID = function(unit) return unit == "target" and DUMMY_GUID or nil end
+DPS.OnCombatStart()
+clock = clock + 10  -- only 10s
+DPS.OnCombatEnd()
+assert(#DPS.GetLeaderboard(buildId,"dummy") == 0, "short session must not commit")
+print("short session correctly ignored -- OK")
+
+-- 2. Valid dummy session
+DPS.OnCombatStart()
+clock = clock + 20; DPS.OnUpdate(10); DPS.OnUpdate(10)
+stubDps = 75000
+clock = clock + 15; DPS.OnCombatEnd()
+local lb = DPS.GetLeaderboard(buildId,"dummy")
+assert(#lb == 1 and lb[1].dps == 75000, "dummy session not recorded: "..(#lb > 0 and lb[1].dps or "empty"))
+assert(#DPS.GetLeaderboard(buildId,"lk") == 0, "LK leaderboard should be empty after dummy session")
+print("dummy session recorded correctly, LK leaderboard untouched -- OK")
+
+-- 3. Lich King session recorded in separate category
+UnitGUID = function(unit) return unit == "target" and LK_GUID or nil end
+stubDps = 90000
+DPS.OnCombatStart()
+clock = clock + 40; DPS.OnUpdate(10); DPS.OnUpdate(10); DPS.OnUpdate(10)
+DPS.OnCombatEnd()
+local lkLb = DPS.GetLeaderboard(buildId,"lk")
+assert(#lkLb == 1 and lkLb[1].dps == 90000, "LK session not recorded")
+assert(#DPS.GetLeaderboard(buildId,"dummy") == 1, "dummy leaderboard should be unchanged")
+print("LK session recorded in its own category -- OK")
+
+-- 4. Personal best: lower doesn't replace, higher does
+UnitGUID = function(unit) return unit == "target" and DUMMY_GUID or nil end
+stubDps = 60000  -- lower
+DPS.OnCombatStart(); clock = clock + 40; DPS.OnUpdate(10); DPS.OnUpdate(10); DPS.OnCombatEnd()
+assert(DPS.GetLeaderboard(buildId,"dummy")[1].dps == 75000, "lower DPS must not replace best")
+
+stubDps = 100000  -- higher
+DPS.OnCombatStart(); clock = clock + 40; DPS.OnUpdate(10); DPS.OnUpdate(10); DPS.OnCombatEnd()
+local pb = DPS.GetPersonalBest(buildId,"dummy")
+assert(pb and pb.dps == 100000, "higher DPS should replace best")
+assert(#DPS.GetLeaderboard(buildId,"dummy") == 1, "still one entry per player")
+print("personal best updates correctly (lower ignored, higher replaces) -- OK")
+
+-- 5. Peer submission: only the highest record for each exact build/category is retained
+DPS.ReceiveSubmission(buildId,"Alice",120000,80,"dummy",12345)
+local lb2 = DPS.GetLeaderboard(buildId,"dummy")
+assert(#lb2 == 1 and lb2[1].player=="Alice" and lb2[1].dps==120000, "Alice should hold the single dummy record")
+DPS.ReceiveSubmission(buildId,"Alice",85000,80,"lk",12345)
+local lk2 = DPS.GetLeaderboard(buildId,"lk")
+assert(#lk2 == 1 and lk2[1].player=="Solkr" and lk2[1].dps==90000, "lower LK data must not replace the record")
+DPS.ReceiveSubmission(buildId,"Alice",125000,80,"lk",12346)
+lk2 = DPS.GetLeaderboard(buildId,"lk")
+assert(#lk2 == 1 and lk2[1].player=="Alice" and lk2[1].dps==125000, "higher LK data should replace the record")
+print("peer submissions retain only the highest exact-build record -- OK")
+
+-- 6. Submission for unknown build: silently ignored
+DPS.ReceiveSubmission("no-such-build","Bob",999999,80,"dummy",0)
+assert(#DPS.GetLeaderboard("no-such-build","dummy") == 0,
+    "unknown build submission must be silently ignored")
+print("unknown build submission ignored -- OK")
+
+-- 7. Lower remote data cannot replace the single record
+DPS.ReceiveSubmission(buildId,"Carol",110000,80,"dummy",12345)
+DPS.ReceiveSubmission(buildId,"Dave",95000,80,"dummy",12345)
+local lb3 = DPS.GetLeaderboard(buildId,"dummy")
+assert(#lb3 == 1 and lb3[1].player == "Alice" and lb3[1].dps == 120000,
+    "lower remote submissions must not replace the record")
+print("single-record leaderboard rejects lower data -- OK")
+
+print("All DPS capture tests passed.")

--- a/tests/run_dps_mesh_sync.lua
+++ b/tests/run_dps_mesh_sync.lua
@@ -1,0 +1,48 @@
+-- Mesh audit: Sync Now responses include every held build and only its highest DPS record.
+local H=dofile("tests/harness.lua")
+dofile("core/Codec.lua"); dofile("core/Sync.lua"); dofile("core/DpsCapture.lua")
+local Sync, DPS=Nexus.Sync, Nexus.DpsCapture
+local clock=1000; GetTime=function() return clock end; time=function() return 50000 end
+local currentName="Relay"
+UnitName=function() return currentName end; UnitLevel=function() return 80 end
+local echoes={}; for i=1,79 do echoes[i]={spellId=210000+i,stacks=1} end
+local build={id="remote-record-build",title="Mesh Record",author="Origin",class="MAGE",echoes=echoes,postedAt=1,lastModified=1,isMine=false}
+NexusDB={communityBuilds={[build.id]=build},syncTombstones={},dpsCapture={}}
+Sync.Init(Nexus.Codec,{})
+DPS.Init({},Sync)
+local fp=DPS.GetEchoKey(echoes)
+assert(DPS.ReceiveRecord({v=3,f=fp,e=echoes,c="dummy",d=31000000,u=65,t=50000,p="Champion",k="MAGE",l=80,b=build.id}),"seed record failed")
+
+H.sentChatMessages={}
+clock=clock+100
+Sync.HandleIncoming("WLRQ|NewPeer|0","NewPeer")
+for i=1,1000 do Sync.OnUpdate(0.2) end
+local sawBuild,sawDps=false,false
+for _,m in ipairs(H.sentChatMessages) do
+    assert(#m.text<=255,"wire message exceeds WoW limit")
+    if m.text:find("^WLBI|") then sawBuild=true end
+    if m.text:find("^WLD2|") then sawDps=true end
+end
+assert(not sawBuild,"relay redistributed a remotely authored build as its own")
+assert(not sawDps,"relay redistributed a verified DPS record without origin evidence")
+
+-- The actual record owner can still publish the exact evidence.
+currentName="Champion"
+H.sentChatMessages={}
+assert(DPS.BroadcastAllBuildBests("0")>0,"record owner did not queue its DPS evidence")
+for i=1,1000 do Sync.OnUpdate(0.2) end
+local dpsMessages={}
+for _,m in ipairs(H.sentChatMessages) do
+    if m.text:find("^WLD2|") then dpsMessages[#dpsMessages+1]=m.text end
+end
+assert(#dpsMessages>0,"record owner produced no DPS chunks")
+
+-- Fresh receiver: the chunks reconstruct the exact authoritative record.
+NexusDB={communityBuilds={[build.id]=build},syncTombstones={},dpsCapture={}}
+DPS.Init({},Sync)
+for _,text in ipairs(dpsMessages) do Sync.HandleIncoming(text,"Champion") end
+local lb=DPS.GetLeaderboard(build.id,"dummy")
+assert(#lb==1 and lb[1].dps==31000000 and lb[1].player=="Champion","DPS chunks did not reconstruct the highest record")
+assert(not DPS.ReceiveRecord({v=3,f=fp,e=echoes,c="dummy",d=30000000,u=65,t=50001,p="Champion",k="MAGE",l=80,b=build.id}),"lower record should be rejected")
+assert(DPS.GetLeaderboard(build.id,"dummy")[1].dps==31000000,"stale data overwrote the record")
+print("DPS origin authority, chunking, reconstruction and stale rejection -- OK")

--- a/tests/run_editor_autorefresh.lua
+++ b/tests/run_editor_autorefresh.lua
@@ -1,0 +1,32 @@
+-- Verifies the editor refreshes itself periodically while open (2026-07-24
+-- gap: previously nothing updated the tracking status after an upload's
+-- server round-trip finished unless the user happened to click something).
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/WishlistEditor.lua")
+
+NexusDB = {}
+H.playerLevel = 1
+-- start with NO wishlist at all
+local Adapter, Model = Nexus.GameAdapter, Nexus.Model
+local EW = Nexus.WishlistEditor
+EW.Init(Adapter, Model)
+EW.Show()
+
+local refreshCount = 0
+local realRefresh = EW.Refresh
+EW.Refresh = function(...)
+    refreshCount = refreshCount + 1
+    return realRefresh(...)
+end
+
+local before = refreshCount
+H.Advance(5)  -- 5 seconds of real play time
+assert(refreshCount > before, "editor never refreshed itself while open over 5 seconds")
+print(string.format("editor auto-refreshed %d times over 5s while open -- OK", refreshCount - before))

--- a/tests/run_editor_resilience.lua
+++ b/tests/run_editor_resilience.lua
@@ -1,0 +1,60 @@
+-- Regression for the live 2026-07-24 crash: WishlistEditor called
+-- SetColorTexture (a retail-only API absent on this WotLK 3.3.5 client),
+-- which threw INSIDE EnsureFrame before pickRows/applyBtn/footers were
+-- created -- and because EnsureFrame memoizes, every later Toggle()/
+-- Show() call silently returned the half-built frame forever after.
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/WishlistEditor.lua")
+
+-- Simulate the exact live failure: make SetColorTexture throw, exactly
+-- like calling a nonexistent method would on the real client, on ANY
+-- texture this window creates.
+local realCreateFrame = CreateFrame
+CreateFrame = function(kind, name, parent, ...)
+    local f = realCreateFrame(kind, name, parent, ...)
+    local realCreateTexture = f.CreateTexture
+    f.CreateTexture = function(self, ...)
+        local tex = realCreateTexture(self, ...)
+        tex.SetColorTexture = function() error("SetColorTexture not supported on this client") end
+        return tex
+    end
+    return f
+end
+
+NexusDB = {}
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+} }
+H.playerLevel = 5
+
+local Adapter, Model = Nexus.GameAdapter, Nexus.Model
+Adapter.Wishlist = function()
+    return { name=H.wishlist.name, class=H.wishlist.class, entries=H.wishlist.echoes }
+end
+local EW = Nexus.WishlistEditor
+EW.Init(Adapter, Model)
+
+local ok, err = pcall(EW.OpenForCandidate, {title=H.wishlist.name, echoes=H.wishlist.echoes})
+assert(ok, "Show() threw despite SetColorTexture being unavailable: " .. tostring(err))
+
+-- The actual regression: every functional widget must exist, not just
+-- the frame itself. DebugPendingCount() exercises Refresh() internals
+-- which touch the pending list built from real widgets.
+assert(EW.DebugPendingCount() == 1, "pending list wasn't built correctly")
+
+local ok2 = pcall(EW.Refresh)
+assert(ok2, "Refresh() failed after the cosmetic texture failure")
+
+local ok3 = pcall(EW.Toggle)
+assert(ok3, "Toggle() failed -- this is exactly what crashed live")
+local ok4 = pcall(EW.Toggle)
+assert(ok4, "second Toggle() failed")
+
+print("editor survives a SetColorTexture-style failure with all widgets intact")

--- a/tests/run_editor_scroll_icons.lua
+++ b/tests/run_editor_scroll_icons.lua
@@ -1,0 +1,68 @@
+-- Verifies: (1) mouse-wheel scrolling replaces Prev/Next, (2) real spell
+-- icons are set instead of the hardcoded question-mark placeholder.
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+
+local allFrames = {}
+local realCreateFrame = CreateFrame
+CreateFrame = function(...)
+    local f = realCreateFrame(...)
+    allFrames[#allFrames + 1] = f
+    -- also capture every texture this frame creates -- the icon regions
+    -- are textures, not frames, so CreateFrame alone never sees them
+    local realCreateTexture = f.CreateTexture
+    f.CreateTexture = function(self, ...)
+        local tex = realCreateTexture(self, ...)
+        allFrames[#allFrames + 1] = tex
+        return tex
+    end
+    return f
+end
+
+dofile("ui/WishlistEditor.lua")
+
+-- fake GetSpellInfo returning a distinct icon per spellId
+GetSpellInfo = function(id)
+    return "Echo " .. id, nil, "Interface\\Icons\\Ability_Fake_" .. id
+end
+
+NexusDB = {}
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+} }
+H.playerLevel = 5
+
+local Adapter, Model = Nexus.GameAdapter, Nexus.Model
+local EW = Nexus.WishlistEditor
+EW.Init(Adapter, Model)
+EW.Show()
+
+-- no Prev/Next buttons should exist anymore
+for _, f in ipairs(allFrames) do
+    local t = f.text
+    assert(t ~= "Prev" and t ~= "Next",
+        "a Prev/Next button still exists -- should be wheel-scroll only")
+end
+print("Prev/Next buttons are gone -- OK")
+
+-- some frame must have wheel-scroll wired
+local wheelFrames = 0
+for _, f in ipairs(allFrames) do
+    if f.scripts and f.scripts.OnMouseWheel then wheelFrames = wheelFrames + 1 end
+end
+assert(wheelFrames > 0, "no OnMouseWheel handlers found anywhere in the editor")
+print(string.format("found %d wheel-scrollable regions -- OK", wheelFrames))
+
+-- icons: the left-list row for Alpha Strike (200100) must show its real icon
+local foundRealIcon = false
+for _, f in ipairs(allFrames) do
+    if type(f.texture) == "string" and f.texture:find("Ability_Fake_200100") then foundRealIcon = true end
+end
+assert(foundRealIcon, "left-list row did not get the real spell icon (still showing placeholder?)")
+print("real spell icons are being set instead of the placeholder -- OK")

--- a/tests/run_fontstring_mouse.lua
+++ b/tests/run_fontstring_mouse.lua
@@ -1,0 +1,49 @@
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/Readout.lua")
+dofile("ui/Panel.lua")
+
+-- Simulate the ACTUAL live failure: FontStrings on this client don't
+-- support EnableMouse/SetScript at all. Patch CreateFontString's return
+-- value so calling EnableMouse on it throws, exactly like the real client.
+local realCreateFrame = CreateFrame
+CreateFrame = function(kind, name, parent, ...)
+    local f = realCreateFrame(kind, name, parent, ...)
+    local realCreateFontString = f.CreateFontString
+    f.CreateFontString = function(self, ...)
+        local fs = realCreateFontString(self, ...)
+        fs.EnableMouse = function() error("FontString has no EnableMouse on this client") end
+        fs.SetScript = function() error("FontString has no SetScript on this client") end
+        return fs
+    end
+    return f
+end
+
+NexusDB = {}
+Nexus.Panel.Init({ ToggleAuto = function() return true end })
+
+local ok, err = pcall(function()
+    Nexus.Panel.Render({
+        status = "test", cards = {}, recommendation = "",
+        progress = { owned = 1, total = 2, loadoutStacks = { stackCount=1, stackTotal=2 },
+            missing = {"Thing"} },
+        auto = true, version = "test",
+    })
+end)
+assert(ok, "Render threw despite FontStrings rejecting EnableMouse: " .. tostring(err))
+print("panel survived FontString EnableMouse rejection")
+
+-- The actual regression: autoBtn must be usable (this is exactly what
+-- crashed live -- "attempt to index upvalue 'autoBtn' (a nil value)")
+local ok2, err2 = pcall(function()
+    Nexus.Panel.Render({ status = "t2", cards = {}, recommendation = "",
+        progress = nil, auto = false, version = "test" })
+end)
+assert(ok2, "second render (the one that crashed live) failed: " .. tostring(err2))
+print("second render OK -- autoBtn exists and is usable")

--- a/tests/run_full_boot_polish.lua
+++ b/tests/run_full_boot_polish.lua
@@ -1,0 +1,61 @@
+-- Confirms the new features (overlay, quick-start, community button, editor
+-- checkbox) all wire together through the REAL Main.lua Init()/Step() flow
+-- without crashing, and that the quick-start fires exactly once.
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Relay.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/Readout.lua")
+dofile("ui/Panel.lua")
+dofile("ui/JournalTab.lua")
+dofile("ui/LogViewer.lua")
+dofile("ui/WishlistEditor.lua")
+dofile("ui/WishlistOverlay.lua")
+dofile("ui/QuickStart.lua")
+dofile("core/Main.lua")
+
+NexusDB = {}
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+} }
+H.playerLevel = 5
+
+H.FireEvent("ADDON_LOADED", "Nexus")
+H.FireEvent("SPELLS_CHANGED")
+H.FireEvent("PLAYER_ENTERING_WORLD")
+H.Advance(2)
+
+-- quick-start must have fired exactly once by now (real wishlist present)
+local qsFrame = _G.NexusQuickStart
+assert(qsFrame and qsFrame:IsShown(), "quick-start never showed during real boot")
+assert(qsFrame.body.text:find("Already have a finished build", 1, true),
+    "wrong quick-start content for real boot")
+print("quick-start fires correctly during a real Main.lua boot -- OK")
+
+-- dismiss and advance further -- must not reappear
+NexusDB.hasSeenQuickStart = true
+qsFrame:Hide()
+H.Advance(3)
+assert(not qsFrame:IsShown(), "quick-start reappeared after dismissal during live play")
+print("quick-start stays dismissed through continued play -- OK")
+
+-- editor and overlay must both be reachable and functional via slash commands
+local ok1 = pcall(function() SlashCmdList["NEXUS"]("editor") end)
+assert(ok1, "/wr editor crashed")
+local editorFrame = _G.NexusEditorFrame
+assert(editorFrame and editorFrame:IsShown(), "/wr editor did not open the editor")
+print("/wr editor works end-to-end through real Main.lua -- OK")
+
+-- the overlay checkbox in the editor must exist and toggling it works
+-- (exercised via the public API directly, matching what the checkbox calls)
+local ok2 = pcall(Nexus.WishlistOverlay.Show)
+assert(ok2, "overlay Show() crashed when driven the same way the checkbox does")
+assert(Nexus.WishlistOverlay.IsShown(), "overlay did not show")
+print("overlay reachable and functional -- OK")
+
+print("full boot + polish integration OK (checks=4)")

--- a/tests/run_historical_class_repair.lua
+++ b/tests/run_historical_class_repair.lua
@@ -1,0 +1,35 @@
+-- Historical leaderboard/build class repair regression coverage.
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua"); dofile("core/Sync.lua"); dofile("core/DpsCapture.lua")
+dofile("data/DefaultProfile.lua"); dofile("logic/Model.lua"); dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua"); dofile("logic/Policy.lua"); dofile("core/Store.lua")
+dofile("core/GameAdapter.lua"); dofile("ui/CommunityBuilds.lua"); dofile("ui/Leaderboard.lua")
+
+local DPS=Nexus.DpsCapture
+local A=Nexus.GameAdapter
+local now=70000; time=function() return now end
+GetNormalizedRealmName=function() return "Ebonhold" end
+UnitName=function() return "Explore" end
+UnitClass=function() return "Mage", "MAGE" end
+
+local echoes={{spellId=200100,count=1},{spellId=200101,count=1}}
+NexusDB={communityBuilds={},syncTombstones={},dpsCapture={personalBest={},characterBest={dummy={},lk={}}}}
+DPS.Init(A,nil)
+local fp=DPS.GetEchoKey(echoes)
+local id="dps-old-shaman"
+NexusDB.communityBuilds[id]={id=id,title="Shaman Record Loadout",author="Explore",ownerKey="explore@ebonhold",class="SHAMAN",echoes=echoes,autoDps=true,postedAt=1,lastModified=1}
+local row={player="Explore",ownerKey="explore@ebonhold",realm="ebonhold",class="SHAMAN",dps=24000000,duration=60,ts=100,level=80,buildId=id,echoes=echoes,fingerprint=fp}
+NexusDB.dpsCapture.characterBest.dummy["explore@ebonhold"]=row
+NexusDB.dpsCapture.personalBest[fp]={dummy={player="Explore",class="SHAMAN",dps=24000000,buildId=id,fingerprint=fp}}
+
+local board=DPS.GetDpsBoard("dummy")
+assert(#board==1 and board[1].class=="MAGE", "local historical row must repair to current character class")
+assert(NexusDB.communityBuilds[id].class=="MAGE", "linked automatic record page class must repair")
+assert(NexusDB.communityBuilds[id].title=="Mage Record Loadout", "untouched default title must repair")
+
+-- Equal-DPS corrected metadata must be accepted by a peer with stale class.
+UnitName=function() return "Other" end
+UnitClass=function() return "Shaman", "SHAMAN" end
+DPS.ReceiveRecord({v=7,f=fp,e=echoes,c="dummy",d=24000000,u=60,t=100,p="Explore",k="MAGE",o="explore@ebonhold",r="ebonhold",l=80,b=id})
+assert(NexusDB.dpsCapture.characterBest.dummy["explore@ebonhold"].class=="MAGE", "peer row must retain corrected Mage class")
+print("historical class repair -- OK")

--- a/tests/run_integration.lua
+++ b/tests/run_integration.lua
@@ -1,0 +1,725 @@
+-- Nexus integration suite: boots the REAL addon files under the
+-- harness and asserts the safety-critical flows headlessly.
+-- Run from the addon root:  luajit tests/run_integration.lua
+-- Exits non-zero on any failure. A red suite blocks deploy.
+
+local H = dofile("tests/harness.lua")
+
+local failures, checks = 0, 0
+local function check(cond, msg)
+    checks = checks + 1
+    if not cond then
+        failures = failures + 1
+        print("FAIL: " .. msg)
+    end
+end
+
+dofile("tests/run_secure_globals.lua")
+
+-- Boot in .toc order.
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Relay.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/Readout.lua")
+dofile("ui/Panel.lua")
+dofile("ui/JournalTab.lua")
+dofile("core/Main.lua")
+
+NexusDB = {}
+
+-- Wishlist fixture (client shape; families: Alpha, Beta, DoubleStrike x3, g50)
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+    { spellId = 200102, quality = 2, stacks = 1 },
+    { spellId = 200104, quality = 2, stacks = 3 },
+    { spellId = 200110, quality = 0, stacks = 1 },
+} }
+
+local function DesignedWishlistEchoes()
+    return {
+        { spellId = 200100, quality = 3, stacks = 1, locked = false },
+        { spellId = 200102, quality = 2, stacks = 1, locked = false },
+        { spellId = 200104, quality = 2, stacks = 3, locked = false },
+        { spellId = 200110, quality = 0, stacks = 1, locked = false },
+    }
+end
+
+local function PadGrantedTo79(granted, currentTotal)
+    granted["Capacity Filler"] = granted["Capacity Filler"] or {}
+    for _ = currentTotal + 1, 79 do
+        granted["Capacity Filler"][#granted["Capacity Filler"] + 1] = {
+            spellId=200200, stack=1, maxStack=1, quality=1,
+        }
+    end
+    return granted
+end
+
+------------------------------------------------------------------------
+-- S1: boot at level 1; SPELLS_CHANGED-before-PEW guard; solo picker
+------------------------------------------------------------------------
+H.playerLevel = 1
+H.FireEvent("ADDON_LOADED", "Nexus")
+H.FireEvent("SPELLS_CHANGED")
+H.FireEvent("PLAYER_ENTERING_WORLD")
+-- 1.19.3 intentionally starts in manual mode; the integration run opts in to
+-- automation before exercising automatic board and tome behavior.
+SlashCmdList.NEXUS("auto")
+check(H.ChatContains("nexus for commands") or H.ChatContains("Nexus"),
+    "S1 addon initialized after PLAYER_ENTERING_WORLD")
+check(H.optSettings.autoAcceptLoadoutEchoes == false,
+    "S1 client auto-accept disabled (sole picker)")
+check((H.slotRequests or 0) >= 1, "S1 RequestServerBuildSlots fired on load")
+
+local A = Nexus.GameAdapter
+
+local function AssociateSnapshot(snapshotSlot, wishlistSlot)
+    local ok, err = A.SetLoadoutWishlist(snapshotSlot, wishlistSlot)
+    check(ok, "test fixture associated Snapshot " .. tostring(snapshotSlot)
+        .. " with wishlist " .. tostring(wishlistSlot) .. ": " .. tostring(err))
+end
+
+------------------------------------------------------------------------
+-- S2: catalog -- lever conformance, families, corrected class mask
+------------------------------------------------------------------------
+local cat = A.Catalog()
+check(cat ~= nil, "S2 catalog built")
+check(cat.levers[9] and cat.levers[9].conformant == false,
+    "S2 garbage lever 9 marked non-conformant")
+check(cat.levers[300400] and cat.levers[300400].conformant == true
+    and #cat.levers[300400].members == 2,
+    "S2 shared conformant lever 300400 has 2 members")
+check(cat.familyOf[200110] == "g50" and cat.familyOf[200112] == "g50",
+    "S2 multi-quality family shares key g50")
+check(cat.playerMask == 128, "S2 corrected MAGE class mask")
+
+------------------------------------------------------------------------
+-- S3: ARM at L1 -- activate best verified slot; lever discipline
+------------------------------------------------------------------------
+-- only these off-wishlist tome echoes have been discovered (learned); their
+-- levers are disable-able. 200700 (Lone Tome) is NOT discovered -> skip it.
+H.discovered = { [200200] = 1, [200400] = 1, [200402] = 1 }
+H.DeliverDiscovery({})     -- discovery synced, nothing disabled
+local activatesBeforeArm = #H.activateCalls
+H.DeliverSlots({
+    [2] = { slot = 2, name = "Main", verified = true, echoes = {
+        { spellId = 200100, quality = 3, stacks = 1, locked = false },
+        { spellId = 200200, quality = 1, stacks = 1, locked = false },
+        { spellId = 200104, quality = 2, stacks = 2, locked = false },
+        { spellId = 200202, quality = 1, stacks = 1, locked = false },
+    } },
+    [3] = { slot = 3, name = "Design", verified = false,
+        echoes = DesignedWishlistEchoes() },
+}, 2)
+AssociateSnapshot(2, 3)
+-- Rare Tome of Echo items show this stock bind confirmation. The guard must
+-- engage while the tome is still in the bag, before the first click, and must
+-- leave the stock popup's acceptance path untouched so the item is learned.
+H.SetBagItem(0, 1, "Tome of Echo: Demon's Bane")
+StaticPopupDialogs["USE_BIND"] = {
+    text = "Using this item will bind it to you.",
+    OnAccept = function()
+        H.SetBagItem(0, 1, nil)
+        H.discovered[200569] = 1
+    end,
+}
+H.Advance(2)
+check(#H.wire == 0,
+    "S3 carried Tome of Echo pauses mutations before the first item click")
+StaticPopup_Show("USE_BIND")
+check(H.AcceptLastStaticPopup()
+        and H.discovered[200569] == 1
+        and GetContainerItemLink(0, 1) == nil,
+    "S3 stock bind acceptance consumes and learns Demon's Bane")
+H.Advance(8)
+check(#H.wire == 0,
+    "S3 learned tome keeps automatic mutations paused while settling")
+H.Advance(13)              -- clears the 20s bind-settle guard
+check(#H.activateCalls == activatesBeforeArm
+        and A.Slots().activeSlot == 2,
+    "S3 preserves the user-selected active Snapshot instead of switching builds")
+
+local function CountWire(prefix)
+    local n = 0
+    for _, w in ipairs(H.wire) do
+        if w:sub(1, #prefix) == prefix then n = n + 1 end
+    end
+    return n
+end
+H.Advance(3)               -- more ticks BEFORE the 530 reply: dedupe must hold
+check(CountWire("300200|0") == 1, "S3 off-wishlist lever 300200 disabled EXACTLY once")
+check(CountWire("300400|0") == 1, "S3 shared lever 300400 disabled EXACTLY once")
+check(CountWire("9|") == 0, "S3 garbage lever 9 NEVER toggled")
+check(CountWire("300700|") == 0,
+    "S3 undiscovered tome lever (Lone Tome) is SKIPPED, not toggled (no spam)")
+check(CountWire("300100|") == 0 and CountWire("300110|") == 0
+    and CountWire("300112|") == 0,
+    "S3 wishlist-family levers never disabled (incl. other quality rank)")
+H.DeliverDiscovery({ 200200, 200400, 200402 })   -- server confirms
+H.Advance(1)
+check(CountWire("300200|0") == 1, "S3 no re-send after 530 confirmation")
+
+------------------------------------------------------------------------
+-- S4: RUN -- guaranteed identified by FLAG at arbitrary index
+------------------------------------------------------------------------
+H.playerLevel = 5
+H.granted = { ["Alpha Strike"] = { { spellId = 200100, stack = 1, maxStack = 1, quality = 3 } } }
+H.locked = nil
+H.DeliverBoard({
+    { spellId = 200104, quality = 2, isGuaranteed = true },   -- index 1, not "rightmost"
+    { spellId = 200202, quality = 1 },
+    { spellId = 200500, quality = 1 },
+})
+H.Advance(1.2)
+check(H.selectCalls[#H.selectCalls] == 200104,
+    "S4 took the guaranteed wanted card found by flag at index 1")
+H.ResolveSelect(true)
+H.Advance(0.5)
+local owned = A.Owned()
+check((owned.bySpell[200104] or 0) >= 1,
+    "S4 recorded pick unions into owned before granted refresh")
+
+------------------------------------------------------------------------
+-- S5: wanted FREE card beats guaranteed filler; disable self-check demotes
+------------------------------------------------------------------------
+H.DeliverBoard({
+    { spellId = 200200, quality = 1, isGuaranteed = true },   -- disabled-lever filler, flag-3!
+    { spellId = 200102, quality = 2 },                        -- uncovered wishlist family
+    { spellId = 200202, quality = 1 },
+})
+H.Advance(1.2)
+check(H.selectCalls[#H.selectCalls] == 200102,
+    "S5 took the wanted free card over guaranteed filler")
+check(Nexus.Store.State().flagDemotions.DISABLE_SUPPRESSES_GUARANTEE ~= nil,
+    "S5 disabled-lever guarantee demoted DISABLE_SUPPRESSES_GUARANTEE")
+H.ResolveSelect(true)
+H.Advance(0.5)
+
+------------------------------------------------------------------------
+-- S6: zero-guaranteed board (4-card trim case) falls through gracefully
+------------------------------------------------------------------------
+local selectsBefore = #H.selectCalls
+H.DeliverBoard({
+    { spellId = 200202, quality = 1 },
+    { spellId = 200500, quality = 1 },
+})
+H.Advance(1.2)
+check(#H.selectCalls == selectsBefore + 1,
+    "S6 zero-flag-3 board still resolved to a least-harmful take")
+H.ResolveSelect(true)
+H.Advance(0.5)
+
+------------------------------------------------------------------------
+-- S7: stall regression -- blocked cards refuse locally, sender untouched
+------------------------------------------------------------------------
+H.DeliverBoard({
+    { spellId = 200400, quality = 3, isGuaranteed = true },
+    { spellId = 200202, quality = 1, justFrozen = true },
+    { spellId = 200500, quality = 1 },
+})
+local banishesBefore = #H.banishCalls
+local ok1 = A.Banish(0)
+check(ok1 == false and #H.banishCalls == banishesBefore,
+    "S7 banish on guaranteed card dropped BEFORE the client sender")
+local ok2 = A.Banish(1)
+check(ok2 == false and #H.banishCalls == banishesBefore,
+    "S7 banish on justFrozen card dropped (post-SS-104 window covered)")
+
+------------------------------------------------------------------------
+-- S8: charge ledger -- {} run data, synthesized formats, one-per-push
+------------------------------------------------------------------------
+H.runDataTable = nil
+local ch = A.Charges()
+check(ch.arrived == false and ch.banish == 0 and ch.reroll == 0,
+    "S8 empty run data reads as not-arrived, zero charges, no error")
+H.PushRunData({ remainingBanishes = 1, totalFreezes = 0, usedFreezes = 0,
+    totalRerolls = 0, usedRerolls = 0 })
+ch = A.Charges()
+check(ch.trustworthy == false, "S8 synthesized 14-field shape flagged untrustworthy")
+H.PushRunData({ remainingBanishes = 2, totalFreezes = 2, usedFreezes = 0,
+    totalRerolls = 5, usedRerolls = 0 })
+H.DeliverBoard({
+    { spellId = 200202, quality = 1 },
+    { spellId = 200500, quality = 1 },
+})
+local okB = A.Banish(0)
+check(okB == true, "S8 banish on junk card allowed with charges")
+local okB2 = A.Banish(1)
+check(okB2 == false, "S8 second banish same push refused (ledger gate)")
+H.ResolveBanish(200102, 2)
+H.Advance(0.5)
+check((H.updateSingleCalls or 0) >= 1, "S8 banish result arrived via UpdateSinglePerk")
+H.PushRunData({ remainingBanishes = 1, totalFreezes = 2, usedFreezes = 0,
+    totalRerolls = 5, usedRerolls = 0 })
+ch = A.Charges()
+check(ch.banishSpentThisPush == false, "S8 fresh push resets the per-push banish gate")
+
+------------------------------------------------------------------------
+-- S9: deep-copy isolation (board + wishlist are copies, never references)
+------------------------------------------------------------------------
+H.DeliverBoard({ { spellId = 200202, quality = 1 } })
+local b = A.Board()
+b.cards[1].spellId = 999999
+check(H.Perks.currentChoice[1].spellId == 200202,
+    "S9 board copy isolated from the client's internal table")
+local wl = A.Wishlist()
+wl.entries[1].spellId = 999999
+check(H.wishlist.echoes[1].spellId == 200100,
+    "S9 wishlist copy isolated from the SavedVariables store")
+H.ResolveSelect(false)
+
+------------------------------------------------------------------------
+-- S10: the polluted predicate is NEVER consulted
+------------------------------------------------------------------------
+check(H.pollutedCalls == 0, "S10 IsSpellInActiveEchoLoadout never called")
+
+------------------------------------------------------------------------
+-- S11: verified-field-absent payload never arms
+------------------------------------------------------------------------
+H.playerLevel = 1
+H.Advance(0.3)             -- let Main observe the level change (resets arm state)
+local activatesBefore = #H.activateCalls
+H.DeliverSlots({
+    [2] = { slot = 2, name = "Main", verified = true, echoes = {
+        { spellId = 200100, quality = 3, stacks = 1, locked = false } } },
+    [7] = { slot = 7, name = "Design", verified = true, echoes = {} },  -- designed slot "verified"
+}, 0)
+H.Advance(6)
+check(#H.activateCalls == activatesBefore,
+    "S11 verified-defaults-true payload (designed slot verified) never armed")
+
+------------------------------------------------------------------------
+-- S12: explicit level gates on build ops
+------------------------------------------------------------------------
+H.playerLevel = 5
+local okAct = A.Activate(2)
+check(okAct == false, "S12 activate refused at level 5 (client would send it)")
+local okSave = A.Save(2, "x")
+check(okSave == false, "S12 save refused below level 80")
+
+------------------------------------------------------------------------
+-- S13: SAVE at 80 -- domination-guarded save fires once
+------------------------------------------------------------------------
+H.DeliverSlots({
+    [2] = { slot = 2, name = "Main", verified = true, echoes = {
+        { spellId = 200100, quality = 3, stacks = 1, locked = false },
+        { spellId = 200200, quality = 1, stacks = 1, locked = false },
+        { spellId = 200104, quality = 2, stacks = 2, locked = false },
+        { spellId = 200202, quality = 1, stacks = 1, locked = false },
+    } },
+    [3] = { slot = 3, name = "Design", verified = false,
+        echoes = DesignedWishlistEchoes() },
+}, 2)
+AssociateSnapshot(2, 3)
+H.granted = {
+    ["Alpha Strike"] = { { spellId = 200100, stack = 1, maxStack = 1, quality = 3 } },
+    ["Beta Guard"] = { { spellId = 200102, stack = 1, maxStack = 1, quality = 2 } },
+    ["Gamma Bolt"] = { { spellId = 200110, stack = 1, maxStack = 1, quality = 0 } },
+    ["Double Strike"] = {
+        { spellId = 200104, stack = 1, maxStack = 5, quality = 2 },
+        { spellId = 200104, stack = 1, maxStack = 5, quality = 2 },
+        { spellId = 200104, stack = 1, maxStack = 5, quality = 2 },
+    },
+}
+PadGrantedTo79(H.granted, 6)
+H.DeliverBoard({
+    { spellId=200102, quality=2 },
+    { spellId=200202, quality=1 },
+})
+H.Advance(0.3)
+H.Perks.currentChoice = nil
+H.playerLevel = 80
+H.Perks.currentChoice = nil      -- final board already consumed
+H.Advance(8)
+check(#H.saveCalls >= 1 and H.saveCalls[#H.saveCalls].slot == 2,
+    "S13 dominating run saved only into the confirmed active loadout")
+local savesAfter = #H.saveCalls
+H.Advance(4)
+check(#H.saveCalls == savesAfter, "S13 save fires only once per visit")
+
+------------------------------------------------------------------------
+-- S14: bad run does NOT save (anti-brick)
+------------------------------------------------------------------------
+H.playerLevel = 5
+H.Advance(0.3)
+H.granted = {
+    ["Junk Aura"] = { { spellId = 200200, stack = 1, maxStack = 1, quality = 1 } },
+    ["Double Strike"] = { { spellId = 200104, stack = 1, maxStack = 5, quality = 2 } },
+}
+H.playerLevel = 80
+H.Perks.currentChoice = nil
+local savesBefore = #H.saveCalls
+H.Advance(8)
+check(#H.saveCalls == savesBefore,
+    "S14 non-dominating run (lost coverage, owns filler) never saved")
+
+------------------------------------------------------------------------
+-- S15: advisor mode -- no wishlist, no auto actions
+------------------------------------------------------------------------
+H.playerLevel = 5
+H.Advance(0.3)
+H.wishlist = nil
+A.ClearLoadoutWishlist(2)
+H.DeliverSlots({
+    [2] = { slot = 2, name = "Main", verified = true, echoes = {
+        { spellId = 200100, quality = 3, stacks = 1, locked = false },
+    } },
+    [3] = { slot = 3, name = "MyBuild", verified = false, echoes = {
+        { spellId = 200100, quality = 3, stacks = 1, locked = false },
+        { spellId = 200102, quality = 2, stacks = 1, locked = false },
+    } },
+}, 2)
+local selBefore = #H.selectCalls
+H.DeliverBoard({
+    { spellId = 200102, quality = 2 },
+    { spellId = 200202, quality = 1 },
+})
+H.Advance(1.5)
+check(#H.selectCalls == selBefore, "S15 advisor mode never auto-picks")
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+    { spellId = 200102, quality = 2, stacks = 1 },
+} }
+local restoredAssociation, restoredErr = A.SetLoadoutWishlistIdentity(
+    2, H.wishlist.name, H.wishlist.echoes)
+check(restoredAssociation,
+    "S15 fixture restored the explicit loadout association: "
+        .. tostring(restoredErr))
+
+------------------------------------------------------------------------
+-- S16: rival addon suspends auto
+------------------------------------------------------------------------
+_G.EchoOptimizer = {}
+selBefore = #H.selectCalls
+H.DeliverBoard({
+    { spellId = 200102, quality = 2 },
+    { spellId = 200202, quality = 1 },
+})
+H.Advance(3.5)
+check(#H.selectCalls == selBefore, "S16 auto suspended while EchoOptimizer is loaded")
+_G.EchoOptimizer = nil
+
+------------------------------------------------------------------------
+-- S17: user re-enabling client auto-accept suspends auto
+------------------------------------------------------------------------
+H.optSettings.autoAcceptLoadoutEchoes = true
+selBefore = #H.selectCalls
+local rrBefore = H.rerollCalls
+local banishBeforeResume = #H.banishCalls
+local freezeBeforeResume = #H.freezeCalls
+H.DeliverBoard({
+    { spellId = 200102, quality = 2 },
+    { spellId = 200202, quality = 1 },
+})
+H.Advance(1.5)
+check(#H.selectCalls == selBefore and H.rerollCalls == rrBefore,
+    "S17 auto suspended when client picker re-enabled")
+H.optSettings.autoAcceptLoadoutEchoes = false
+H.Advance(3.5)
+-- Deferred-reroll economics (v1.3.1): a board whose best option is a
+-- deferred loadout echo is RE-ROLLED when charges and EV allow, else
+-- selected. Either way, auto must have acted after the picker went off.
+check(#H.selectCalls == selBefore + 1 or H.rerollCalls == rrBefore + 1
+    or #H.banishCalls == banishBeforeResume + 1
+    or #H.freezeCalls == freezeBeforeResume + 1,
+    "S17 auto resumes once the client picker is off")
+if H.Perks.pendingSelectSpellId then
+    H.ResolveSelect(true)
+elseif H.Perks.pendingReroll then
+    -- resolve the reroll: latch clears, board goes away before any
+    -- further action can fire (no state leaks into later scenarios)
+    H.Perks.pendingReroll = nil
+    H.Perks.currentChoice = nil
+    H.Advance(0.3)
+elseif H.Perks.pendingBanishIndex then
+    H.Perks.pendingBanishIndex = nil
+elseif H.Perks.pendingFreezeIndex then
+    H.Perks.pendingFreezeIndex = nil
+end
+H.Perks.currentChoice = nil
+H.Advance(0.3)
+
+------------------------------------------------------------------------
+-- S19: an unusable filler guarantee does not suppress search. Nexus safely
+-- Banishes an off-wishlist side while preserving wished families.
+------------------------------------------------------------------------
+H.PushRunData({ remainingBanishes = 2, totalFreezes = 2, usedFreezes = 0,
+    totalRerolls = 0, usedRerolls = 0 })
+-- S17 now rerolls its board (deferred-reroll economics) instead of
+-- selecting Alpha, so Alpha ownership must be granted explicitly for
+-- this scenario's "owned duplicate" premise to hold.
+H.granted = { ["Alpha Strike"] = { { spellId = 200100, stack = 1, maxStack = 1, quality = 3 } } }
+local banishesB4 = #H.banishCalls
+local selectsB4 = #H.selectCalls
+H.DeliverBoard({
+    { spellId = 200302, quality = 0 },                       -- filler (worst)
+    { spellId = 200100, quality = 3 },                       -- owned duplicate
+    { spellId = 200300, quality = 0, isGuaranteed = true },  -- filler, flag-3
+})
+H.Advance(1.5)
+check(#H.banishCalls == banishesB4 + 1,
+    "S19 unusable guaranteed filler permits a safe search Banish")
+check(#H.selectCalls == selectsB4,
+    "S19 did not drain the unusable guarantee before search")
+H.ResolveBanish(200102, 2)
+H.Perks.currentChoice = nil
+H.Advance(0.3)
+
+------------------------------------------------------------------------
+-- S20: advisor mode (no wishlist) never auto-ACTIVATES a snapshot
+-- (the save gate existed; the activate gate was missing)
+------------------------------------------------------------------------
+H.granted, H.locked = nil, nil       -- fresh run owns nothing
+H.wishlist = nil                     -- advisor mode
+H.playerLevel = 1
+H.Advance(0.3)                       -- run-boundary reset (owned sig "")
+H.buildBusyUntil = -1
+local actB4 = #H.activateCalls
+H.DeliverSlots({
+    [2] = { slot = 2, name = "Main", verified = true, echoes = {
+        { spellId = 200100, quality = 3, stacks = 1, locked = false } } },
+    [3] = { slot = 3, name = "MyBuild", verified = false, echoes = {
+        { spellId = 200100, quality = 3, stacks = 1, locked = false },
+        { spellId = 200102, quality = 2, stacks = 1, locked = false },
+    } },
+}, 0)
+H.Advance(8)
+check(#H.activateCalls == actB4, "S20 advisor mode never auto-activates a snapshot")
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+    { spellId = 200102, quality = 2, stacks = 1 },
+} }
+local starterOk = A.SetFirstRunWishlistIdentity(
+    H.wishlist.name, H.wishlist.echoes)
+check(starterOk, "S20 fixture restored the explicit first-run wishlist")
+H.granted = {}
+A.RequestGranted()
+
+------------------------------------------------------------------------
+-- S21: untrustworthy charges (fabricated legacy remainingBanishes=1)
+-- must NOT fire a banish into a dead latch; board still resolves
+------------------------------------------------------------------------
+H.playerLevel = 5
+H.Advance(0.3)
+H.PushRunData({ remainingBanishes = 1, totalFreezes = 0, usedFreezes = 0,
+    totalRerolls = 0, usedRerolls = 0 })     -- tf==0,uf==0,rb==1 -> trustworthy=false
+local banB4, selB4 = #H.banishCalls, #H.selectCalls
+H.DeliverBoard({
+    { spellId = 200302, quality = 0 },       -- filler
+    { spellId = 200202, quality = 1 },       -- filler
+})
+H.Advance(1.5)
+check(#H.banishCalls == banB4, "S21 untrustworthy charges -> no auto-banish")
+check(#H.selectCalls == selB4 + 1, "S21 junk board still resolved with a take")
+H.ResolveSelect(true)
+H.Advance(0.3)
+
+------------------------------------------------------------------------
+-- S22: save is CONFIRMED against a fresh SS-540, not latched on send.
+-- An invisible SS-541 FAIL (saveBlackhole) must clear savedThisVisit and
+-- retry, never leave a false "saved" behind.
+------------------------------------------------------------------------
+H.saveBlackhole = true
+H.granted = nil
+H.playerLevel = 1
+H.Advance(0.5)
+H.granted = {
+    ["Alpha Strike"] = { { spellId = 200100, stack = 1, maxStack = 1, quality = 3 } },
+    ["Beta Guard"] = { { spellId = 200102, stack = 1, maxStack = 1, quality = 2 } },
+}
+PadGrantedTo79(H.granted, 2)
+A.RequestGranted()
+H.DeliverSlots({
+    [2] = { slot = 2, name = "Main", verified = true, echoes = {
+        { spellId = 200100, quality = 3, stacks = 1, locked = false } } },
+    [3] = { slot = 3, name = "D", verified = false,
+        echoes = DesignedWishlistEchoes() },
+}, 2)
+AssociateSnapshot(2, 3)
+H.buildBusyUntil = -1
+H.playerLevel = 2
+H.DeliverBoard({{spellId=200102,quality=2},{spellId=200202,quality=1}})
+H.Advance(0.3)
+H.playerLevel = 80
+H.Perks.currentChoice = nil
+local saveB4 = #H.saveCalls
+H.Advance(45)                        -- one save; bounded readback remains unconfirmed
+check(#H.saveCalls == saveB4 + 1
+    and NexusDB.lastSaveStatus and NexusDB.lastSaveStatus.state == "saved_unverified",
+    "S22 unconfirmed save stayed single-write and was not falsely confirmed"
+        .. " calls=" .. tostring(#H.saveCalls-saveB4)
+        .. " state=" .. tostring(NexusDB.lastSaveStatus
+            and NexusDB.lastSaveStatus.state))
+H.saveBlackhole = false
+H.Advance(6)
+local saveAfterConfirm = #H.saveCalls
+H.Advance(8)
+check(#H.saveCalls == saveAfterConfirm,
+    "S22 unconfirmed save never retries an overwrite automatically")
+
+------------------------------------------------------------------------
+-- S23: Phi-monotone ratchet -- a coverage-gaining run still saves even
+-- though it picks up one extra filler family (subset test would refuse)
+------------------------------------------------------------------------
+H.granted = nil
+H.playerLevel = 1
+H.Advance(0.5)
+H.granted = {
+    ["Alpha Strike"] = { { spellId = 200100, stack = 1, maxStack = 1, quality = 3 } },
+    ["Beta Guard"] = { { spellId = 200102, stack = 1, maxStack = 1, quality = 2 } },
+    ["Junk Aura"] = { { spellId = 200200, stack = 1, maxStack = 1, quality = 1 } },
+}
+PadGrantedTo79(H.granted, 3)
+A.RequestGranted()
+H.DeliverSlots({
+    [2] = { slot = 2, name = "Main", verified = true, echoes = {
+        { spellId = 200100, quality = 3, stacks = 1, locked = false } } },  -- covers {Alpha}
+    [3] = { slot = 3, name = "D", verified = false,
+        echoes = DesignedWishlistEchoes() },
+}, 2)
+AssociateSnapshot(2, 3)
+H.buildBusyUntil = -1
+H.playerLevel = 2
+H.DeliverBoard({{spellId=200102,quality=2},{spellId=200202,quality=1}})
+H.Advance(0.3)
+H.playerLevel = 80
+H.Perks.currentChoice = nil
+saveB4 = #H.saveCalls
+H.Advance(8)
+check(#H.saveCalls == saveB4 + 1,
+    "S23 coverage +1 with filler +1 still saves (Phi-monotone, not filler-subset)")
+
+------------------------------------------------------------------------
+-- S24: Ready() gate -- per-char getters must not run before the player
+-- is known (else the client's session char-key is poisoned)
+------------------------------------------------------------------------
+local realUnitName = UnitName
+UnitName = function() return "Unknown" end
+check(Nexus.GameAdapter.Ready() == false,
+    "S24 Adapter.Ready() false while UnitName is Unknown")
+UnitName = realUnitName
+check(Nexus.GameAdapter.Ready() == true,
+    "S24 Adapter.Ready() true once UnitName resolves")
+
+------------------------------------------------------------------------
+-- S25: /wr wishlist reports the detected wishlist NAME (and "none" when
+-- there is no active loadout)
+------------------------------------------------------------------------
+H.wishlist = { name = "Frostbite Tank", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+    { spellId = 200104, quality = 2, stacks = 3 },
+} }
+H.DeliverSlots({
+    [2] = { slot = 2, name = "Snap", verified = true, echoes = {
+        { spellId = 200100, quality = 3, stacks = 1, locked = false } } },
+    [3] = { slot = 3, name = "Frostbite Tank", verified = false, echoes = {
+        { spellId = 200100, quality = 3, stacks = 1, locked = false },
+        { spellId = 200104, quality = 2, stacks = 3, locked = false },
+    } },
+}, 2)
+AssociateSnapshot(2, 3)
+local chatB4 = #H.chat
+SlashCmdList["NEXUS"]("wishlist")
+check(H.ChatContains("Frostbite Tank") ~= nil,
+    "S25 /wr wishlist prints the detected wishlist name")
+H.wishlist = nil
+-- clear any designed builds so this reads as genuinely no-wishlist
+H.DeliverSlots({
+    [2] = { slot = 2, name = "Snap", verified = true, echoes = {
+        { spellId = 200100, quality = 3, stacks = 1, locked = false } } },
+}, 2)
+A.ClearLoadoutWishlist(2)
+SlashCmdList["NEXUS"]("wishlist")
+check(H.ChatContains("no wishlist association") ~= nil,
+    "S25 /wr wishlist explains the missing active-Snapshot association")
+
+------------------------------------------------------------------------
+-- S26: 1.19.3 never guesses a target from an arbitrary designed slot. The
+-- active Saved Build needs an explicit association selected by the player.
+------------------------------------------------------------------------
+H.wishlist = nil                     -- no active loadout
+H.DeliverSlots({
+    [2] = { slot = 2, name = "Snap", verified = true, echoes = {   -- a snapshot
+        { spellId = 200100, quality = 3, stacks = 1, locked = false } } },
+    [6] = { slot = 6, name = "My Goal", verified = false, echoes = {  -- designed wishlist
+        { spellId = 200100, quality = 3, stacks = 1, locked = false },
+        { spellId = 200102, quality = 2, stacks = 1, locked = false },
+        { spellId = 200104, quality = 2, stacks = 3, locked = false } } },
+}, 2)
+local wlD = Nexus.GameAdapter.Wishlist()
+check(wlD == nil,
+    "S26 unassociated designed slot is not guessed as the active target")
+local chatD = #H.chat
+SlashCmdList["NEXUS"]("wishlist")
+check(H.ChatContains("no wishlist association") ~= nil,
+    "S26 /wr wishlist explains that an explicit association is required")
+
+------------------------------------------------------------------------
+-- S27: /wr status reports BOTH the target source and whether the loadout
+-- snapshots are readable (answers "is it reading wishlist or loadout")
+------------------------------------------------------------------------
+H.chat = {}
+SlashCmdList["NEXUS"]("status")
+check(H.ChatContains("TARGET:") ~= nil and H.ChatContains("no wishlist") ~= nil,
+    "S27 /wr status reports the missing explicit target")
+check(H.ChatContains("loadout snapshot") ~= nil and H.ChatContains("ACTIVE slot 2") ~= nil,
+    "S27 /wr status reports readable loadout snapshots and the active build")
+
+------------------------------------------------------------------------
+-- S28: never-duplicate -- a board of one owned duplicate + one new echo
+-- takes the NEW echo (feeds Adaptive Power's distinct count), never the
+-- duplicate, even though the duplicate has the higher raw Delta
+------------------------------------------------------------------------
+local dupPlan = Nexus.Strategy.Compile(
+    Nexus.GameAdapter.Catalog(),
+    { name = "w", entries = { { spellId = 200100, quality = 3, stacks = 1, family = "s200100" } },
+      byFamily = { s200100 = { targetStacks = 1, wishedQuality = 3, spellId = 200100 } } },
+    Nexus.Store.Settings())
+local dupOwned = { bySpell = { [200100] = 1 }, byFamily = { s200100 = 1 },
+    synced = true, distinct = 1 }
+local dupState = {
+    board = { cards = {
+        { spellId = 200100, quality = 3, family = "s200100" },   -- owned duplicate
+        { spellId = 200202, quality = 1, family = "s200202" },   -- new (filler) echo
+    }, guaranteedIndex = nil, signature = "dup" },
+    owned = dupOwned, charges = { banish = 0, reroll = 0, trustworthy = true },
+    plan = dupPlan, catalog = Nexus.GameAdapter.Catalog(),
+    level = 40, params = Nexus.DefaultProfile.params,
+}
+local dupAct = Nexus.Policy.Decide(dupState)
+check(dupAct.type == "take" and dupAct.spellId == 200202,
+    "S28 takes the NEW distinct echo, never the owned duplicate")
+
+------------------------------------------------------------------------
+-- S29: anchor auto-detection -- a wishlist containing "Adaptive Power"
+-- (200960) sets it as the diversity anchor with no manual /wr anchor
+------------------------------------------------------------------------
+local apPlan = Nexus.Strategy.Compile(
+    Nexus.GameAdapter.Catalog(),
+    { name = "ap", entries = {
+        { spellId = 200960, quality = 3, stacks = 1, family = "s200960" },
+        { spellId = 200100, quality = 3, stacks = 1, family = "s200100" } },
+      byFamily = {
+        s200960 = { targetStacks = 1, wishedQuality = 3, spellId = 200960 },
+        s200100 = { targetStacks = 1, wishedQuality = 3, spellId = 200100 } } },
+    Nexus.Store.Settings())
+check(apPlan.anchorSpellId == 200960,
+    "S29 Adaptive Power auto-detected as the anchor from the wishlist")
+
+------------------------------------------------------------------------
+-- S18: journal tab soft-fail (no journal frames in harness)
+------------------------------------------------------------------------
+local okInstall = pcall(function()
+    return Nexus.JournalTab.TryInstall(function()
+        return { sections = {}, version = "t" }
+    end)
+end)
+check(okInstall, "S18 JournalTab.TryInstall soft-fails without journal frames")
+
+------------------------------------------------------------------------
+print(string.format("checks=%d failures=%d", checks, failures))
+os.exit(failures == 0 and 0 or 1)

--- a/tests/run_leaderboard_ui.lua
+++ b/tests/run_leaderboard_ui.lua
@@ -1,0 +1,25 @@
+-- Dedicated leaderboard is separate from Builds and renders dense ranked rows.
+local H=dofile("tests/harness.lua")
+dofile("core/Codec.lua"); dofile("core/Sync.lua"); dofile("core/DpsCapture.lua")
+dofile("data/DefaultProfile.lua"); dofile("logic/Model.lua"); dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua"); dofile("logic/Policy.lua"); dofile("core/Store.lua")
+dofile("core/GameAdapter.lua"); dofile("ui/CommunityBuilds.lua"); dofile("ui/Leaderboard.lua")
+UnitName=function(unit) return unit=="player" and "Viewer" or nil end
+UnitClass=function() return "Mage","MAGE" end
+NexusDB={communityBuilds={},syncTombstones={},dpsCapture={}}
+local DPS=Nexus.DpsCapture
+DPS.Init({}, {BroadcastBuild=function() return true end})
+local a={{spellId=200001,stacks=2},{spellId=200002,stacks=1}}
+local b={{spellId=200010,stacks=1},{spellId=200011,stacks=3}}
+assert(DPS.ReceiveRecord({v=4,f=DPS.GetEchoKey(a),e=a,c="dummy",d=24000000,u=65,t=100,p="Alpha",k="MAGE",l=80}))
+assert(DPS.ReceiveRecord({v=4,f=DPS.GetEchoKey(b),e=b,c="dummy",d=28000000,u=65,t=101,p="Bravo",k="MAGE",l=80}))
+Nexus.CommunityBuilds.Init(Nexus.GameAdapter,Nexus.Model)
+Nexus.Leaderboard.Init(Nexus.GameAdapter)
+Nexus.Leaderboard.Show("dummy")
+assert(H.frames.NexusLeaderboardFrame and H.frames.NexusLeaderboardFrame:IsShown(),"leaderboard window did not open")
+-- Refreshing a selected record must use WoW 3.3.5 Button:Enable/Disable, not modern SetEnabled.
+Nexus.Leaderboard.Refresh()
+assert(not H.frames.NexusCommunityBuildsFrame or not H.frames.NexusCommunityBuildsFrame:IsShown(),"build browser should not be required for leaderboard")
+Nexus.CommunityBuilds.SetViewMode("lk")
+assert(Nexus.Leaderboard.IsShown(),"legacy leaderboard route did not open dedicated window")
+print("dedicated dense leaderboard window and legacy routing -- OK")

--- a/tests/run_main_refusal_recovery.lua
+++ b/tests/run_main_refusal_recovery.lua
@@ -1,0 +1,50 @@
+-- Ordinary (non-final) synchronous search refusals must advance instead of
+-- retrying the same client mutation forever.
+local H=dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua"); dofile("logic/Model.lua")
+dofile("logic/Strategy.lua"); dofile("logic/Ratchet.lua")
+dofile("logic/Relay.lua"); dofile("logic/Policy.lua")
+dofile("core/Store.lua"); dofile("core/GameAdapter.lua")
+dofile("ui/Readout.lua"); dofile("ui/Panel.lua"); dofile("ui/JournalTab.lua")
+dofile("core/Main.lua")
+
+NexusDB={}
+H.playerLevel=20
+H.granted={}
+H.wishlist={name="Goal",class="MAGE",echoes={{spellId=200100,quality=3,stacks=1}}}
+H.FireEvent("ADDON_LOADED","Nexus")
+H.FireEvent("PLAYER_ENTERING_WORLD")
+SlashCmdList.NEXUS("auto")
+H.DeliverSlots({
+  [2]={slot=2,name="Snapshot",verified=true,echoes={{spellId=200200,quality=1,stacks=1}}},
+  [3]={slot=3,name="Goal",verified=false,echoes={{spellId=200100,quality=3,stacks=1}}},
+},2)
+assert(Nexus.GameAdapter.SetLoadoutWishlist(2,3))
+Nexus.GameAdapter.RequestGranted()
+assert(Nexus.GameAdapter.Owned().synced,"owned-state fixture did not synchronize")
+
+H.PushRunData({remainingBanishes=2,totalFreezes=0,usedFreezes=0,
+  totalRerolls=2,usedRerolls=0})
+H.refuseNextBanish=true
+local banishBefore=H.banishAttempts or 0
+local rerollsBefore=H.rerollCalls or 0
+H.DeliverBoard({{spellId=200200,quality=1},{spellId=200202,quality=1}})
+H.Advance(1.5)
+assert((H.banishAttempts or 0)==banishBefore+1,
+  "refused ordinary Banish was retried")
+assert((H.rerollCalls or 0)==rerollsBefore+1,
+  "refused ordinary Banish did not advance to Reroll")
+
+H.DeliverBoard({{spellId=200202,quality=1},{spellId=200500,quality=1}})
+H.PushRunData({remainingBanishes=0,totalFreezes=0,usedFreezes=0,
+  totalRerolls=2,usedRerolls=0})
+H.refuseNextReroll=true
+local rerollBefore=H.rerollAttempts or 0
+local selectsBefore=#H.selectCalls
+H.Advance(1.5)
+assert((H.rerollAttempts or 0)==rerollBefore+1,
+  "refused ordinary Reroll was retried")
+assert(#H.selectCalls==selectsBefore+1,
+  "refused ordinary Reroll did not advance to the mandatory take")
+
+print("ordinary Banish and Reroll refusal recovery -- OK")

--- a/tests/run_migration_owned_lifecycle.lua
+++ b/tests/run_migration_owned_lifecycle.lua
@@ -1,0 +1,125 @@
+-- Locked-Echo migration and current-run ownership generation regressions.
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua")
+dofile("core/DpsCapture.lua")
+
+local Codec = Nexus.Codec
+local oldKey = "200100x2,200200x1"
+local newKey = "200100x1,200200x1"
+local sourceRow = {
+    dps=25000000, duration=65, ts=50000, player="Boganic", level=80,
+    class="MAGE", fingerprint=oldKey,
+    echoes={{spellId=200100,count=2},{spellId=200200,count=1}},
+}
+local function FreshDpsDb()
+    return {
+        personalBest={ [oldKey]={dummy={
+            dps=sourceRow.dps, duration=sourceRow.duration, ts=sourceRow.ts,
+            player=sourceRow.player, level=sourceRow.level, class=sourceRow.class,
+            fingerprint=sourceRow.fingerprint,
+            echoes={{spellId=200100,count=2},{spellId=200200,count=1}},
+        }}},
+        buildBest={},
+        characterBest={dummy={},lk={}},
+    }
+end
+
+NexusDB={communityBuilds={},dpsCapture=FreshDpsDb()}
+local lockedReady = false
+local adapter = {
+    LockedOwned=function()
+        return {synced=lockedReady,bySpell=lockedReady and {[200100]=1} or {}}
+    end,
+    Owned=function() return {synced=true,bySpell={},byFamily={}} end,
+}
+local DPS=Nexus.DpsCapture
+DPS.Init(adapter,{})
+assert(not NexusDB.dpsCapture.lockedMigrationVersion
+    and NexusDB.dpsCapture.personalBest[oldKey],
+    "migration ran before locked data was authoritative")
+
+lockedReady=true
+DPS.Init(adapter,{})
+assert(NexusDB.dpsCapture.lockedMigrationVersion==1,
+    "successful locked migration did not persist its version")
+assert(not NexusDB.dpsCapture.personalBest[oldKey]
+    and NexusDB.dpsCapture.personalBest[newKey]
+    and NexusDB.dpsCapture.personalBest[newKey].dummy.echoes[1].count==1,
+    "locked baseline was not subtracted exactly once")
+local once=Codec.JSONEncode(NexusDB.dpsCapture)
+DPS.Init(adapter,{})
+assert(Codec.JSONEncode(NexusDB.dpsCapture)==once,
+    "repeated initialization changed completed migration data")
+
+-- Simulate a reload interrupt after one row was already modified. The saved
+-- immutable source must win, so retrying cannot subtract the baseline twice.
+local original=FreshDpsDb()
+local interrupted=FreshDpsDb()
+interrupted.personalBest={ [newKey]={dummy={
+    dps=sourceRow.dps,duration=65,ts=50000,player="Boganic",level=80,
+    class="MAGE",fingerprint=newKey,
+    echoes={{spellId=200100,count=1},{spellId=200200,count=1}},
+}}}
+interrupted.lockedMigrationSource={
+    personalBest=original.personalBest,
+    buildBest=original.buildBest,
+    characterBest=original.characterBest,
+}
+NexusDB.dpsCapture=interrupted
+dofile("core/DpsCapture.lua")
+DPS=Nexus.DpsCapture
+DPS.Init(adapter,{})
+local retried=NexusDB.dpsCapture.personalBest[newKey]
+assert(retried and retried.dummy.echoes[1].spellId==200100
+    and retried.dummy.echoes[1].count==1
+    and NexusDB.dpsCapture.lockedMigrationSource==nil,
+    "interrupted migration did not restore and recompute from its source")
+local retryOnce=Codec.JSONEncode(NexusDB.dpsCapture)
+dofile("core/DpsCapture.lua")
+Nexus.DpsCapture.Init(adapter,{})
+assert(Codec.JSONEncode(NexusDB.dpsCapture)==retryOnce,
+    "reload after resumed migration changed data again")
+
+-- Run ownership: a successful prior generation must not authorize the next.
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+local A=Nexus.GameAdapter
+NexusDB=NexusDB or {}
+Nexus.Store.Init()
+A.Init({},Nexus.Store)
+H.granted={ ["Alpha Strike"]={{spellId=200100,stack=1,quality=3}} }
+A.OnEvent("PLAYER_ENTERING_WORLD")
+local runOne=A.Owned()
+assert(runOne.synced and runOne.generation==0 and runOne.bySpell[200100]==1,
+    "first run did not confirm its ownership response")
+local requestsBefore=H.grantedRequests or 0
+
+H.granted=nil
+A.RunBoundaryReset()
+local runTwo=A.Owned()
+assert(not runTwo.synced and runTwo.generation==1
+    and (H.grantedRequests or 0)>requestsBefore,
+    "new run reused the prior generation or failed to request ownership")
+for _=1,6 do
+    H.now=H.now+6
+    A.Poll()
+    assert(not A.Owned().synced,
+        "elapsed time incorrectly made missing ownership authoritative")
+end
+assert((H.grantedRequests or 0)>requestsBefore+1,
+    "new-run ownership did not retry boundedly")
+
+-- A fresh empty table is the explicit, authoritative empty response.
+H.granted={}
+A.RequestGranted()
+local confirmedEmpty=A.Owned()
+assert(confirmedEmpty.synced and confirmedEmpty.generation==1
+    and confirmedEmpty.total==0,
+    "confirmed empty current-run ownership was not supported")
+
+print("locked migration and owned-state generations are idempotent -- OK")

--- a/tests/run_minimap_drag.lua
+++ b/tests/run_minimap_drag.lua
@@ -1,0 +1,38 @@
+dofile("tests/harness.lua")
+dofile("ui/Panel.lua")
+
+NexusDB = {}
+Nexus.Panel.Init({ ToggleAuto = function() return true end })
+
+local btn = _G.NexusMinimapButton
+assert(btn, "minimap button was never created")
+
+-- Simulate dragging the cursor to a known position relative to the
+-- minimap center, then check the button repositions to the SAME side,
+-- not the mirror-opposite side (the actual live bug).
+Minimap.GetCenter = function() return 100, 100 end
+Minimap.GetEffectiveScale = function() return 1 end
+
+-- cursor directly to the RIGHT of the minimap center (px > mx, py == my)
+GetCursorPosition = function() return 200, 100 end
+
+local dragStart = btn:GetScript("OnDragStart")
+dragStart(btn)
+local onUpdate = btn:GetScript("OnUpdate")
+onUpdate(btn)
+
+-- angle for "directly right" should be 0 degrees; cos(0)=1, sin(0)=0,
+-- so the button's X offset from Minimap center should be POSITIVE
+-- (same side as the cursor), not negative (opposite side).
+local point, relTo, relPoint, x, y = btn:GetPoint()
+print(string.format("cursor right of center -> button offset x=%s y=%s", tostring(x), tostring(y)))
+assert(x and x > 0, "button moved to the OPPOSITE side of the cursor (x should be positive, got " .. tostring(x) .. ")")
+
+-- cursor directly ABOVE the minimap center
+GetCursorPosition = function() return 100, 200 end
+onUpdate(btn)
+local _, _, _, x2, y2 = btn:GetPoint()
+print(string.format("cursor above center -> button offset x=%s y=%s", tostring(x2), tostring(y2)))
+assert(y2 and y2 > 0, "button did not follow cursor correctly on the Y axis (got y=" .. tostring(y2) .. ")")
+
+print("minimap drag sign convention OK -- button follows the cursor, not its mirror")

--- a/tests/run_minimap_rightclick.lua
+++ b/tests/run_minimap_rightclick.lua
@@ -1,0 +1,24 @@
+dofile("tests/harness.lua")
+dofile("ui/Panel.lua")
+
+NexusDB = {}
+local editorOpened, panelToggled = false, false
+Nexus.WishlistEditor = { Show = function() editorOpened = true end }
+Nexus.Panel.Init({ ToggleAuto = function() return true end })
+Nexus.Panel.Render({ status="t", cards={}, recommendation="", auto=true, version="v" })
+
+local btn = _G.NexusMinimapButton
+assert(btn, "minimap button missing")
+local onClick = btn.scripts.OnClick
+assert(onClick, "no OnClick handler on minimap button")
+
+onClick(btn, "RightButton")
+assert(editorOpened, "right-click did not open the Wishlist Editor")
+assert(not panelToggled, "right-click should not toggle the panel")
+print("minimap right-click opens the Wishlist Editor -- OK")
+
+editorOpened = false
+local shownBefore = _G.NexusPanel and _G.NexusPanel:IsShown()
+onClick(btn, "LeftButton")
+assert(not editorOpened, "left-click should not open the editor")
+print("minimap left-click still toggles the panel, not the editor -- OK")

--- a/tests/run_nameplate.lua
+++ b/tests/run_nameplate.lua
@@ -1,0 +1,165 @@
+-- Nameplate: Nexus badge appears correctly on player mouseover.
+-- Tests the AugmentUnitTooltip logic directly since GameTooltip
+-- HookScript can't fire in the test harness.
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua"); dofile("core/Sync.lua"); dofile("core/DpsCapture.lua")
+dofile("data/DefaultProfile.lua"); dofile("logic/Model.lua"); dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua"); dofile("logic/Policy.lua"); dofile("core/Store.lua")
+dofile("core/GameAdapter.lua"); dofile("ui/CommunityBuilds.lua"); dofile("ui/Nameplate.lua")
+
+local DPS = Nexus.DpsCapture
+local NP  = Nexus.Nameplate
+local clock=1000; GetTime=function() return clock end
+local wall=50000; time=function() return wall end
+UnitName=function(u) return u=="player" and "Solkr" or nil end
+UnitIsPlayer=function(u) return true end  -- all units are "players" in test
+
+NexusDB={ communityBuilds={}, syncTombstones={}, dpsCapture={} }
+DPS.Init({}, nil)
+
+-- Seed leaderboard records
+local echoes={{spellId=200100,stacks=2},{spellId=200101,stacks=1}}
+local fp=DPS.GetEchoKey(echoes)
+assert(DPS.ReceiveRecord({v=6,f=fp,e=echoes,c="dummy",d=8000000,u=65,t=50000,p="Alice",k="MAGE",l=80}))
+assert(DPS.ReceiveRecord({v=6,f=fp,e=echoes,c="dummy",d=5000000,u=65,t=50001,p="Bob",k="MAGE",l=80}))
+assert(DPS.ReceiveRecord({v=6,f=fp,e=echoes,c="lk",   d=6500000,u=90,t=50002,p="Alice",k="MAGE",l=80}))
+
+-- 1. GetPlayerInfo rank
+local alice=DPS.GetPlayerInfo("Alice")
+assert(alice and alice.rank==1 and alice.dps==8000000, "Alice should be #1 dummy: "..tostring(alice and alice.rank))
+local bob=DPS.GetPlayerInfo("Bob")
+assert(bob and bob.rank==2, "Bob should be #2")
+print("GetPlayerInfo rank ordering correct -- OK")
+
+-- 2. Tooltip augmentation via the exported function
+local lines={}
+local fakeTooltip={
+    _unit="target",
+    GetUnit=function(self) return self._unit, self._unit end,
+    AddLine=function(self,text,...) lines[#lines+1]=text end,
+    Show=function(self) end,
+}
+
+-- Test: Alice moused over
+UnitName=function(u)
+    if u=="player" then return "Solkr" end
+    if u=="target"  then return "Alice" end
+    return nil
+end
+NP._AugmentUnitTooltip(fakeTooltip)
+assert(#lines >= 2, "should have badge + rank line for Alice: "..#lines.." lines")
+assert(lines[1]:find("Nexus"), "first line should be Nexus badge: "..tostring(lines[1]))
+assert(lines[2] and lines[2]:find("1st",1,true),
+    "second line should show compact rank: "..tostring(lines[2]))
+print("Tooltip augmentation adds Nexus badge and rank -- OK")
+
+-- 3. Bob gets correct rank 2
+lines={}
+UnitName=function(u)
+    if u=="player" then return "Solkr" end
+    if u=="target"  then return "Bob" end
+    return nil
+end
+NP._AugmentUnitTooltip(fakeTooltip)
+assert(lines[2] and lines[2]:find("2nd",1,true),
+    "Bob should show #2: "..tostring(lines[2]))
+print("Rank 2 displays correctly -- OK")
+
+-- 4. Self tooltips remain untouched by the non-intrusive 1.19.3 badge.
+lines={}
+UnitName=function(u) return "Solkr" end  -- both player and target return same name
+NP._AugmentUnitTooltip(fakeTooltip)
+assert(#lines==0, "self tooltip should not be augmented")
+print("Self-mouseover remains untouched -- OK")
+
+-- 5. Unknown player: no lines added
+lines={}
+UnitName=function(u)
+    if u=="player" then return "Solkr" end
+    if u=="target"  then return "RandomPlayer" end
+    return nil
+end
+NP._AugmentUnitTooltip(fakeTooltip)
+assert(#lines==0, "unknown player should add nothing")
+print("Unknown player produces no output -- OK")
+
+-- 6. Community author with no DPS gets author badge
+NexusDB.communityBuilds["b1"]={
+    id="b1",title="Fire Mage",author="AuthorGuy",class="MAGE",
+    echoes=echoes,postedAt=50000,lastModified=50000,isMine=false
+}
+lines={}
+UnitName=function(u)
+    if u=="player" then return "Solkr" end
+    if u=="target"  then return "AuthorGuy" end
+    return nil
+end
+NP._AugmentUnitTooltip(fakeTooltip)
+assert(#lines>=1 and lines[1]:find("Nexus"), "author should get Nexus badge")
+assert(#lines==2 and lines[2]:find("Community build author",1,true),
+    "non-ranked author tooltip lost its compact author label")
+print("Community author gets compact Nexus and author labels -- OK")
+
+-- 7. NPC: no lines added
+lines={}
+UnitIsPlayer=function(u) return false end
+UnitName=function(u)
+    if u=="player" then return "Solkr" end
+    if u=="target"  then return "Some NPC" end
+    return nil
+end
+NP._AugmentUnitTooltip(fakeTooltip)
+assert(#lines==0, "NPC mouseover should add nothing")
+print("NPC mouseover produces no output -- OK")
+
+-- 8. Verify GetUnit returning nil is handled safely
+lines={}
+local nilUnitTooltip={
+    GetUnit=function(self) return nil, nil end,
+    AddLine=function(self,text,...) lines[#lines+1]=text end,
+    Show=function(self) end,
+}
+local ok=pcall(NP._AugmentUnitTooltip, nilUnitTooltip)
+assert(ok and #lines==0, "nil unit should not error and should add nothing")
+print("nil unit handled safely -- OK")
+
+-- 9. A discovered Nexus peer with no build or DPS still gets the user badge.
+lines={}
+UnitIsPlayer=function(u) return true end
+UnitName=function(u)
+    if u=="player" then return "Solkr" end
+    if u=="target" then return "PeerOnly" end
+    return nil
+end
+time=function() return 60000 end
+Nexus.Sync.HandleIncoming("WLNP|PeerOnly-Realm|1.19.3", "PeerOnly-Realm")
+assert(Nexus.Sync.IsKnownPeer("PeerOnly"), "recognized presence should record the peer")
+fakeTooltip.__nexusAugmentedFor=nil
+NP._AugmentUnitTooltip(fakeTooltip)
+assert(lines[1] and lines[1]:find("Nexus user"), "known peer should show Nexus user badge")
+assert(#lines==2 and lines[2]:find("Connected",1,true),
+    "peer without rank/build lost its compact connection label")
+print("Known Nexus peer gets badge and connection label -- OK")
+
+-- 10. Unknown protocol traffic must not create a fake Nexus user.
+Nexus.Sync.HandleIncoming("FAKE|Spoofer|x", "Spoofer")
+assert(not Nexus.Sync.IsKnownPeer("Spoofer"), "unknown wire code must not mark a Nexus peer")
+print("Unknown protocol cannot spoof Nexus-user presence -- OK")
+
+
+-- 11. Even a realm-qualified self record must not alter the self tooltip.
+lines={}
+UnitExists=function(u) return u=="player" end
+UnitIsPlayer=function(u) return u=="player" end
+UnitName=function(u) if u=="player" then return "Explore" end end
+local selfTooltip={
+    GetUnit=function(self) return "Explore", "player" end,
+    AddLine=function(self,text,...) lines[#lines+1]=text end,
+    Show=function(self) end,
+}
+Nexus.DpsCapture.GetPlayerInfo=function(name)
+    if name=="Explore" then return { rank=1, dps=24000000, category="dummy", title="Mage Record Loadout" } end
+end
+NP._AugmentUnitTooltip(selfTooltip)
+assert(#lines==0, "realm-qualified self row altered the self tooltip")
+print("Realm-qualified self row remains non-intrusive -- OK")

--- a/tests/run_overlay_lock_sync.lua
+++ b/tests/run_overlay_lock_sync.lua
@@ -1,0 +1,97 @@
+-- Verifies the editor's "Display..." button opens the on-screen-wishlist
+-- popup, and that popup's Lock/Unlock button genuinely drives the
+-- overlay's real lock state (not a decoy local flag).
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/WishlistOverlay.lua")
+dofile("ui/WishlistEditor.lua")
+
+NexusDB = {}
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+} }
+H.playerLevel = 5
+
+local Adapter, Model = Nexus.GameAdapter, Nexus.Model
+local OV, EW = Nexus.WishlistOverlay, Nexus.WishlistEditor
+OV.Init(Adapter, Model)
+EW.Init(Adapter, Model)
+
+assert(OV.IsLocked(), "overlay should default to locked")
+OV.ToggleLock()
+assert(not OV.IsLocked() and NexusDB.overlayLocked == false,
+    "ToggleLock() did not unlock / persist")
+OV.ToggleLock()
+assert(OV.IsLocked(), "ToggleLock() did not re-lock")
+print("WishlistOverlay.IsLocked()/ToggleLock() public API works -- OK")
+
+-- Open the editor, then explicitly open the Display popup the same way
+-- the "Display..." button does, then find ITS Lock/Unlock button and
+-- confirm clicking it genuinely flips the overlay's real lock state.
+EW.Show()
+local ok = pcall(EW.ToggleDisplayPopup)
+assert(ok, "ToggleDisplayPopup() threw")
+
+local popup = _G.NexusDisplayPopup
+assert(popup and popup:IsShown(), "Display popup did not open")
+
+-- walk the popup's own children looking for the lock button by behavior
+local lockBtn = nil
+local function ScanChildren(f)
+    if f.scripts and f.scripts.OnClick then
+        local before = OV.IsLocked()
+        local ok2 = pcall(f.scripts.OnClick, f)
+        if ok2 and OV.IsLocked() ~= before then
+            lockBtn = f
+            return true
+        end
+    end
+    return false
+end
+-- the harness doesn't track parent/child relationships explicitly, so
+-- intercept CreateFrame during a FRESH popup open to enumerate exactly
+-- what the popup creates
+popup:Hide()
+local created = {}
+local realCreateFrame = CreateFrame
+CreateFrame = function(...)
+    local f = realCreateFrame(...)
+    created[#created + 1] = f
+    return f
+end
+_G.NexusDisplayPopup = nil
+dofile("ui/WishlistEditor.lua")
+local EW2 = Nexus.WishlistEditor
+EW2.Init(Adapter, Model)
+EW2.ToggleDisplayPopup()
+
+for _, f in ipairs(created) do
+    if ScanChildren(f) then break end
+end
+assert(lockBtn, "no widget in the Display popup actually toggles the overlay's lock state")
+print("Display popup's Lock/Unlock button genuinely drives the overlay's lock state -- OK")
+
+-- The checkbox inside the popup must genuinely show/hide the overlay.
+-- Every harness widget technically exposes SetChecked (shared metatable
+-- fallback), so detect the real checkbox by OBSERVED behavior instead of
+-- by which methods happen to exist.
+OV.Hide()
+local checkBtn = nil
+for _, f in ipairs(created) do
+    if f.scripts and f.scripts.OnClick then
+        f:SetChecked(true)
+        local ok3 = pcall(f.scripts.OnClick, f)
+        if ok3 and OV.IsShown() then
+            checkBtn = f
+            break
+        end
+    end
+end
+assert(checkBtn, "no widget in the Display popup actually shows the overlay when checked")
+print("Display popup's checkbox genuinely shows the overlay -- OK")

--- a/tests/run_overlay_zorder.lua
+++ b/tests/run_overlay_zorder.lua
@@ -1,0 +1,48 @@
+-- Regression for the live bug (2026-07-24): the overlay used MEDIUM
+-- strata while the editor uses DIALOG, so it was structurally guaranteed
+-- to render behind the editor regardless of frame level. Verifies the
+-- overlay now outranks the editor using Blizzard's real strata ordering.
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/WishlistOverlay.lua")
+dofile("ui/WishlistEditor.lua")
+
+NexusDB = {}
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+} }
+H.playerLevel = 5
+
+local Adapter, Model = Nexus.GameAdapter, Nexus.Model
+local OV, EW = Nexus.WishlistOverlay, Nexus.WishlistEditor
+OV.Init(Adapter, Model)
+EW.Init(Adapter, Model)
+
+OV.Show()
+EW.Show()
+
+local ovFrame = _G.NexusOverlay
+local edFrame = _G.NexusEditorFrame
+assert(ovFrame and edFrame, "both frames must exist")
+
+local STRATA_RANK = { BACKGROUND=1, LOW=2, MEDIUM=3, HIGH=4, DIALOG=5,
+    FULLSCREEN=6, FULLSCREEN_DIALOG=7, TOOLTIP=8 }
+
+local ovStrata, edStrata = ovFrame:GetFrameStrata(), edFrame:GetFrameStrata()
+local ovLevel, edLevel = ovFrame:GetFrameLevel(), edFrame:GetFrameLevel()
+print(string.format("overlay: strata=%s level=%d | editor: strata=%s level=%d",
+    tostring(ovStrata), ovLevel, tostring(edStrata), edLevel))
+
+local ovRank = STRATA_RANK[ovStrata] or 0
+local edRank = STRATA_RANK[edStrata] or 0
+
+local overlayOnTop = (ovRank > edRank) or (ovRank == edRank and ovLevel > edLevel)
+assert(overlayOnTop,
+    "overlay does NOT render above the editor -- this is the exact live bug")
+print("overlay correctly renders ABOVE the editor -- OK")

--- a/tests/run_panel_adaptive_states.lua
+++ b/tests/run_panel_adaptive_states.lua
@@ -1,0 +1,28 @@
+local H = dofile("tests/harness.lua")
+dofile("ui/Panel.lua")
+
+NexusDB = {}
+Nexus.DpsCapture = {
+    GetPersonalBestForEchoes = function(echoes, category)
+        if category == "dummy" then return { dps=24080000, duration=60 } end
+    end,
+    GetLeaderboardForEchoes = function(echoes, category)
+        if category == "dummy" then return {{ dps=25100000, player="Othermage" }} end
+        return {}
+    end,
+}
+Nexus.Panel.Init({ ToggleAuto=function() return true end })
+
+Nexus.Panel.Render({progress={},cards={},recommendation="",auto=true,version="2.12"})
+local panel = _G.NexusPanel
+assert(panel and panel:GetHeight() == 219, "setup state should match the compact 1.19.3 layout")
+
+Nexus.Panel.Render({progress={wishlistName="Leveling",owned=25,total=79,missing={"A","B"},shed={"C"},dpsEchoes={{spellId=1,stacks=1}}},cards={},recommendation="",auto=true,version="2.12"})
+assert(panel:GetHeight() == 208, "progress state height incorrect")
+
+Nexus.Panel.Render({progress={wishlistName="Complete",owned=79,total=79,missing={},shed={},dpsEchoes={{spellId=1,stacks=1}}},cards={},recommendation="",auto=true,version="2.12"})
+assert(panel:GetHeight() == 109, "completed state should collapse progress lists")
+
+Nexus.Panel.Render({progress={wishlistName="Complete",owned=79,total=79,missing={},shed={},dpsEchoes={{spellId=1,stacks=1}},activeSlot=3},cards={{text="Echo A"}},recommendation="Take Echo A",auto=true,version="2.12"})
+assert(panel:GetHeight() == 233, "live roll should expand completed HUD")
+print("adaptive panel states OK")

--- a/tests/run_panel_click_editor.lua
+++ b/tests/run_panel_click_editor.lua
@@ -1,0 +1,37 @@
+dofile("tests/harness.lua")
+
+-- Capture EVERY frame CreateFrame produces (the hit-frame over the
+-- Missing text is anonymous, so the harness's name-keyed registry
+-- never sees it otherwise).
+local allFrames = {}
+local realCreateFrame = CreateFrame
+CreateFrame = function(...)
+    local f = realCreateFrame(...)
+    allFrames[#allFrames + 1] = f
+    return f
+end
+
+dofile("ui/Panel.lua")
+
+NexusDB = {}
+local shown = false
+Nexus.WishlistEditor = { Show = function() shown = true end }
+Nexus.Panel.Init({ ToggleAuto = function() return true end })
+
+Nexus.Panel.Render({
+    status = "t", cards = {}, recommendation = "", auto = true, version = "v",
+    progress = { owned = 1, total = 2, loadoutStacks = { stackCount=1, stackTotal=2 },
+        missing = {"Thing"} },
+})
+
+local clicked = 0
+for _, f in ipairs(allFrames) do
+    local fn = f.scripts and f.scripts.OnMouseUp
+    if fn then
+        clicked = clicked + 1
+        pcall(fn, f)
+    end
+end
+assert(clicked > 0, "no frame with an OnMouseUp handler was found at all")
+assert(shown, "clicking the Missing hit-frame did not open the Wishlist Editor")
+print("Missing text click correctly opens the Wishlist Editor -- OK")

--- a/tests/run_panel_close.lua
+++ b/tests/run_panel_close.lua
@@ -1,0 +1,32 @@
+dofile("tests/harness.lua")
+dofile("ui/Panel.lua")
+
+NexusDB = {}
+Nexus.Panel.Init({ ToggleAuto = function() return true end })
+
+local model = { status="t", cards={}, recommendation="", auto=true, version="v" }
+
+-- first render: should show (default state)
+Nexus.Panel.Render(model)
+local frame = _G.NexusPanel
+assert(frame:IsShown(), "panel should be shown after first render")
+
+-- explicit toggle-off via /wr panel path (Panel.Toggle)
+Nexus.Panel.Toggle()
+assert(not frame:IsShown(), "panel should be hidden immediately after Toggle()")
+
+-- simulate the next several poll ticks calling Render() again (this is
+-- exactly what happens every 0.2s in real play) -- it must NOT re-show
+for i = 1, 5 do
+    Nexus.Panel.Render(model)
+    assert(not frame:IsShown(),
+        "Render() re-showed the panel after an explicit hide (tick " .. i .. ")")
+end
+print("panel stays hidden across repeated Render() calls after Toggle-off -- OK")
+
+-- toggling back on must work and then Render() must keep it visible
+Nexus.Panel.Toggle()
+assert(frame:IsShown(), "panel should be shown again after second Toggle()")
+Nexus.Panel.Render(model)
+assert(frame:IsShown(), "panel should remain shown on next render")
+print("panel toggles back on correctly -- OK")

--- a/tests/run_panel_resilience.lua
+++ b/tests/run_panel_resilience.lua
@@ -1,0 +1,50 @@
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/Readout.lua")
+dofile("ui/Panel.lua")
+
+-- Simulate the exact live failure: SetBackdrop throws on this client.
+-- Monkey-patch the frame metatable's fallback so SetBackdrop specifically
+-- errors, mirroring the modified-client incompatibility.
+local realCreateFrame = CreateFrame
+CreateFrame = function(kind, name, parent)
+    local f = realCreateFrame(kind, name, parent)
+    if kind == "Frame" and name == "NexusPanel" then
+        f.SetBackdrop = function() error("SetBackdrop not supported on this client") end
+    end
+    return f
+end
+
+NexusDB = {}
+Nexus.Panel.Init({ ToggleAuto = function() return true end })
+
+-- This must NOT throw, and the panel must still be fully functional
+-- afterward -- specifically, missingText and the Auto button must exist.
+local ok, err = pcall(function()
+    Nexus.Panel.Render({
+        status = "test", cards = {}, recommendation = "",
+        progress = { owned = 1, total = 2, loadoutStacks = { stackCount=1, stackTotal=2 },
+            missing = {"Thing"} },
+        auto = true, version = "test",
+    })
+end)
+assert(ok, "Render threw despite the SetBackdrop failure: " .. tostring(err))
+
+local btn = _G.NexusPanel
+assert(btn, "panel frame was never created")
+print("panel survived a SetBackdrop failure with all functional widgets intact")
+
+-- Second render must also work (proves EnsureFrame's memoization didn't
+-- leave things half-built for subsequent calls either)
+local ok2 = pcall(function()
+    Nexus.Panel.Render({ status = "test2", cards = {}, recommendation = "",
+        progress = nil, auto = false, version = "test" })
+end)
+assert(ok2, "second render failed")
+print("second render also OK -- no permanent half-built state")

--- a/tests/run_panel_wishlist_name.lua
+++ b/tests/run_panel_wishlist_name.lua
@@ -1,0 +1,76 @@
+-- Verifies the panel shows the ACTUAL tracked wishlist name instead of
+-- the generic "Ideal loadout" label (2026-07-24 request: eliminate
+-- confusion about which wishlist the numbers refer to).
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Relay.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/Readout.lua")
+dofile("ui/Panel.lua")
+Nexus.LogViewer = { Init = function() end }
+dofile("core/Main.lua")
+
+NexusDB = {}
+H.wishlist = { name = "MyAwesomeBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+} }
+H.playerLevel = 5
+
+local lastModel
+Nexus.GameAdapter.Wishlist = function()
+    return { name=H.wishlist.name, class=H.wishlist.class, entries=H.wishlist.echoes }
+end
+local realRender = Nexus.Panel.Render
+Nexus.Panel.Render = function(m) lastModel = m; realRender(m) end
+
+H.FireEvent("ADDON_LOADED", "Nexus")
+H.FireEvent("SPELLS_CHANGED")
+H.FireEvent("PLAYER_ENTERING_WORLD")
+H.Advance(2)
+
+assert(lastModel and lastModel.progress, "no progress captured")
+assert(lastModel.progress.wishlistName == "MyAwesomeBuild",
+    "expected wishlistName 'MyAwesomeBuild', got " .. tostring(lastModel.progress.wishlistName))
+print("progress table carries the real wishlist name -- OK")
+
+-- render it and check the actual displayed text mentions the real name,
+-- not the old generic label
+local frame = _G.NexusPanel
+-- find the loadoutText fontstring by scanning created regions for one
+-- containing the wishlist name
+local allWidgets = {}
+local realCreateFrame = CreateFrame
+CreateFrame = function(...)
+    local f = realCreateFrame(...)
+    allWidgets[#allWidgets + 1] = f
+    local realCFS = f.CreateFontString
+    f.CreateFontString = function(self, ...)
+        local fs = realCFS(self, ...)
+        allWidgets[#allWidgets + 1] = fs
+        return fs
+    end
+    return f
+end
+_G.NexusPanel = nil
+dofile("ui/Panel.lua")
+Nexus.Panel.Render(lastModel)
+
+-- In the new panel design the wishlist name appears in the DPS section
+-- label when a matching WR Build is found, and the progress table still
+-- carries it (tested above). The generic "Ideal loadout" label is gone.
+local foundOldLabel = false
+for _, w in ipairs(allWidgets) do
+    if type(w.text) == "string" then
+        if w.text:find("Ideal loadout") then foundOldLabel = true end
+    end
+end
+assert(not foundOldLabel, "panel still shows the old generic 'Ideal loadout' label")
+-- The progress table carries the real wishlist name (verified above) --
+-- the panel renders it contextually rather than as a static label.
+print("panel no longer shows stale 'Ideal loadout' label -- OK")
+print("wishlist name is in the progress model and used contextually -- OK")

--- a/tests/run_private_sync_compat.lua
+++ b/tests/run_private_sync_compat.lua
@@ -1,0 +1,63 @@
+-- Safe mixed-version behavior: exact-evidence DPS remains compatible, while
+-- legacy packets that cannot carry that evidence are rejected.
+local H=dofile('tests/harness.lua')
+dofile('core/Codec.lua'); dofile('core/Sync.lua'); dofile('core/DpsCapture.lua')
+local Codec,Sync,DPS=Nexus.Codec,Nexus.Sync,Nexus.DpsCapture
+local clock=1000; GetTime=function() return clock end; time=function() return 50000 end
+UnitName=function() return 'Localhero' end
+UnitClass=function() return 'Mage','MAGE' end
+UnitLevel=function() return 80 end
+GetNormalizedRealmName=function() return 'Ebonhold' end
+local function Pump(seconds)
+    for _=1,math.ceil(seconds/0.2) do clock=clock+0.2; Sync.OnUpdate(0.2) end
+end
+local function Parts(text)
+    text=tostring(text or ''):gsub('||','|'); local out={}
+    for part in text:gmatch('([^|]*)|?') do out[#out+1]=part; if #out>12 then break end end
+    return out
+end
+local function DecodeDps(messages)
+    local chunks,total={},nil
+    for _,message in ipairs(messages) do
+        local p=Parts(message.text)
+        if p[1]=='WLD2' then
+            local i,n=tostring(p[4]):match('^(%d+)/(%d+)$'); i,n=tonumber(i),tonumber(n)
+            total=total or n; chunks[i]=p[5]
+        end
+        assert(#message.text<=255,'wire message exceeded 255 bytes')
+    end
+    assert(total and total>0,'no exact-evidence DPS payload was sent')
+    local joined={}; for i=1,total do assert(chunks[i],'missing DPS chunk'); joined[#joined+1]=chunks[i] end
+    return Codec.JSONDecode(Codec.Base64Decode(table.concat(joined)))
+end
+
+local echoes={{spellId=200100,stacks=1},{spellId=200102,stacks=2}}
+local fp,hash=DPS.GetEchoKey(echoes),DPS.GetEchoHash(echoes)
+NexusDB={communityBuilds={},syncTombstones={},dpsCapture={}}
+Sync.Init(Codec,{}); DPS.Init({},Sync)
+local record={protocolVersion=7,fingerprint=fp,loadoutHash=hash,echoes=echoes,
+    category='dummy',dps=25000000,duration=65,ts=49000,player='Localhero',class='MAGE',
+    ownerKey='localhero@ebonhold',realm='ebonhold',level=80,buildId='dps-local'}
+H.sentChatMessages={}; assert(Sync.BroadcastDpsRecord(record,'local')); Pump(8)
+local payload=DecodeDps(H.sentChatMessages)
+assert(payload.v==7 and payload.f==fp and payload.h==hash and type(payload.e)=='table',
+    'current wire lost exact Echo evidence')
+assert(payload.p=='Localhero' and payload.k=='MAGE' and payload.o=='localhero@ebonhold',
+    'current wire lost sender identity evidence')
+
+-- A v6 peer remains acceptable only when it supplies the same complete proof.
+assert(DPS.ReceiveRecord({v=6,f=fp,h=hash,e=echoes,c='dummy',d=18000000,u=61,t=40000,
+    p='Legacy',k='MAGE',o='legacy@ebonhold',r='ebonhold',l=80,b='legacy-build'},'Legacy'),
+    'safe v6 exact-evidence record was rejected')
+assert(not DPS.ReceiveRecord({v=6,h=hash,c='dummy',d=19000000,u=61,t=40001,
+    p='Legacy',k='MAGE',o='legacy@ebonhold',r='ebonhold',l=80,b='missing-evidence'},'Legacy'),
+    'v6 record without an Echo list entered the verified board')
+assert(not DPS.ReceiveRecord({v=7,f=fp,h=hash,e=echoes,c='dummy',d=19000000,u=61,t=40002,
+    p='Legacy',k='MAGE',o='legacy@ebonhold',r='ebonhold',l=80},'Spoofer'),
+    'transport sender spoof gained DPS authority')
+
+-- The evidence-free WLDS format is retired, including the historical huge-DPS exploit.
+local before=#DPS.GetDpsBoard('dummy')
+Sync.HandleIncoming('WLDS|Attacker|victim|dummy|999999999999|80|Attacker','Attacker')
+assert(#DPS.GetDpsBoard('dummy')==before,'legacy enormous/no-duration DPS was accepted')
+print('safe v6 evidence compatibility, protocol 7 wire, and legacy rejection -- OK')

--- a/tests/run_quickstart.lua
+++ b/tests/run_quickstart.lua
@@ -1,0 +1,38 @@
+dofile("tests/harness.lua")
+dofile("ui/QuickStart.lua")
+
+NexusDB = {}
+local QS = Nexus.QuickStart
+
+-- first time: should show the four-path release setup
+QS.ShowIfFirstTime(false)
+local frame = _G.NexusQuickStart
+assert(frame and frame:IsShown(), "guide did not show on first launch")
+assert(frame.body.text:find("Starting fresh", 1, true),
+    "first-launch path guidance not shown")
+print("first-time guide shows the release setup paths -- OK")
+
+-- dismiss it
+local gotIt
+for name, f in pairs(_G) do end -- no direct access; simulate via the flag directly
+NexusDB.hasSeenQuickStart = true
+frame:Hide()
+
+-- second "first time" check (e.g. next login) must NOT show again
+QS.ShowIfFirstTime(false)
+assert(not frame:IsShown(), "guide showed again after being dismissed once")
+print("guide never shows again after dismissal -- OK")
+
+-- fresh account with a wishlist already present still gets the same concise
+-- path chooser; it is intentionally not a separate tutorial branch.
+NexusDB2 = {}
+_G.NexusQuickStart = nil
+NexusDB.hasSeenQuickStart = nil
+dofile("ui/QuickStart.lua")
+local QS2 = Nexus.QuickStart
+QS2.ShowIfFirstTime(true)
+local frame2 = _G.NexusQuickStart
+assert(frame2:IsShown(), "guide did not show for the has-wishlist case")
+assert(frame2.body.text:find("Already have a finished build", 1, true),
+    "current-build path not shown")
+print("first-time guide remains useful when a wishlist already exists -- OK")

--- a/tests/run_ratchet_rotation.lua
+++ b/tests/run_ratchet_rotation.lua
@@ -1,0 +1,172 @@
+-- Equal-progress wishlist rotations must advance the active snapshot without
+-- allowing a true wishlist regression or a dirtier filler trade.
+Nexus = {}
+dofile("logic/Model.lua")
+dofile("logic/Ratchet.lua")
+
+local Ratchet = Nexus.Ratchet
+local catalog = {
+    familyOf = {
+        [100] = "saved",
+        [200] = "new",
+        [300] = "filler",
+        [400] = "quality",
+        [401] = "quality",
+    },
+    familyName = {
+        saved = "Saved Target",
+        new = "New Target",
+        filler = "Filler",
+        quality = "Quality Target",
+    },
+    rows = {
+        [400] = { spellId=400, quality=0, maxStack=10 },
+        [401] = { spellId=401, quality=2, maxStack=10 },
+    },
+    familyMembers = {
+        quality={400,401},
+    },
+}
+local plan = {
+    wishedFamilies = { saved=true, new=true },
+    targets = {
+        saved={ targetStacks=1, spellId=100 },
+        new={ targetStacks=1, spellId=200 },
+    },
+}
+local incumbent = {
+    { spellId=100, family="saved", stacks=1 },
+}
+
+local ok, reason = Ratchet.Dominates({
+    byFamily={ new=1 },
+    bySpell={ [200]=1 },
+}, incumbent, plan, catalog)
+assert(ok and reason:find("wishlist rotation", 1, true),
+    "a clean one-for-one wishlist rotation must save")
+
+ok = Ratchet.Dominates({
+    byFamily={ new=1, filler=1 },
+    bySpell={ [200]=1, [300]=1 },
+}, incumbent, plan, catalog)
+assert(not ok,
+    "an equal-progress wishlist rotation must not save when it adds filler")
+
+ok = Ratchet.Dominates({
+    byFamily={},
+    bySpell={},
+}, incumbent, plan, catalog)
+assert(not ok,
+    "a true wishlist-progress regression must never save")
+
+ok = Ratchet.Dominates({
+    byFamily={ saved=1 },
+    bySpell={ [100]=1 },
+}, incumbent, plan, catalog)
+assert(not ok,
+    "an unchanged wishlist snapshot must not save")
+
+local stackPlan = {
+    wishedFamilies = { new=true },
+    targets = { new={ targetStacks=5, spellId=200 } },
+}
+local oneStack = Ratchet.ScoreSlot({
+    { spellId=200, family="new", stacks=1 },
+}, stackPlan, catalog)
+local fourStacks = Ratchet.ScoreSlot({
+    { spellId=200, family="new", stacks=4 },
+}, stackPlan, catalog)
+assert(fourStacks > oneStack,
+    "slot scoring must prefer greater progress toward a requested stack target")
+
+local qualityPlan = {
+    wishedFamilies = { quality=true },
+    targets = {
+        quality={ targetStacks=1, wishedQuality=2, spellId=401 },
+    },
+}
+ok = Ratchet.Dominates({
+    byFamily={ quality=1 },
+    bySpell={ [400]=1 },
+}, {}, qualityPlan, catalog)
+assert(not ok,
+    "below-target quality must not count as saveable wishlist progress")
+
+ok = Ratchet.Dominates({
+    byFamily={ quality=1 },
+    bySpell={ [400]=1 },
+}, {
+    { spellId=300, family="filler", stacks=1 },
+}, qualityPlan, catalog)
+assert(not ok,
+    "below-target quality must not masquerade as cleaner filler")
+
+ok = Ratchet.Dominates({
+    byFamily={ quality=1 },
+    bySpell={ [401]=1 },
+}, {}, qualityPlan, catalog)
+assert(ok,
+    "quality-qualified target progress must pass the save gate")
+
+local emptyScore = Ratchet.ScoreSlot({}, qualityPlan, catalog)
+local lowQualityScore = Ratchet.ScoreSlot({
+    { spellId=400, family="quality", stacks=1 },
+}, qualityPlan, catalog)
+local qualifiedScore = Ratchet.ScoreSlot({
+    { spellId=401, family="quality", stacks=1 },
+}, qualityPlan, catalog)
+assert(lowQualityScore < emptyScore and qualifiedScore > emptyScore,
+    "slot scoring must penalize an unqualified wished-family variant")
+
+local qualityQueue = Ratchet.PredictQueue({
+    { spellId=400, family="quality", quality=0, stacks=1 },
+    { spellId=401, family="quality", quality=2, stacks=1 },
+}, {
+    byFamily={}, bySpell={},
+}, qualityPlan, {}, {}, catalog)
+assert(qualityQueue.entries[1].wanted == false
+        and qualityQueue.entries[2].wanted == true,
+    "predicted guarantees must expose quality-qualified wanted state")
+
+local lowEstimate = Ratchet.RunsEstimate(qualityPlan, {
+    byFamily={ quality=1 },
+    bySpell={ [400]=1 },
+}, qualityQueue, nil, catalog)
+local highEstimate = Ratchet.RunsEstimate(qualityPlan, {
+    byFamily={ quality=1 },
+    bySpell={ [401]=1 },
+}, qualityQueue, nil, catalog)
+assert(lowEstimate.text:find("~1 wishlist echo", 1, true)
+        and highEstimate.text:find("wishlist complete", 1, true),
+    "runs estimate must use quality-qualified completion")
+
+local tierPlan = {
+    wishedFamilies = { quality=true },
+    targets = {
+        quality={
+            targetStacks=2, wishedQuality=0, spellId=400,
+            qualityTiers={
+                { q=0, n=1, spellId=400 },
+                { q=2, n=1, spellId=401 },
+            },
+        },
+    },
+}
+local tierIncumbent = {
+    { spellId=400, family="quality", stacks=1 },
+}
+ok = Ratchet.Dominates({
+    byFamily={ quality=2 },
+    bySpell={ [400]=2 },
+}, tierIncumbent, tierPlan, catalog)
+assert(not ok,
+    "surplus low-tier copies must not satisfy a higher-tier quota")
+
+ok = Ratchet.Dominates({
+    byFamily={ quality=2 },
+    bySpell={ [400]=1, [401]=1 },
+}, tierIncumbent, tierPlan, catalog)
+assert(ok,
+    "an exact newly completed quality tier must count as progress")
+
+print("ratchet wishlist rotation scenarios OK")

--- a/tests/run_record_identity_integrity.lua
+++ b/tests/run_record_identity_integrity.lua
@@ -23,6 +23,7 @@ local id,b=C.EnsureDpsBuildForEchoes(mageEchoes,"dummy",{
 })
 assert(id and b and b.class=="MAGE", "local Mage record must create a Mage build")
 assert(type(b.fingerprintHash)=="string" and b.fingerprintHash~=""
+  and b.fingerprintHash==DPS.GetEchoHash(mageEchoes)
   and b.echoCount==2 and b.loadoutAvailable==true,
   "DPS build creation must refresh every derived identity field")
 assert(C.IsOwnBuild(id), "capturing character must own its record page")
@@ -46,6 +47,7 @@ for _,build in pairs(NexusDB.communityBuilds) do
 end
 assert(found and found.class=="MAGE", "remote Mage record must not inherit local Shaman class")
 assert(type(found.fingerprintHash)=="string" and found.fingerprintHash~=""
+  and found.fingerprintHash==DPS.GetEchoHash(remoteEchoes)
   and found.echoCount==3 and found.loadoutAvailable==true,
   "remote DPS build completion must refresh every derived identity field")
 assert(not found.isMine and not C.IsOwnBuild(found), "remote record build must remain non-editable")
@@ -57,5 +59,31 @@ assert(not DPS.ReceiveRecord({v=7,f=remoteFp,e=remoteEchoes,c="dummy",d=26000000
 assert(not DPS.ReceiveRecord({v=7,f=remoteFp,e=remoteEchoes,c="dummy",d=26000000,u=65,t=now,
   p="Remotemage",k="MAGE",o="someoneelse@ebonhold",r="ebonhold",l=80}),
   "mismatched owner identity must be rejected")
+
+-- A hostile/accidental build ID collision must not attach an exact DPS row
+-- to an unrelated loadout merely because the opaque IDs match.
+local collisionEchoes={{spellId=200104,stacks=1}}
+NexusDB.communityBuilds.collision={id="collision",title="Unrelated",author="Other",
+  ownerKey="other@ebonhold",class="MAGE",echoes=collisionEchoes,
+  fingerprint=DPS.GetEchoKey(collisionEchoes),postedAt=1,lastModified=1}
+local winningEchoes={{spellId=200105,stacks=2}}
+local winningFp=DPS.GetEchoKey(winningEchoes)
+assert(DPS.ReceiveRecord({v=7,f=winningFp,h=DPS.GetEchoHash(winningEchoes),e=winningEchoes,
+  c="dummy",d=27000000,u=65,t=now+1,p="Collisionmage",k="MAGE",
+  o="collisionmage@ebonhold",r="ebonhold",l=80,b="collision"},"Collisionmage"),
+  "valid colliding DPS record was rejected")
+local collisionRow
+for _,row in ipairs(DPS.GetDpsBoard("dummy")) do
+  if row.player=="Collisionmage" then collisionRow=row break end
+end
+assert(collisionRow and collisionRow.buildId~="collision"
+  and NexusDB.communityBuilds[collisionRow.buildId]
+  and NexusDB.communityBuilds[collisionRow.buildId].fingerprint==winningFp,
+  "colliding DPS build ID was not detached to an exact safe loadout")
+local unrelated=DPS.GetLeaderboard("collision","dummy")
+for _,row in ipairs(unrelated) do
+  assert(row.player~="Collisionmage",
+    "colliding DPS row leaked onto the unrelated build leaderboard")
+end
 
 print("record class, ownership, and identity integrity -- OK")

--- a/tests/run_record_identity_integrity.lua
+++ b/tests/run_record_identity_integrity.lua
@@ -1,0 +1,61 @@
+-- Record class and per-character ownership regression coverage.
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua"); dofile("core/Sync.lua"); dofile("core/DpsCapture.lua")
+dofile("data/DefaultProfile.lua"); dofile("logic/Model.lua"); dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua"); dofile("logic/Policy.lua"); dofile("core/Store.lua")
+dofile("core/GameAdapter.lua"); dofile("ui/CommunityBuilds.lua")
+
+local DPS=Nexus.DpsCapture
+local C=Nexus.CommunityBuilds
+local A=Nexus.GameAdapter
+local now=50000; time=function() return now end
+GetNormalizedRealmName=function() return "Ebonhold" end
+UnitName=function() return "Mageowner" end
+UnitClass=function() return "Mage", "MAGE" end
+NexusDB={communityBuilds={},syncTombstones={},dpsCapture={}}
+DPS.Init(A,nil); C.Init(A,Nexus.Model)
+
+local mageEchoes={{spellId=200100,stacks=1},{spellId=200101,stacks=1}}
+local fp=DPS.GetEchoKey(mageEchoes)
+local id,b=C.EnsureDpsBuildForEchoes(mageEchoes,"dummy",{
+  player="Mageowner",class="MAGE",ownerKey="mageowner@ebonhold",realm="ebonhold",
+  dps=24000000,duration=65,ts=now,fingerprint=fp,echoes=mageEchoes,
+})
+assert(id and b and b.class=="MAGE", "local Mage record must create a Mage build")
+assert(type(b.fingerprintHash)=="string" and b.fingerprintHash~=""
+  and b.echoCount==2 and b.loadoutAvailable==true,
+  "DPS build creation must refresh every derived identity field")
+assert(C.IsOwnBuild(id), "capturing character must own its record page")
+
+-- Account-wide SavedVariables do not grant ownership to another character.
+UnitName=function() return "Shamanalt" end
+UnitClass=function() return "Shaman", "SHAMAN" end
+assert(not C.IsOwnBuild(id), "another character on the same account must not own the Mage build")
+local ok,err=C.EditBuild(id,"Fraud edit","no")
+assert(not ok and err=="not your build", "cross-character edit must be rejected")
+
+-- Receiving a Mage record while logged into a Shaman must preserve Mage.
+local remoteEchoes={{spellId=200102,stacks=1},{spellId=200103,stacks=2}}
+local remoteFp=DPS.GetEchoKey(remoteEchoes)
+assert(DPS.ReceiveRecord({v=7,f=remoteFp,e=remoteEchoes,c="dummy",d=25000000,u=65,t=now,
+  p="Remotemage",k="MAGE",o="remotemage@ebonhold",r="ebonhold",l=80}),
+  "valid remote Mage record should be accepted")
+local found
+for _,build in pairs(NexusDB.communityBuilds) do
+  if build.author=="Remotemage" then found=build break end
+end
+assert(found and found.class=="MAGE", "remote Mage record must not inherit local Shaman class")
+assert(type(found.fingerprintHash)=="string" and found.fingerprintHash~=""
+  and found.echoCount==3 and found.loadoutAvailable==true,
+  "remote DPS build completion must refresh every derived identity field")
+assert(not found.isMine and not C.IsOwnBuild(found), "remote record build must remain non-editable")
+
+-- Explicitly invalid identity/class metadata is rejected.
+assert(not DPS.ReceiveRecord({v=7,f=remoteFp,e=remoteEchoes,c="dummy",d=26000000,u=65,t=now,
+  p="Remotemage",k="NOTACLASS",o="remotemage@ebonhold",r="ebonhold",l=80}),
+  "invalid class token must be rejected")
+assert(not DPS.ReceiveRecord({v=7,f=remoteFp,e=remoteEchoes,c="dummy",d=26000000,u=65,t=now,
+  p="Remotemage",k="MAGE",o="someoneelse@ebonhold",r="ebonhold",l=80}),
+  "mismatched owner identity must be rejected")
+
+print("record class, ownership, and identity integrity -- OK")

--- a/tests/run_relay.lua
+++ b/tests/run_relay.lua
@@ -1,0 +1,257 @@
+-- Offline regression coverage for the two-Snapshot guarantee relay.
+-- Run from the Nexus addon root with Lua 5.1/LuaJIT:
+--   luajit tests/run_relay.lua
+
+Nexus = {}
+dofile("logic/Model.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Relay.lua")
+
+local Relay = Nexus.Relay
+local passed = 0
+
+local function Eq(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s: expected %s, got %s",
+            label, tostring(expected), tostring(actual)), 2)
+    end
+    passed = passed + 1
+end
+
+local catalog = {
+    rows = {
+        [1] = { spellId=1, name="One", maxStack=1, quality=1 },
+        [2] = { spellId=2, name="Two", maxStack=1, quality=1 },
+        [3] = { spellId=3, name="Three", maxStack=1, quality=1 },
+        [9] = { spellId=9, name="Filler", maxStack=1, quality=1 },
+        [10] = { spellId=10, name="One Variant", maxStack=1, quality=1 },
+    },
+    familyOf = {
+        [1]="s1", [2]="s2", [3]="s3", [9]="s9", [10]="s1",
+    },
+    familyMembers = {
+        s1={1,10}, s2={2}, s3={3}, s9={9},
+    },
+    familyName = {
+        s1="One", s2="Two", s3="Three", s9="Filler",
+    },
+}
+
+local plan = {
+    wishedFamilies = { s1=true, s2=true, s3=true },
+    targets = {
+        s1={targetStacks=1,spellId=1}, s2={targetStacks=1,spellId=2},
+        s3={targetStacks=1,spellId=3},
+    },
+}
+
+local function Echoes(...)
+    local ids = {...}
+    local out = {}
+    for i = 1, #ids do
+        local id = ids[i]
+        out[i] = { spellId=id, family=catalog.familyOf[id], stacks=1 }
+    end
+    return out
+end
+
+local function Row(...)
+    return {
+        verified=true, verifiedFieldPresent=true, suspectParse=false,
+        echoes=Echoes(...),
+    }
+end
+
+local candidate = {
+    byFamily = { s1=1, s2=1 },
+    bySpell = { [1]=1, [2]=1 },
+}
+
+local function Select(fields)
+    fields = fields or {}
+    fields.catalog = catalog
+    fields.plan = plan
+    fields.candidateOwned = candidate
+    fields.wishlistKey = fields.wishlistKey or "wish-A"
+    fields.unlockedSlots = fields.unlockedSlots or 3
+    fields.associations = fields.associations or { [1]="wish-A" }
+    return Relay.SelectSaveTarget(fields)
+end
+
+do
+    local slot = Select({
+        activeSlot=1,
+        slots={activeSlot=1, maxSlots=3, bySlot={ [1]=Row(1) }},
+    })
+    Eq(slot, 2, "empty inactive slot starts the relay")
+end
+
+do
+    local slot = Select({
+        activeSlot=1,
+        unlockedSlots=1,
+        slots={activeSlot=1, maxSlots=3, bySlot={ [1]=Row(1) }},
+    })
+    Eq(slot, nil, "active Snapshot is never overwritten when it is the only unlocked slot")
+end
+
+do
+    local slot = Select({
+        activeSlot=2,
+        preferredSlot=1,
+        associations={ [1]="wish-A", [2]="wish-A" },
+        slots={activeSlot=2, maxSlots=3, bySlot={
+            [1]=Row(1), [2]=Row(1),
+        }},
+    })
+    Eq(slot, 1, "persisted relay peer is reused before another empty slot")
+end
+
+do
+    local slot = Select({
+        activeSlot=1,
+        preferredSlot=2,
+        associations={ [1]="wish-A", [2]="wish-A" },
+        slots={activeSlot=1, maxSlots=3, bySlot={
+            [1]=Row(1), [2]=Row(1, 2, 3),
+        }},
+    })
+    Eq(slot, 3, "stronger relay peer is preserved when an empty slot exists")
+end
+
+do
+    local slot = Select({
+        activeSlot=1,
+        associations={ [1]="wish-A", [2]="wish-B", [3]="wish-C" },
+        slots={activeSlot=1, maxSlots=3, bySlot={
+            [1]=Row(1), [2]=Row(1), [3]=Row(1),
+        }},
+    })
+    Eq(slot, nil, "unrelated Snapshots are never overwritten")
+end
+
+do
+    local slot = Select({
+        activeSlot=1,
+        associations={ [1]="wish-A", [2]="wish-A", [3]="wish-B" },
+        slots={activeSlot=1, maxSlots=3, bySlot={
+            [1]=Row(1), [2]=Row(1), [3]=Row(1),
+        }},
+    })
+    Eq(slot, 2, "weaker same-wishlist Snapshot is a safe fallback relay")
+end
+
+do
+    local unverified = Row(1)
+    unverified.verified = false
+    local slot = Select({
+        activeSlot=1,
+        unlockedSlots=2,
+        associations={ [1]="wish-A", [2]="wish-A" },
+        slots={activeSlot=1, maxSlots=2, bySlot={
+            [1]=Row(1), [2]=unverified,
+        }},
+    })
+    Eq(slot, nil, "unverified Snapshot is never overwritten")
+end
+
+local armSlots = {
+    activeSlot=1, maxSlots=3,
+    bySlot={ [1]=Row(1), [2]=Row(1, 2) },
+}
+local pending = {
+    sourceSlot=1, targetSlot=2, wishlistKey="wish-A", wishlistSlot=7,
+    snapshot={
+        byFamily={ s1=1, s2=1 },
+        bySpell={ [1]=1, [2]=1 },
+    },
+}
+
+do
+    local action = Relay.ArmDecision({
+        pending=pending, slots=armSlots,
+        associations={ [1]="wish-A", [2]="wish-A" },
+    })
+    Eq(action, "activate", "verified same-wishlist relay target is armed")
+end
+
+do
+    armSlots.activeSlot = 2
+    local action = Relay.ArmDecision({
+        pending=pending, slots=armSlots,
+        associations={ [1]="wish-A", [2]="wish-A" },
+    })
+    Eq(action, "confirmed", "server-confirmed relay activation clears pending")
+end
+
+do
+    armSlots.activeSlot = 3
+    local action = Relay.ArmDecision({
+        pending=pending, slots=armSlots,
+        associations={ [1]="wish-A", [2]="wish-A" },
+    })
+    Eq(action, "cancel", "manual switch outside the relay is respected")
+end
+
+do
+    armSlots.activeSlot = 1
+    local action = Relay.ArmDecision({
+        pending=pending, slots=armSlots,
+        associations={ [1]="wish-A", [2]="wish-B" },
+    })
+    Eq(action, "cancel", "changed target association blocks automatic activation")
+end
+
+do
+    local unverifiedSlots = {
+        activeSlot=1, maxSlots=3,
+        bySlot={ [1]=Row(1), [2]=Row(1, 2) },
+    }
+    unverifiedSlots.bySlot[2].verifiedFieldPresent = false
+    local action = Relay.ArmDecision({
+        pending=pending, slots=unverifiedSlots,
+        associations={ [1]="wish-A", [2]="wish-A" },
+    })
+    Eq(action, "wait", "automatic activation waits for verified slot data")
+end
+
+do
+    local changedSlots = {
+        activeSlot=1, maxSlots=3,
+        bySlot={ [1]=Row(1), [2]=Row(1, 3) },
+    }
+    local action = Relay.ArmDecision({
+        pending=pending, slots=changedSlots,
+        associations={ [1]="wish-A", [2]="wish-A" },
+    })
+    Eq(action, "cancel", "changed relay Snapshot contents block automatic activation")
+end
+
+do
+    local changedVariantSlots = {
+        activeSlot=1, maxSlots=3,
+        bySlot={ [1]=Row(1), [2]=Row(10, 2) },
+    }
+    local action = Relay.ArmDecision({
+        pending=pending, slots=changedVariantSlots,
+        associations={ [1]="wish-A", [2]="wish-A" },
+    })
+    Eq(action, "cancel",
+        "same-family replacement cannot bypass exact relay verification")
+end
+
+do
+    local invalidCountSlots = {
+        activeSlot=1, maxSlots=3,
+        bySlot={ [1]=Row(1), [2]=Row(1, 2) },
+    }
+    invalidCountSlots.bySlot[2].echoes[1].stacks = 0
+    local action = Relay.ArmDecision({
+        pending=pending, slots=invalidCountSlots,
+        associations={ [1]="wish-A", [2]="wish-A" },
+    })
+    Eq(action, "cancel",
+        "non-positive stack data cannot satisfy exact relay verification")
+end
+
+io.write(string.format("relay tests passed: %d\n", passed))

--- a/tests/run_release_mesh_stress.lua
+++ b/tests/run_release_mesh_stress.lua
@@ -1,0 +1,34 @@
+-- 100-character leaderboard stress: bounded rows, bucket deltas, and exact
+-- loadout references remain stable.
+local H=dofile("tests/harness.lua")
+dofile("core/Codec.lua"); dofile("core/Sync.lua"); dofile("core/DpsCapture.lua")
+local DPS=Nexus.DpsCapture
+NexusDB={communityBuilds={},syncTombstones={},dpsCapture={}}
+UnitName=function() return "Viewer" end
+local broadcasts={}
+DPS.Init({}, {BroadcastDpsRecord=function(r) broadcasts[#broadcasts+1]=r return true end})
+for i=1,100 do
+ local echoes={{spellId=300000+i,stacks=1},{spellId=310000+i,stacks=(i%3)+1}}
+ local id="stress-"..i
+ NexusDB.communityBuilds[id]={id=id,title="Loadout "..i,author="Player"..i,class="MAGE",echoes=echoes,lastModified=i,postedAt=i,isMine=false}
+ local fp=DPS.GetEchoKey(echoes)
+ assert(DPS.ReceiveRecord({v=6,f=fp,e=echoes,c="dummy",d=1000000+i*10000,u=65,t=i,p="Player"..i,k="MAGE",l=80,b=id}))
+end
+local rows=DPS.GetDpsBoard("dummy")
+assert(#rows==100,"100 distinct characters should produce 100 rows")
+-- Same character, stronger different exact loadout: still 100 rows.
+local better={{spellId=400050,stacks=2},{spellId=410050,stacks=1}}
+NexusDB.communityBuilds["stress-50b"]={id="stress-50b",title="Winner 50",author="Player50",class="MAGE",echoes=better,lastModified=200,postedAt=200,isMine=false}
+assert(DPS.ReceiveRecord({v=6,f=DPS.GetEchoKey(better),e=better,c="dummy",d=9000000,u=65,t=200,p="Player50",k="MAGE",l=80,b="stress-50b"}))
+rows=DPS.GetDpsBoard("dummy")
+assert(#rows==100,"new winning loadout for one character must replace, not append")
+local found=false; for _,r in ipairs(rows) do if r.player=="Player50" then found=r.buildId=="stress-50b" and r.dps==9000000 end end
+assert(found,"Player50 winning loadout was not replaced correctly")
+local fullHash=DPS.GetSyncHash()
+assert(select(2,fullHash:gsub(",",","))==7,"DPS sync hash should contain 8 delta buckets")
+assert(DPS.BroadcastAllBuildBests(fullHash)==0,"identical peer should receive zero leaderboard records")
+local parts={}; for p in fullHash:gmatch("([^,]+)") do parts[#parts+1]=p end; parts[1]="different"
+broadcasts={}
+local n=DPS.BroadcastAllBuildBests(table.concat(parts,","))
+assert(n>0 and n<40,"one changed bucket should send a bounded subset, got "..tostring(n))
+print("100-entry leaderboard and bucket-delta sync stress -- OK")

--- a/tests/run_release_ui_polish.lua
+++ b/tests/run_release_ui_polish.lua
@@ -1,0 +1,21 @@
+local H=dofile("tests/harness.lua")
+dofile("core/Codec.lua"); dofile("core/Sync.lua"); dofile("core/DpsCapture.lua")
+dofile("data/DefaultProfile.lua"); dofile("logic/Model.lua"); dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua"); dofile("logic/Policy.lua"); dofile("core/Store.lua")
+dofile("core/GameAdapter.lua"); dofile("ui/CommunityBuilds.lua"); dofile("ui/Leaderboard.lua")
+NexusDB={communityBuilds={},dpsCapture={}}
+local D=Nexus.DpsCapture
+D.Init({},nil)
+local echoes={{spellId=200100,stacks=1}}
+local id="verified-build"
+NexusDB.communityBuilds[id]={id=id,title="Verified Mage",author="Mageone",class="MAGE",echoes=echoes,postedAt=1,lastModified=1}
+local fp=D.GetEchoKey(echoes)
+assert(not D.ReceiveRecord({v=7,f=fp,e=echoes,c="dummy",d=1000000,u=29,t=1,p="Mageone",k="MAGE",l=80,b=id}),"29 second current record accepted")
+assert(D.ReceiveRecord({v=7,f=fp,e=echoes,c="dummy",d=1000000,u=30,t=2,p="Mageone",k="MAGE",l=80,b=id}),"30 second record rejected")
+local verified=D.GetBuildVerification(id)
+assert(verified and verified.duration==30,"verified build stamp missing")
+Nexus.CommunityBuilds.Init(Nexus.GameAdapter,Nexus.Model)
+Nexus.CommunityBuilds.Show()
+assert(_G.NexusCommunityBuildsFrame._sortToggle:GetText()=="Sort: Highest DPS",
+    "1.19.3 evidence-first default sort changed")
+print("release UI polish and Details verification -- OK")

--- a/tests/run_scale_relocated.lua
+++ b/tests/run_scale_relocated.lua
@@ -1,0 +1,97 @@
+-- Verifies the scale control was actually MOVED (not duplicated): no
+-- slider on the overlay itself, and the editor's popup genuinely drives
+-- WishlistOverlay's real scale with fine (0.02) steps via +/- and slider.
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+
+local overlayWidgets = {}
+local realCreateFrame1 = CreateFrame
+CreateFrame = function(...)
+    local f = realCreateFrame1(...)
+    overlayWidgets[#overlayWidgets + 1] = f
+    return f
+end
+dofile("ui/WishlistOverlay.lua")
+
+NexusDB = {}
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+} }
+H.playerLevel = 5
+
+local Adapter, Model = Nexus.GameAdapter, Nexus.Model
+local OV = Nexus.WishlistOverlay
+OV.Init(Adapter, Model)
+OV.Show()
+
+-- no Slider-kind frame should exist among anything the overlay created
+local foundSliderOnOverlay = false
+for _, f in ipairs(overlayWidgets) do
+    if f.kind == "Slider" then foundSliderOnOverlay = true end
+end
+-- (harness doesn't track "kind" explicitly -- check via the known global
+-- name the old slider used to register under instead, which is the
+-- reliable signal here)
+assert(_G.NexusOverlayScale == nil,
+    "the old overlay-mounted scale slider still exists -- should be removed")
+print("no scale slider remains on the overlay itself -- OK")
+
+-- default scale, GetScale/SetScale round-trip
+assert(OV.GetScale() == 1.0, "default scale should be 1.0, got " .. tostring(OV.GetScale()))
+OV.SetScale(1.2)
+assert(OV.GetScale() == 1.2, "SetScale/GetScale round-trip failed")
+assert(NexusDB.overlayScale == 1.2, "scale not persisted to SavedVariables")
+print("WishlistOverlay.GetScale()/SetScale() public API works -- OK")
+
+-- clamping: out-of-range values must be clamped, not silently broken
+OV.SetScale(5.0)
+assert(OV.GetScale() <= 1.6, "scale was not clamped to a sane maximum")
+OV.SetScale(-1.0)
+assert(OV.GetScale() >= 0.5, "scale was not clamped to a sane minimum")
+print("scale is safely clamped to a sane range -- OK")
+
+-- Now verify the EDITOR's popup genuinely drives this real overlay.
+dofile("ui/WishlistEditor.lua")
+local EW = Nexus.WishlistEditor
+EW.Init(Adapter, Model)
+
+local popupWidgets = {}
+local realCreateFrame2 = CreateFrame
+CreateFrame = function(...)
+    local f = realCreateFrame2(...)
+    popupWidgets[#popupWidgets + 1] = f
+    return f
+end
+EW.ToggleDisplayPopup()
+
+assert(_G.NexusScaleSlider ~= nil,
+    "expected a scale slider inside the editor's Display popup")
+print("scale slider now lives in the editor's popup -- OK")
+
+OV.SetScale(1.0)
+-- find the +/- nudge buttons by observed behavior (fine +/-0.02 steps)
+local plusBtn, minusBtn = nil, nil
+for _, f in ipairs(popupWidgets) do
+    if f.scripts and f.scripts.OnClick and f.text == "+" then plusBtn = f end
+    if f.scripts and f.scripts.OnClick and f.text == "-" then minusBtn = f end
+end
+assert(plusBtn and minusBtn, "could not find both +/- nudge buttons in the popup")
+
+plusBtn.scripts.OnClick(plusBtn)
+local afterPlus = OV.GetScale()
+assert(math.abs(afterPlus - 1.02) < 0.001,
+    string.format("expected fine +0.02 nudge (1.02), got %.4f", afterPlus))
+print("'+' nudge button applies a FINE 0.02 step -- OK")
+
+minusBtn.scripts.OnClick(minusBtn)
+minusBtn.scripts.OnClick(minusBtn)
+local afterMinus = OV.GetScale()
+assert(math.abs(afterMinus - 0.98) < 0.001,
+    string.format("expected fine -0.02 steps back to 0.98, got %.4f", afterMinus))
+print("'-' nudge button applies a FINE 0.02 step -- OK")

--- a/tests/run_scenarios.lua
+++ b/tests/run_scenarios.lua
@@ -653,6 +653,8 @@ do
     })
     expect(result.type == "take",
         "disabled automatic Banish must fall through to a selectable action")
+    expect(result.forced == true,
+        "mandatory least-harmful selections must preserve forced-take metadata")
 end
 
 -- Final Phase B has no protected guarantee/frozen fallback, but its search

--- a/tests/run_scenarios.lua
+++ b/tests/run_scenarios.lua
@@ -1,0 +1,694 @@
+-- Deterministic guaranteed-queue policy scenarios.
+dofile("logic/Model.lua")
+dofile("logic/Policy.lua")
+
+local Policy = Nexus.Policy
+local checks = 0
+
+local function expect(condition, message)
+    checks = checks + 1
+    assert(condition, message)
+end
+
+local rows = {
+    [100] = { spellId=100, name="Stack Target", quality=1, maxStack=3 },
+    [200] = { spellId=200, name="Ordinary Target", quality=1, maxStack=1 },
+    [210] = { spellId=210, name="Quality Target", quality=0, maxStack=1 },
+    [211] = { spellId=211, name="Quality Target", quality=2, maxStack=1 },
+    [220] = { spellId=220, name="Held Target", quality=1, maxStack=1 },
+    [221] = { spellId=221, name="Equal Side Target", quality=1, maxStack=1 },
+    [222] = { spellId=222, name="Another Target", quality=1, maxStack=1 },
+    [300] = { spellId=300, name="Guaranteed Target", quality=1, maxStack=1 },
+    [400] = { spellId=400, name="Filler A", quality=1, maxStack=1 },
+    [401] = { spellId=401, name="Filler B", quality=1, maxStack=1 },
+}
+local catalog = {
+    rows = rows,
+    familyOf = {
+        [100]="stack", [200]="ordinary", [210]="quality", [211]="quality",
+        [220]="held", [221]="side", [222]="another",
+        [300]="guaranteed", [400]="fillerA", [401]="fillerB",
+    },
+    familyMembers = {
+        stack={100}, ordinary={200}, quality={210,211}, guaranteed={300},
+        held={220}, side={221}, another={222},
+        fillerA={400}, fillerB={401},
+    },
+}
+local plan = {
+    advisorOnly = false,
+    wishedFamilies = {
+        stack=true, ordinary=true, quality=true, held=true,
+        side=true, another=true, guaranteed=true,
+    },
+    targets = {
+        stack={ targetStacks=3, wishedQuality=1 },
+        ordinary={ targetStacks=1, wishedQuality=1 },
+        quality={ targetStacks=1, wishedQuality=2 },
+        held={ targetStacks=1, wishedQuality=1 },
+        side={ targetStacks=1, wishedQuality=1 },
+        another={ targetStacks=1, wishedQuality=1 },
+        guaranteed={ targetStacks=1, wishedQuality=1 },
+    },
+}
+
+local function card(spellId, extra)
+    local out = {
+        spellId=spellId,
+        family=catalog.familyOf[spellId],
+        quality=rows[spellId].quality,
+    }
+    for key, value in pairs(extra or {}) do out[key] = value end
+    return out
+end
+
+local function decide(cards, guaranteedIndex, options)
+    options = options or {}
+    return Policy.Decide({
+        board={ cards=cards, guaranteedIndex=guaranteedIndex },
+        owned={
+            synced=options.synced ~= false,
+            bySpell=options.bySpell or {},
+            byFamily=options.byFamily or {},
+        },
+        charges=options.charges or {
+            freeze=1, banish=1, reroll=1, trustworthy=true,
+            banishSpentThisPush=options.banishSpentThisPush,
+        },
+        plan=plan,
+        queue=options.queue,
+        catalog=catalog,
+        canFreeze=options.canFreeze,
+        level=options.level ~= nil and options.level or 20,
+        horizon=options.horizon,
+        flags=options.flags,
+        searchRefused=options.searchRefused,
+        allowBanish=options.allowBanish,
+    })
+end
+
+-- An unsynchronized owned snapshot is not safe for irreversible auto-play.
+do
+    local result = decide({
+        card(400, { isGuaranteed=true }), card(401),
+    }, 1, {
+        synced=false,
+        charges={ freeze=0, banish=0, reroll=0, trustworthy=true },
+    })
+    expect(result.type == "wait",
+        "an unsynchronized owned snapshot must pause automatic choices")
+end
+
+-- Wanted side + wanted guaranteed: bank the side first, then drain.
+do
+    local first = decide({
+        card(200), card(300, { isGuaranteed=true }), card(400),
+    }, 2)
+    expect(first.type == "freeze" and first.index == 1,
+        "wanted side must freeze before a wanted guaranteed card")
+    local second = decide({
+        card(200, { isFrozen=true }), card(300, { isGuaranteed=true }), card(400),
+    }, 2)
+    expect(second.type == "banish" and second.index == 3,
+        "a safe filler must be Banished after the wanted side is protected")
+    local third = decide({
+        card(200, { isFrozen=true }), card(300, { isGuaranteed=true }), card(400),
+    }, 2, { charges={ freeze=0, banish=0, reroll=1, trustworthy=true } })
+    expect(third.type == "take" and third.index == 2,
+        "guaranteed card must drain after early Banishes are exhausted")
+end
+
+-- A filler guarantee is rejected as soon as a wanted side Echo is visible.
+do
+    local result = decide({
+        card(200), card(400, { isGuaranteed=true }), card(401),
+    }, 2)
+    expect(result.type == "take" and result.index == 1,
+        "wanted side must replace an off-wishlist guaranteed card")
+end
+
+-- A wanted side already promised later by the queue is not one of the missing
+-- targets that should replace an off-wishlist guarantee.
+do
+    local result = decide({
+        card(200), card(400, { isGuaranteed=true }), card(401),
+    }, 2, {
+        queue={ entries={
+            { spellId=200, family="ordinary", wanted=true },
+        } },
+    })
+    expect(result.type == "banish" and result.index == 3
+        and result.annotations[1] == "returns later",
+        "off-wishlist guarantee search must preserve queue-deliverable targets")
+end
+
+-- A useful single-stack side card already pending in the guaranteed queue
+-- returns later; spending Freeze would occupy a side slot for no gain.
+do
+    local result = decide({
+        card(200), card(300, { isGuaranteed=true }), card(400),
+    }, 2, {
+        queue={ entries={
+            { spellId=300, family="guaranteed", wanted=true },
+            { spellId=200, family="ordinary", wanted=true },
+        } },
+    })
+    expect(result.type == "take" and result.index == 2
+        and result.annotations[1] == "returns later",
+        "a queue-deliverable single-stack wanted side card must not be frozen")
+end
+
+-- A high-quality side catch is still scarce when the queue only promises a
+-- below-target member of the same multi-quality family.
+do
+    local result = decide({
+        card(211), card(300, { isGuaranteed=true }), card(400),
+    }, 2, {
+        queue={ entries={
+            { spellId=300, family="guaranteed", wanted=true },
+            { spellId=210, family="quality", wanted=false },
+        } },
+    })
+    expect(result.type == "freeze" and result.index == 1,
+        "a superior-quality catch must remain freeze-worthy")
+end
+
+-- A stacking target stays scarce even when its family appears in the queue:
+-- injection supplies only the first copy, not every requested stack.
+do
+    local result = decide({
+        card(100), card(300, { isGuaranteed=true }), card(400),
+    }, 2, {
+        queue={ entries={
+            { spellId=300, family="guaranteed", wanted=true },
+            { spellId=100, family="stack", wanted=true },
+        } },
+        byFamily={ stack=1 },
+    })
+    expect(result.type == "freeze" and result.index == 1,
+        "a still-short stacking family must remain freeze-worthy")
+end
+
+-- One carried wanted card already protects the side opportunity. Do not
+-- fill the other side slot with a second Freeze.
+do
+    local result = decide({
+        card(200, { isCarried=true }), card(100),
+        card(300, { isGuaranteed=true }),
+    }, 3, { byFamily={ stack=1 } })
+    expect(result.type == "take" and result.index == 3,
+        "an existing carried wanted card must suppress a second Freeze")
+end
+
+-- Unavailable or untrustworthy Freeze uses explicit loss prevention.
+do
+    local result = decide({
+        card(200), card(300, { isGuaranteed=true }), card(401),
+    }, 2, { charges={ freeze=0, banish=9, reroll=9, trustworthy=true } })
+    expect(result.type == "take" and result.index == 1
+        and string.find(result.reason, "Freeze", 1, true),
+        "missing Freeze must take the wanted side with a clear reason")
+end
+
+-- Side priority: stacking, then quality-qualified one-shot, then delta/index.
+do
+    local result = decide({
+        card(200), card(211), card(100), card(300, { isGuaranteed=true }),
+    }, 4, { byFamily={ stack=1 } })
+    expect(result.type == "freeze" and result.index == 3,
+        "a stacking family below target must win side-card priority")
+
+    result = decide({
+        card(200), card(211), card(300, { isGuaranteed=true }),
+    }, 3)
+    expect(result.type == "freeze" and result.index == 2,
+        "a quality-qualified one-shot must beat an ordinary wanted side card")
+
+    result = decide({
+        card(200), card(200), card(300, { isGuaranteed=true }),
+    }, 3)
+    expect(result.type == "freeze" and result.index == 1,
+        "equal wanted side cards must use the lowest stable index")
+end
+
+-- During leveling, safe Banishes are front-loaded even while the guaranteed
+-- queue is active. Guaranteed identity remains semantic, not positional.
+do
+    local result = decide({
+        card(400, { isGuaranteed=true }), card(401), card(400),
+    }, 1, { charges={ freeze=2, banish=3, reroll=4, trustworthy=true } })
+    expect(result.type == "banish" and result.index == 2,
+        "leveling must front-load a safe side Banish before queue drain")
+
+    result = decide({
+        card(400, { isGuaranteed=true }), card(401), card(400),
+    }, 1, { charges={ freeze=2, banish=0, reroll=4, trustworthy=true } })
+    expect(result.type == "reroll",
+        "after Banishes, an off-wishlist guarantee must search with Reroll")
+
+    result = decide({
+        card(400, { isGuaranteed=true }), card(401), card(400),
+    }, 1, { charges={ freeze=2, banish=0, reroll=0, trustworthy=true } })
+    expect(result.type == "take" and result.index == 2,
+        "exhausted search must discard the off-wishlist guarantee via a side")
+end
+
+-- Once the queue is gone, consume frozen wanted cards first.
+do
+    local result = decide({
+        card(200), card(211, { isFrozen=true }), card(100),
+    }, nil)
+    expect(result.type == "take" and result.index == 2,
+        "a frozen wanted card must be taken before unfrozen wanted cards")
+end
+
+-- Search phase: Banish once, then Reroll after re-evaluation.
+do
+    local cards = { card(400), card(401) }
+    local first = decide(cards, nil)
+    expect(first.type == "banish" and first.index == 1,
+        "a junk board must safely Banish the deterministic worst filler")
+    local second = decide(cards, nil, {
+        banishSpentThisPush=true,
+        charges={
+            freeze=0, banish=1, reroll=1, trustworthy=true,
+            banishSpentThisPush=true,
+        },
+    })
+    expect(second.type == "reroll",
+        "the same fresh run-data push must Reroll after its one safe Banish")
+end
+
+-- Front-loading is limited to the leveling run. At level 80 with no confirmed
+-- final horizon, an off-wishlist guarantee is still rejected.
+do
+    local result = decide({
+        card(400, { isGuaranteed=true }), card(401),
+    }, 1, {
+        level=80,
+        charges={ freeze=0, banish=4, reroll=4, trustworthy=true },
+    })
+    expect(result.type == "banish" and result.index == 2,
+        "level 80 must still search away an off-wishlist guarantee")
+end
+
+-- A just-frozen wanted side must finish resolving before the unwanted
+-- guarantee can be discarded.
+do
+    local result = decide({
+        card(400, { isGuaranteed=true }),
+        card(200, { justFrozen=true }),
+        card(401),
+    }, 1)
+    expect(result.type == "wait"
+        and string.find(result.reason, "Freeze", 1, true),
+        "off-wishlist guarantee search must wait for a just-frozen wanted side")
+end
+
+-- A below-quality wished family is not wanted, but the family is protected
+-- from Banish because Banish may remove every quality variant.
+do
+    local result = decide({ card(210), card(400) }, nil)
+    expect(result.type == "banish" and result.index == 2,
+        "below-quality wished family must be protected from Banish")
+end
+
+-- A held wanted Echo protects the side opportunity, so leveling may spend a
+-- safe early Banish before normal guaranteed draining.
+do
+    local result = decide({
+        card(220, { isFrozen=true }), card(400),
+        card(300, { isGuaranteed=true }),
+    }, 3, {
+        horizon=2,
+        charges={ freeze=0, banish=4, reroll=4, trustworthy=true },
+    })
+    expect(result.type == "banish" and result.index == 2,
+        "a banked wanted side must permit a safe early Banish")
+
+    result = decide({
+        card(220, { isFrozen=true }), card(400),
+        card(300, { isGuaranteed=true }),
+    }, 3, {
+        horizon=2,
+        charges={ freeze=0, banish=0, reroll=4, trustworthy=true },
+    })
+    expect(result.type == "take" and result.index == 3,
+        "after early Banishes, horizon above one must drain the guarantee")
+end
+
+-- Level 80 can still have multiple selections. Freeze remains valid only
+-- when Main has confirmed a numeric horizon above one.
+do
+    local result = decide({
+        card(220), card(400), card(300, { isGuaranteed=true }),
+    }, 3, {
+        level=80,
+        horizon=2,
+        canFreeze=true,
+        charges={ freeze=1, banish=0, reroll=0, trustworthy=true },
+    })
+    expect(result.type == "freeze" and result.index == 1,
+        "level 80 with horizon above one must still allow Freeze")
+
+    result = decide({
+        card(220), card(400), card(300, { isGuaranteed=true }),
+    }, 3, {
+        level=80,
+        horizon=1,
+        canFreeze=false,
+        charges={ freeze=1, banish=0, reroll=0, trustworthy=true },
+    })
+    expect(result.type == "take" and result.index == 1,
+        "final selection must take an unfrozen wanted side Echo as loss prevention")
+end
+
+-- A lower-level horizon of one only ends the current pending-roll batch. It
+-- must keep normal queue behavior because later leveling boards still exist.
+do
+    local result = decide({
+        card(220), card(400), card(300, { isGuaranteed=true }),
+    }, 3, {
+        level=18,
+        horizon=1,
+        canFreeze=true,
+        charges={ freeze=1, banish=4, reroll=4, trustworthy=true },
+    })
+    expect(result.type == "freeze" and result.index == 1
+        and not result.endgame,
+        "lower-level horizon one must not trigger final-selection search")
+end
+
+-- On the final selection, search the safe free slot before consuming the
+-- held wanted Echo. Protected and guaranteed cards are never Banish targets.
+do
+    local result = decide({
+        card(220, { isFrozen=true }), card(400),
+        card(300, { isGuaranteed=true }),
+    }, 3, {
+        level=80,
+        horizon=1,
+        charges={ freeze=0, banish=2, reroll=3, trustworthy=true },
+    })
+    expect(result.type == "banish" and result.index == 2 and result.endgame,
+        "final selection must safely Banish the off-wishlist side card first")
+end
+
+-- A wanted guaranteed card is also a protected final fallback. Even without a
+-- frozen card, spend a safe Banish on an off-wishlist side before draining it.
+do
+    local result = decide({
+        card(400), card(401), card(300, { isGuaranteed=true }),
+    }, 3, {
+        level=80,
+        horizon=1,
+        charges={ freeze=0, banish=2, reroll=3, trustworthy=true },
+    })
+    expect(result.type == "banish" and result.index == 1 and result.endgame,
+        "final selection must safely Banish before a protected guarantee")
+end
+
+-- Once that Banish is spent, an unconfirmed Reroll hold must not gamble away
+-- the wanted guaranteed fallback. A confirmed hold may continue the search.
+do
+    local result = decide({
+        card(400), card(401), card(300, { isGuaranteed=true }),
+    }, 3, {
+        level=80,
+        horizon=1,
+        flags={},
+        charges={
+            freeze=0, banish=1, reroll=3, trustworthy=true,
+            banishSpentThisPush=true,
+        },
+    })
+    expect(result.type == "take" and result.index == 3,
+        "unknown Reroll hold must drain the protected guaranteed card")
+
+    result = decide({
+        card(400), card(401), card(300, { isGuaranteed=true }),
+    }, 3, {
+        level=80,
+        horizon=1,
+        flags={ REROLL_HOLDS_GUARANTEED=true },
+        charges={
+            freeze=0, banish=1, reroll=3, trustworthy=true,
+            banishSpentThisPush=true,
+        },
+    })
+    expect(result.type == "reroll" and result.endgame,
+        "confirmed Reroll hold must search beyond the protected guarantee")
+end
+
+-- A filler guarantee needs no hold proof: after the safe Banish, Reroll may
+-- continue looking for any still-missing wanted target.
+do
+    local result = decide({
+        card(401), card(400, { isGuaranteed=true }),
+    }, 2, {
+        level=80,
+        horizon=1,
+        flags={},
+        charges={
+            freeze=0, banish=1, reroll=3, trustworthy=true,
+            banishSpentThisPush=true,
+        },
+    })
+    expect(result.type == "reroll" and result.endgame,
+        "a filler guaranteed card must not block final Reroll search")
+
+    result = decide({
+        card(401), card(400, { isGuaranteed=true }),
+    }, 2, {
+        level=80,
+        horizon=1,
+        charges={ freeze=0, banish=0, reroll=0, trustworthy=true },
+    })
+    expect(result.type == "take" and result.index == 1 and result.endgame,
+        "exhausted final search must discard an off-wishlist guarantee")
+end
+
+-- One-Banish-per-push remains binding. Once that safe action is spent,
+-- final search advances to Reroll without claiming the guaranteed is held.
+do
+    local result = decide({
+        card(220, { isFrozen=true }), card(400),
+        card(300, { isGuaranteed=true }),
+    }, 3, {
+        level=80,
+        horizon=1,
+        flags={},
+        charges={
+            freeze=0, banish=1, reroll=2, trustworthy=true,
+            banishSpentThisPush=true,
+        },
+    })
+    expect(result.type == "reroll" and result.endgame,
+        "spent final-selection Banish must advance to Reroll")
+    expect(not string.find(result.reason, "guaranteed wanted Echo is held", 1, true),
+        "Reroll reason must not claim the guaranteed is held without the flag")
+
+    -- Remove the frozen fallback here so the confirmed guarantee hold is the
+    -- specific protection that makes Reroll safe (and therefore the reason
+    -- Nexus should report).
+    result = decide({
+        card(400), card(401), card(300, { isGuaranteed=true }),
+    }, 3, {
+        level=80,
+        horizon=1,
+        flags={ REROLL_HOLDS_GUARANTEED=true },
+        charges={
+            freeze=0, banish=1, reroll=2, trustworthy=true,
+            banishSpentThisPush=true,
+        },
+    })
+    expect(result.type == "reroll"
+        and string.find(result.reason, "guaranteed wanted Echo is held", 1, true),
+        "confirmed Reroll hold may be stated in the final-search reason")
+end
+
+-- Exhausted search always cashes the frozen target instead of falling back
+-- to the guaranteed card.
+do
+    local result = decide({
+        card(220, { isFrozen=true }), card(400),
+        card(300, { isGuaranteed=true }),
+    }, 3, {
+        level=80,
+        horizon=1,
+        charges={ freeze=0, banish=0, reroll=0, trustworthy=true },
+    })
+    expect(result.type == "take" and result.index == 1 and result.endgame,
+        "no final-search charges must take the frozen Echo, not guaranteed")
+end
+
+-- Final comparison uses ordinary wishlist demand only. Equal targets keep the
+-- protected frozen card; a real stacking deficit may replace it.
+do
+    local result = decide({
+        card(220, { isFrozen=true }), card(221),
+        card(300, { isGuaranteed=true }),
+    }, 3, {
+        level=80,
+        horizon=1,
+        charges={ freeze=0, banish=0, reroll=0, trustworthy=true },
+    })
+    expect(result.type == "take" and result.index == 1 and result.endgame,
+        "equal remaining targets must keep the protected frozen Echo")
+
+    result = decide({
+        card(220, { isFrozen=true }), card(100),
+        card(300, { isGuaranteed=true }),
+    }, 3, {
+        level=80,
+        horizon=1,
+        charges={ freeze=0, banish=0, reroll=0, trustworthy=true },
+    })
+    expect(result.type == "take" and result.index == 2 and result.endgame,
+        "normal stacking demand must drive final selection without name rules")
+end
+
+-- The final branch is independent of guaranteed-card identity. It continues
+-- after Reroll removes the guaranteed card as long as the frozen Echo remains.
+do
+    local result = decide({
+        card(220, { isFrozen=true }), card(400),
+    }, nil, {
+        level=80,
+        horizon=1,
+        charges={ freeze=0, banish=0, reroll=2, trustworthy=true },
+    })
+    expect(result.type == "reroll" and result.endgame,
+        "final search must continue when Reroll removes the guaranteed card")
+end
+
+-- Missing horizon is conservative: no final exception is inferred from level.
+do
+    local result = decide({
+        card(220, { isFrozen=true }), card(400),
+        card(300, { isGuaranteed=true }),
+    }, 3, {
+        level=80,
+        charges={ freeze=0, banish=4, reroll=4, trustworthy=true },
+    })
+    expect(result.type == "take" and result.index == 3,
+        "nil horizon must not trigger the final-selection exception")
+
+    result = decide({
+        card(220, { isFrozen=true }), card(400),
+        card(300, { isGuaranteed=true }),
+    }, 3, {
+        level=80,
+        horizon="1",
+        charges={ freeze=0, banish=4, reroll=4, trustworthy=true },
+    })
+    expect(result.type == "take" and result.index == 3,
+        "non-numeric horizon must not trigger the final-selection exception")
+end
+
+-- With no guarantee and selections still remaining, Phase B keeps its
+-- existing consume-bank-first behavior.
+do
+    local result = decide({
+        card(220, { isFrozen=true }), card(400),
+    }, nil, {
+        horizon=2,
+        charges={ freeze=0, banish=4, reroll=4, trustworthy=true },
+    })
+    expect(result.type == "take" and result.index == 1,
+        "non-final Phase B must take the frozen Echo before searching")
+end
+
+-- A wished low-quality family, frozen card, and guaranteed card are all
+-- protected from Banish. With no safe target or Reroll, cash the frozen Echo.
+do
+    local result = decide({
+        card(220, { isFrozen=true }), card(210),
+        card(300, { isGuaranteed=true }),
+    }, 3, {
+        level=80,
+        horizon=1,
+        charges={ freeze=0, banish=3, reroll=0, trustworthy=true },
+    })
+    expect(result.type == "take" and result.index == 1,
+        "final Banish must never target frozen, guaranteed, or wished cards")
+end
+
+-- Synchronous search refusals are supplied by Main on the next pure-policy
+-- call: skip the refused action, then settle on the frozen target.
+do
+    local result = decide({
+        card(220, { isFrozen=true }), card(400),
+        card(300, { isGuaranteed=true }),
+    }, 3, {
+        level=80,
+        horizon=1,
+        searchRefused={ banish=true },
+        charges={ freeze=0, banish=2, reroll=1, trustworthy=true },
+    })
+    expect(result.type == "reroll",
+        "a refused final Banish must advance to Reroll")
+
+    result = decide({
+        card(220, { isFrozen=true }), card(400),
+        card(300, { isGuaranteed=true }),
+    }, 3, {
+        level=80,
+        horizon=1,
+        searchRefused={ banish=true, reroll=true },
+        charges={ freeze=0, banish=2, reroll=1, trustworthy=true },
+    })
+    expect(result.type == "take" and result.index == 1,
+        "refused final search actions must take the frozen Echo")
+end
+
+-- Disabling automatic Banish must advance to another executable action rather
+-- than repeatedly proposing a Banish that Main intentionally will not send.
+do
+    local result = decide({
+        card(400), card(401),
+    }, nil, {
+        allowBanish=false,
+        charges={ freeze=0, banish=2, reroll=0, trustworthy=true },
+    })
+    expect(result.type == "take",
+        "disabled automatic Banish must fall through to a selectable action")
+end
+
+-- Final Phase B has no protected guarantee/frozen fallback, but its search
+-- actions still need endgame refusal recovery.
+do
+    local result = decide({
+        card(400), card(401),
+    }, nil, {
+        level=80,
+        horizon=1,
+        charges={ freeze=0, banish=2, reroll=1, trustworthy=true },
+    })
+    expect(result.type == "banish" and result.endgame,
+        "unprotected final Banish must be marked for refusal recovery")
+
+    result = decide({
+        card(400), card(401),
+    }, nil, {
+        level=80,
+        horizon=1,
+        searchRefused={ banish=true },
+        charges={ freeze=0, banish=2, reroll=1, trustworthy=true },
+    })
+    expect(result.type == "reroll" and result.endgame,
+        "refused final Banish must advance to an endgame Reroll")
+
+    result = decide({
+        card(400), card(401),
+    }, nil, {
+        level=80,
+        horizon=1,
+        searchRefused={ banish=true, reroll=true },
+        charges={ freeze=0, banish=2, reroll=1, trustworthy=true },
+    })
+    expect(result.type == "take" and result.endgame,
+        "exhausted unprotected final search must make a mandatory selection")
+end
+
+print("guaranteed-queue policy scenarios OK (checks=" .. checks .. ")")

--- a/tests/run_secure_globals.lua
+++ b/tests/run_secure_globals.lua
@@ -1,0 +1,32 @@
+-- Regression guard for Blizzard-owned globals used by protected UI paths.
+-- Nexus may add namespaced entries, but it must never reassign the globals.
+
+local files = {
+    "core/GameAdapter.lua", "core/Main.lua",
+    "ui/WishlistEditor.lua", "ui/CommunityBuilds.lua",
+    "ui/LogViewer.lua", "ui/Leaderboard.lua",
+}
+
+for _, path in ipairs(files) do
+    local handle = assert(io.open(path, "rb"))
+    local source = handle:read("*a"):gsub("\r\n", "\n")
+    handle:close()
+
+    for _, name in ipairs({ "StaticPopupDialogs", "UISpecialFrames" }) do
+        local assignment = "\n%s*" .. name .. "%s*="
+        assert(not source:match(assignment)
+                and not source:match("^%s*" .. name .. "%s*="),
+            path .. " reassigns Blizzard-owned global " .. name)
+    end
+    assert(not source:match('StaticPopupDialogs%s*%[%s*["\']USE_BIND["\']%s*%]%s*='),
+        path .. " overrides the stock USE_BIND confirmation")
+    assert(not source:match('hooksecurefunc%s*%(%s*StaticPopup_Show'),
+        path .. " hooks the protected popup dispatcher")
+    assert(not source:match('StaticPopup[1-4]%s*='),
+        path .. " assigns a stock popup frame global")
+    assert(not source:match('ConfirmBindOnUse%s*%(')
+            and not source:match('UseContainerItem%s*%('),
+        path .. " drives protected item acceptance")
+end
+
+print("protected Blizzard globals remain stock-owned -- OK")

--- a/tests/run_security_hardening.lua
+++ b/tests/run_security_hardening.lua
@@ -1,0 +1,199 @@
+-- Hostile Sync/DPS input and CommunityBuild integrity regressions.
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua")
+dofile("core/Sync.lua")
+dofile("core/DpsCapture.lua")
+dofile("ui/CommunityBuilds.lua")
+
+local Codec, Sync, DPS = Nexus.Codec, Nexus.Sync, Nexus.DpsCapture
+time = function() return 50000 end
+NexusDB = { communityBuilds={}, syncTombstones={}, dpsCapture={} }
+
+local function ResetSync()
+    NexusDB.communityBuilds = {}
+    NexusDB.syncTombstones = {}
+    Sync.Init(Codec, {})
+end
+
+local function BuildPacket(sender, build, stamp)
+    local payload = {
+        id=build.id, t=build.title, a=build.author, o=build.ownerKey,
+        c=build.class, m=stamp or build.lastModified, d=build.description,
+        e={{build.echoes[1].spellId, build.echoes[1].quality or 0,
+            build.echoes[1].stacks or 1}},
+    }
+    local encoded = Codec.Base64Encode(Codec.JSONEncode(payload))
+    return table.concat({"WLRB", sender, build.id, tostring(stamp or 1),
+        "1/1", encoded}, "|")
+end
+
+-- Invalid indices/totals never allocate.
+ResetSync()
+for _, spec in ipairs({"0/1", "2/1", "1/0", "1/1000", "999999/999999"}) do
+    Sync.HandleIncoming("WLRB|Flood|bad|1|" .. spec .. "|A", "Flood")
+    Sync.HandleIncoming("WLD2|Flood|bad|" .. spec .. "|A", "Flood")
+end
+local state = Sync.WorkState()
+assert(state.buildInflight == 0 and state.dpsInflight == 0,
+    "invalid chunk geometry allocated state")
+
+-- Duplicate data is free; conflicting data drops the transfer. Per-sender
+-- and global caps include both build and DPS transfers.
+for i = 1, 5 do
+    Sync.HandleIncoming("WLRB|Flood|b" .. i .. "|1|1/2|A", "Flood")
+end
+state = Sync.WorkState()
+assert(state.buildInflight == 4, "per-sender build cap was not enforced")
+local beforeBytes = state.buildBytes
+Sync.HandleIncoming("WLRB|Flood|b1|1|1/2|A", "Flood")
+assert(Sync.WorkState().buildBytes == beforeBytes,
+    "duplicate build chunk double-counted bytes")
+Sync.HandleIncoming("WLRB|Flood|b1|1|1/2|B", "Flood")
+assert(Sync.WorkState().buildInflight == 3,
+    "conflicting duplicate did not discard the build transfer")
+Sync.HandleIncoming("WLD2|Flood|d1|1/2|A", "Flood")
+assert(Sync.WorkState().dpsInflight == 1,
+    "combined per-sender allowance should admit the fourth transfer")
+Sync.HandleIncoming("WLD2|Flood|d2|1/2|A", "Flood")
+assert(Sync.WorkState().dpsInflight == 1,
+    "combined per-sender cap did not reject the fifth transfer")
+
+ResetSync()
+for senderIndex = 1, 6 do
+    local sender = "Peer" .. senderIndex
+    for transfer = 1, 4 do
+        local id = sender .. "-" .. transfer
+        local code = (senderIndex % 2 == 0) and "WLD2" or "WLRB"
+        local msg
+        if code == "WLRB" then
+            msg = "WLRB|" .. sender .. "|" .. id .. "|1|1/2|A"
+        else
+            msg = "WLD2|" .. sender .. "|" .. id .. "|1/2|A"
+        end
+        Sync.HandleIncoming(msg, sender)
+    end
+end
+state = Sync.WorkState()
+assert(state.buildInflight + state.dpsInflight == state.maxGlobal,
+    "combined global transfer cap was not reached deterministically")
+Sync.HandleIncoming("WLRB|Overflow|extra|1|1/2|A", "Overflow")
+state = Sync.WorkState()
+assert(state.buildInflight + state.dpsInflight == state.maxGlobal,
+    "global transfer cap admitted an extra transfer")
+
+-- Every incomplete type expires on the same bounded TTL.
+H.now = H.now + 31
+Sync.OnUpdate(0)
+state = Sync.WorkState()
+assert(state.buildInflight == 0 and state.dpsInflight == 0,
+    "expired build/DPS transfers were retained")
+
+-- Cumulative encoded data is bounded before concatenation.
+ResetSync()
+local chunk = string.rep("A", 255)
+local total = 172
+for i = 1, total do
+    Sync.HandleIncoming("WLRB|Bulk|large|1|" .. i .. "/" .. total
+        .. "|" .. chunk, "Bulk")
+end
+assert(Sync.WorkState().buildInflight == 0,
+    "oversized cumulative build payload remained allocated")
+
+-- Transport identity controls full-build authority. Relayed information may
+-- be stored only as unverified and cannot overwrite verified/local state.
+ResetSync()
+local alice = {
+    id="alice-build", title="Alice Build", author="Alice",
+    ownerKey="alice@ebonhold", class="MAGE", description="original",
+    lastModified=10, echoes={{spellId=200100, quality=3, stacks=1}},
+}
+Sync.HandleIncoming(BuildPacket("Mallory", alice, 10), "Mallory")
+local relayed = NexusDB.communityBuilds[alice.id]
+assert(relayed and relayed.ownerVerified == false and relayed.ownerKey == nil
+    and not relayed.isMine, "relay gained build-owner authority")
+Sync.HandleIncoming(BuildPacket("Alice", alice, 10), "Alice")
+local verified = NexusDB.communityBuilds[alice.id]
+assert(verified and verified.ownerVerified == true
+    and verified.ownerKey == "alice@ebonhold",
+    "direct owner did not replace the unverified relay")
+local forged = {
+    id=alice.id, title="Forged", author="Alice", ownerKey="alice@ebonhold",
+    class="MAGE", description="forged", lastModified=99,
+    echoes={{spellId=200101, quality=3, stacks=1}},
+}
+Sync.HandleIncoming(BuildPacket("Mallory", forged, 99), "Mallory")
+assert(NexusDB.communityBuilds[alice.id].title == "Alice Build",
+    "relayed overwrite changed owner-controlled state")
+Sync.HandleIncoming("WLRD|Mallory|alice-build|100|Alice", "Mallory")
+assert(NexusDB.communityBuilds[alice.id], "spoofed tombstone deleted a build")
+Sync.HandleIncoming("WLRD|Mallory|unknown|100|Mallory", "Mallory")
+assert(NexusDB.syncTombstones.unknown == nil,
+    "unknown tombstone gained persistent authority")
+Sync.HandleIncoming("WLRD|Alice|alice-build|101|Alice", "Alice")
+assert(NexusDB.communityBuilds[alice.id] == nil,
+    "actual owner could not delete the build")
+
+-- Sender spoofing is rejected before any protocol handler sees the packet.
+Sync.HandleIncoming(BuildPacket("Alice", alice, 110), "Mallory")
+assert(NexusDB.communityBuilds[alice.id] == nil,
+    "embedded sender spoof bypassed transport binding")
+
+-- Exact DPS evidence is required and is bound to the transport player.
+NexusDB.dpsCapture = {}
+DPS.Init({}, Sync)
+local echoes = {{spellId=200200, stacks=2}}
+local fingerprint = DPS.GetEchoKey(echoes)
+local record = {
+    v=7, f=fingerprint, h=DPS.GetEchoHash(echoes), e=echoes,
+    c="dummy", d=25000000, u=65, t=50000, p="Alice", l=80,
+    k="MAGE", o="alice@ebonhold", r="ebonhold",
+}
+local dpsData = Codec.Base64Encode(Codec.JSONEncode(record))
+Sync.HandleIncoming("WLD2|Mallory|spoof|1/1|" .. dpsData, "Mallory")
+assert(#DPS.GetDpsBoard("dummy") == 0,
+    "DPS player spoof entered the verified board")
+Sync.HandleIncoming("WLD2|Alice|valid|1/1|" .. dpsData, "Alice")
+assert(#DPS.GetDpsBoard("dummy") == 1,
+    "valid owner-bound DPS record was rejected")
+Sync.HandleIncoming("WLDS|Mallory|x|Mallory|999999999999|80|dummy",
+    "Mallory")
+assert(#DPS.GetDpsBoard("dummy") == 1,
+    "legacy enormous/no-duration DPS altered the board")
+record.d = 26000000
+record.u = 0
+assert(not DPS.ReceiveRecord(record, "Alice"),
+    "no-duration current DPS record was accepted")
+record.u = 65
+record.e = {{spellId=200200, stacks=121}}
+assert(not DPS.ReceiveRecord(record, "Alice"),
+    "oversized Echo evidence was accepted")
+
+-- Failed edits are atomic; successful Echo replacement refreshes all identity.
+UnitName = function() return "Boganic" end
+GetNormalizedRealmName = function() return "Ebonhold" end
+local Builds = Nexus.CommunityBuilds
+local originalEchoes = {{spellId=200300, quality=2, stacks=1}}
+NexusDB.communityBuilds = {
+    mine={id="mine", title="Original", description="Original description",
+        author="Boganic", ownerKey="boganic@ebonhold", class="MAGE",
+        echoes=originalEchoes, postedAt=10, lastModified=10, isMine=true,
+        fingerprint="stale", fingerprintHash="stale", echoCount=99},
+}
+local adapter = { Wishlist=function()
+    return {entries={{spellId=200301, quality=3, stacks=2}}}
+end }
+Builds.Init(adapter, {})
+local ok = Builds.EditBuild("mine", "Changed", "Changed description",
+    "https://example.com/not-discord")
+local mine = NexusDB.communityBuilds.mine
+assert(not ok and mine.title == "Original"
+    and mine.description == "Original description" and mine.lastModified == 10,
+    "invalid link partially mutated the build")
+local oldFingerprint, oldHash = mine.fingerprint, mine.fingerprintHash
+local replaced, count = Builds.UpdateFromWishlist("mine")
+assert(replaced and count == 1 and mine.echoCount == 2
+    and mine.fingerprint ~= oldFingerprint and mine.fingerprintHash ~= oldHash
+    and mine.loadoutAvailable == true and mine.needsFullBuild == false,
+    "Echo replacement left stale derived identity")
+
+print("sync authority, bounded transfers, DPS evidence, and atomic builds -- OK")

--- a/tests/run_snapshot_wishlist_association.lua
+++ b/tests/run_snapshot_wishlist_association.lua
@@ -1,0 +1,65 @@
+-- Regression coverage for the combined Snapshot-specific wishlist resolution.
+-- Run from the Nexus addon root with Lua 5.1/LuaJIT:
+--   luajit tests/run_snapshot_wishlist_association.lua
+
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+
+NexusDB = {}
+H.playerLevel = 1
+Nexus.Store.Init()
+
+local A = Nexus.GameAdapter
+A.Init({}, Nexus.Store)
+H.DeliverSlots({
+    [1] = { slot=1, name="Snapshot A", verified=true, echoes={
+        { spellId=200100, quality=3, stacks=1, locked=false },
+    } },
+    [6] = { slot=6, name="Wishlist A", verified=false, echoes={
+        { spellId=200100, quality=3, stacks=1, locked=false },
+    } },
+    [7] = { slot=7, name="Wishlist B", verified=false, echoes={
+        { spellId=200102, quality=2, stacks=1, locked=false },
+        { spellId=200104, quality=2, stacks=3, locked=false },
+    } },
+}, 1)
+
+local ok, err = A.SetLoadoutWishlist(1, 7)
+assert(ok, "failed to associate active Snapshot: " .. tostring(err))
+local linked = A.Wishlist()
+assert(linked and linked.name == "Wishlist B"
+    and linked.source == "loadout-association",
+    "active Snapshot association did not override an ambiguous designed list")
+assert(linked.byFamily.s200104
+    and linked.byFamily.s200104.targetStacks == 3,
+    "associated wishlist lost requested stack quantity")
+
+A.ClearLoadoutWishlist(1)
+assert(A.Wishlist() == nil,
+    "multiple unassociated designed wishlists should remain ambiguous")
+
+H.DeliverSlots({
+    [1] = { slot=1, name="Snapshot A", verified=true, echoes={
+        { spellId=200100, quality=3, stacks=1, locked=false },
+    } },
+    [7] = { slot=7, name="Wishlist B", verified=false, echoes={
+        { spellId=200102, quality=2, stacks=1, locked=false },
+    } },
+}, 1)
+assert(A.Wishlist() == nil,
+    "1.19.3 must not guess even when only one unassociated wishlist remains")
+
+H.DeliverSlots({
+    [1] = { slot=1, name="Empty", verified=true, echoes={} },
+    [7] = { slot=7, name="Wishlist B", verified=false, echoes={
+        { spellId=200102, quality=2, stacks=1, locked=false },
+    } },
+}, 1)
+ok = A.SetLoadoutWishlist(1, 7)
+assert(ok == false,
+    "an empty Snapshot must not acquire a usable wishlist association")
+
+print("Snapshot wishlist association regression OK")

--- a/tests/run_sniff_pause.lua
+++ b/tests/run_sniff_pause.lua
@@ -1,0 +1,45 @@
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Relay.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/Readout.lua")
+dofile("ui/Panel.lua")
+Nexus.LogViewer = { Init = function() end, Show = function() end }
+dofile("core/Main.lua")
+NexusDB = {}
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+} }
+H.playerLevel = 5
+H.FireEvent("ADDON_LOADED", "Nexus")
+H.FireEvent("SPELLS_CHANGED")
+H.FireEvent("PLAYER_ENTERING_WORLD")
+H.Advance(2)
+
+-- The 1.19.3 player build does not include the temporary developer sniffer.
+-- Its compatibility commands must not pause normal background ownership work.
+SlashCmdList["NEXUS"]("sniff")
+local countAfterSniffStart = 0
+H.Perks.probeCount = 0
+local realGetGranted = ProjectEbonhold.PerkService.GetGrantedPerks
+ProjectEbonhold.PerkService.GetGrantedPerks = function(...)
+    H.Perks.probeCount = H.Perks.probeCount + 1
+    return realGetGranted(...)
+end
+
+H.Advance(3)  -- several poll intervals worth of time
+assert(H.Perks.probeCount > 0,
+    "public /nexus sniff command paused normal ownership polling")
+local beforeDump = H.Perks.probeCount
+print("public build keeps polling active when /nexus sniff is requested")
+
+SlashCmdList["NEXUS"]("sniffdump")
+H.Advance(3)
+assert(H.Perks.probeCount > beforeDump,
+    "normal ownership polling stopped after /nexus sniffdump")
+print("public diagnostic compatibility commands never pause polling")

--- a/tests/run_sniffer.lua
+++ b/tests/run_sniffer.lua
@@ -1,0 +1,44 @@
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Relay.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/Readout.lua")
+dofile("ui/Panel.lua")
+local provider
+Nexus.LogViewer = { Init = function(p) provider = p end,
+    Show = function() end, Toggle = function() end }
+dofile("core/Main.lua")
+NexusDB = {}
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+} }
+H.playerLevel = 1
+H.FireEvent("ADDON_LOADED", "Nexus")
+H.FireEvent("SPELLS_CHANGED")
+H.FireEvent("PLAYER_ENTERING_WORLD")
+H.Advance(1)
+
+-- the target function already exists on PerkService (as it would in the
+-- real game) BEFORE the sniffer gets installed -- InstallSniffer can only
+-- hook what's already present on the table at call time
+ProjectEbonhold.PerkService.AddDesignedPerkStub = function(slot, spellId, quality)
+    return true
+end
+local original = ProjectEbonhold.PerkService.AddDesignedPerkStub
+
+SlashCmdList["NEXUS"]("sniff")
+
+-- simulate the real Echo Journal UI calling it
+ProjectEbonhold.PerkService.AddDesignedPerkStub(3, 200672, 1)
+
+local text = provider("sniffer")
+assert(ProjectEbonhold.PerkService.AddDesignedPerkStub == original,
+    "public command wrapped a protected service function")
+assert(not text:find("AddDesignedPerkStub%(3, 200672, 1%)"),
+    "temporary developer sniffer leaked into the 1.19.3 player build")
+print("public build leaves PerkService functions untouched -- OK")

--- a/tests/run_sniffer_table_dump.lua
+++ b/tests/run_sniffer_table_dump.lua
@@ -1,0 +1,50 @@
+-- Regression for the exact gap that hid UploadServerBuildSlot's echo
+-- data (2026-07-24): the sniffer used to print table arguments as a bare
+-- memory address ("table: 210720A8") instead of their contents.
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Relay.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/Readout.lua")
+dofile("ui/Panel.lua")
+local provider
+Nexus.LogViewer = { Init = function(p) provider = p end,
+    Show = function() end, Toggle = function() end }
+dofile("core/Main.lua")
+NexusDB = {}
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+} }
+H.playerLevel = 1
+H.FireEvent("ADDON_LOADED", "Nexus")
+H.FireEvent("SPELLS_CHANGED")
+H.FireEvent("PLAYER_ENTERING_WORLD")
+H.Advance(1)
+
+-- the target write function already exists on PerkService (as it would
+-- in the real game) before the sniffer is installed
+ProjectEbonhold.PerkService.UploadServerBuildSlot = function(slot, name, echoes)
+    return true
+end
+local original = ProjectEbonhold.PerkService.UploadServerBuildSlot
+
+SlashCmdList["NEXUS"]("sniff")
+
+-- simulate the real Echo Journal calling it with an actual echo table,
+-- exactly the shape a build-slot save would need
+ProjectEbonhold.PerkService.UploadServerBuildSlot(0, "Yoon", {
+    { spellId = 200672, quality = 1, stacks = 9 },
+    { spellId = 200100, quality = 3, stacks = 1 },
+})
+
+local text = provider("sniffer")
+assert(ProjectEbonhold.PerkService.UploadServerBuildSlot == original,
+    "public command replaced UploadServerBuildSlot")
+assert(not text:find("200672") and not text:find("stacks=9"),
+    "temporary argument sniffer exposed protected service payloads")
+print("public build does not wrap or dump protected service arguments -- OK")

--- a/tests/run_spacing_fix.lua
+++ b/tests/run_spacing_fix.lua
@@ -1,0 +1,107 @@
+-- Regression for the live "lock in failed: spacing" bug (2026-07-24).
+-- Root cause: A.RequestSlots() is a READ but stamped the same
+-- lastBuildOpAt guard that throttles WRITES. The background loop calls
+-- it every ~5s and the write guard is 3s, so a manual Lock In / Apply
+-- was refused roughly 60% of the time.
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+
+local A = Nexus.GameAdapter
+local clock = 1000
+GetTime = function() return clock end
+
+NexusDB = {}
+H.wishlist = { name = "W", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 } } }
+H.playerLevel = 5
+H.FireEvent("SPELLS_CHANGED")
+H.FireEvent("PLAYER_ENTERING_WORLD")
+
+local uploaded = nil
+ProjectEbonhold.PerkService.UploadServerBuildSlot = function(slot, name, echoes)
+    uploaded = { slot = slot, name = name, echoes = echoes }
+    return true
+end
+
+local echoes = { { spellId = 200100, quality = 3, stacks = 1 } }
+
+-- THE BUG: a read-only slot refresh immediately before a write must NOT
+-- block that write.
+clock = clock + 100
+A.RequestSlots()                       -- background refresh (a READ)
+clock = clock + 0.1                    -- essentially immediately after
+local ok, err = A.UploadWishlist(0, "Test", echoes)
+assert(ok, "a read-only RequestSlots() blocked a user-initiated write: " .. tostring(err))
+assert(uploaded, "upload never reached the server call")
+print("a background slot refresh no longer blocks a manual write -- OK")
+
+-- The genuine write-vs-write guard must still work (two real writes
+-- back-to-back are still correctly spaced).
+uploaded = nil
+local ok2, err2 = A.UploadWishlist(0, "Test2", echoes)
+assert(not ok2 and err2 == "spacing",
+    "two real writes back-to-back should still be spacing-guarded")
+print("genuine write-vs-write spacing protection still intact -- OK")
+
+-- ...and clears once enough time passes.
+clock = clock + 5
+local ok3 = A.UploadWishlist(0, "Test3", echoes)
+assert(ok3, "write should succeed once the spacing window has passed")
+print("write spacing correctly clears after the guard window -- OK")
+
+-- Simulate the REAL failure pattern: the background loop refreshing
+-- every 5s while the user clicks Lock In at an arbitrary moment. Before
+-- the fix this failed ~60% of the time; now it must always succeed.
+local failures = 0
+for i = 1, 40 do
+    clock = clock + 5
+    A.RequestSlots()                   -- background refresh tick
+    clock = clock + (i % 5) * 0.5      -- user clicks at varying offsets
+    local okN = A.UploadWishlist(0, "Repeated", echoes)
+    if not okN then failures = failures + 1 end
+    clock = clock + 5                  -- spacing clears before next iteration
+end
+assert(failures == 0,
+    failures .. "/40 manual writes were still blocked by background refreshes")
+print("40/40 manual writes succeed against a live background refresh loop -- OK")
+
+------------------------------------------------------------------------
+-- Safety net: even if a genuine collision happens (the automation just
+-- performed a real write), a user-initiated Lock In should RETRY rather
+-- than failing outright.
+------------------------------------------------------------------------
+dofile("ui/CommunityBuilds.lua")
+local CB = Nexus.CommunityBuilds
+CB.Init(A, Nexus.Model)
+
+NexusDB.communityBuilds = { ["b1"] = { id = "b1", title = "Retry Test",
+    description = "d", author = "Bob", class = "MAGE",
+    echoes = { { spellId = 200100, quality = 3, stacks = 1 } },
+    postedAt = 1, lastModified = 1, isMine = false } }
+CB.Show()
+CB.Select("b1")
+
+-- force a genuine collision: a real write immediately before
+clock = clock + 10
+A.UploadWishlist(0, "Occupier", echoes)
+uploaded = nil
+
+CB.LockInSelected()
+H.AcceptLastStaticPopup()
+assert(CB.IsLockInPending(), "a spacing collision should have queued a retry, not failed outright")
+assert(uploaded == nil, "should not have uploaded yet -- still spacing-blocked")
+print("a genuine spacing collision queues a retry instead of failing -- OK")
+
+-- let time pass and pump the retry
+clock = clock + 5
+CB._PumpPendingLockIn()
+assert(uploaded, "the queued retry never completed the upload")
+assert(uploaded.name == "Retry Test", "retry uploaded the wrong build")
+assert(not CB.IsLockInPending(), "pending state should clear after a successful retry")
+print("the queued retry completes automatically once the window clears -- OK")

--- a/tests/run_sync_advanced.lua
+++ b/tests/run_sync_advanced.lua
@@ -1,0 +1,103 @@
+-- Interleaved multi-build chunk reassembly, inflight timeout cleanup,
+-- and RebroadcastMine only sending your own builds.
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua")
+dofile("core/Sync.lua")
+local Codec, Sync = Nexus.Codec, Nexus.Sync
+
+NexusDB = {}
+UnitName = function() return "Alice" end
+local fakeTime = 100
+GetTime = function() return fakeTime end
+local function Pump(steps) for _ = 1, steps do fakeTime = fakeTime + 0.2; Sync.OnUpdate(0.2) end end
+Sync.Init(Codec, nil)
+
+-- 1. Two different builds, both multi-chunk, with their chunks
+-- interleaved in delivery order -- must reassemble independently.
+local buildA = { id = "A", title = "Build A", description = string.rep("alpha ", 40),
+    author = "Alice", class = "MAGE", echoes = { { spellId = 1, quality = 3, stacks = 1 } },
+    postedAt = 1000 }
+local buildB = { id = "B", title = "Build B", description = string.rep("bravo ", 40),
+    author = "Alice", class = "MAGE", echoes = { { spellId = 2, quality = 2, stacks = 1 } },
+    postedAt = 1000 }
+
+H.sentChatMessages = {}
+Sync.BroadcastBuild(buildA)
+Pump(30)
+local msgsA = H.sentChatMessages
+assert(#msgsA > 1, "test setup expects buildA to span multiple chunks")
+
+H.sentChatMessages = {}
+Sync.BroadcastBuild(buildB)
+Pump(30)
+local msgsB = H.sentChatMessages
+assert(#msgsB > 1, "test setup expects buildB to span multiple chunks")
+
+-- Receiving is opt-in: open a window before delivering anything.
+fakeTime = fakeTime + 10
+Sync.RequestSync()
+
+-- interleave: A1, B1, A2, B2, A3, B3, ...
+local maxLen = math.max(#msgsA, #msgsB)
+for i = 1, maxLen do
+    if msgsA[i] then Sync.HandleIncoming(msgsA[i].text, "Alice") end
+    if msgsB[i] then Sync.HandleIncoming(msgsB[i].text, "Alice") end
+end
+
+assert(NexusDB.communityBuilds["A"], "build A did not reassemble correctly when interleaved")
+assert(NexusDB.communityBuilds["B"], "build B did not reassemble correctly when interleaved")
+assert(NexusDB.communityBuilds["A"].title == "Build A")
+assert(NexusDB.communityBuilds["B"].title == "Build B")
+print("interleaved multi-build chunk transfers reassemble independently and correctly -- OK")
+
+-- 2. An incomplete transfer (missing chunks) must eventually be cleaned
+-- up, not leak forever.
+local buildA2 = { id = "A2", title = "Build A2", description = string.rep("alpha ", 40),
+    author = "Alice", class = "MAGE", echoes = { { spellId = 1, quality = 3, stacks = 1 } },
+    postedAt = 1000 }
+local buildB2 = { id = "B2", title = "Build B2", description = string.rep("bravo ", 40),
+    author = "Alice", class = "MAGE", echoes = { { spellId = 2, quality = 2, stacks = 1 } },
+    postedAt = 1000 }
+NexusDB = {}
+H.sentChatMessages = {}
+Sync.BroadcastBuild(buildA2)
+Pump(30)
+fakeTime = fakeTime + 10
+Sync.RequestSync()
+-- deliver only the FIRST chunk, never the rest
+Sync.HandleIncoming(H.sentChatMessages[1].text, "Alice")
+assert(not (NexusDB.communityBuilds and NexusDB.communityBuilds["A2"]),
+    "build should not be considered complete with only 1 of several chunks")
+-- advance fake time past the inflight timeout, then trigger cleanup via
+-- a harmless new incoming message (CleanupExpired runs on each chunked receive)
+fakeTime = fakeTime + 130
+H.sentChatMessages = {}
+Sync.BroadcastBuild(buildB2)
+Pump(30)
+Sync.RequestSync()
+for _, msg in ipairs(H.sentChatMessages) do Sync.HandleIncoming(msg.text, "Alice") end
+-- buildB2 should complete fine; buildA2's stale partial transfer should
+-- have been silently dropped rather than accumulating forever
+assert(NexusDB.communityBuilds["B2"], "buildB2 should complete normally after the timeout window")
+print("incomplete/expired transfers are cleaned up without blocking new ones -- OK")
+
+-- 3. Mesh rebroadcast sends every valid build held locally.
+NexusDB = { communityBuilds = {
+    ["mine-1"] = { id = "mine-1", title = "Mine", description = "d", author = "Alice",
+        class = "MAGE", echoes = { { spellId = 1, quality = 0, stacks = 1 } },
+        postedAt = 1, isMine = true },
+    ["theirs-1"] = { id = "theirs-1", title = "Theirs", description = "d", author = "Bob",
+        class = "ROGUE", echoes = { { spellId = 2, quality = 0, stacks = 1 } },
+        postedAt = 1, isMine = false },
+} }
+H.sentChatMessages = {}
+local n = Sync.BroadcastMine()
+assert(n >= 2, "BroadcastMine should redistribute both locally created and received builds")
+Pump(30)
+local indexCount = 0
+for _, msg in ipairs(H.sentChatMessages) do
+    if msg.text:find("^WLBI|") then indexCount = indexCount + 1 end
+    assert(not msg.text:find("^WLRB|"), "normal mesh rebroadcast leaked a full loadout")
+end
+assert(indexCount >= 2, "mesh rebroadcast must include indexes for locally created and received builds")
+print("BroadcastMine redistributes the compact valid build index -- OK")

--- a/tests/run_sync_autoshare.lua
+++ b/tests/run_sync_autoshare.lua
@@ -1,0 +1,137 @@
+-- Your own builds must auto-share on post AND on every edit, and those
+-- edits must actually PROPAGATE to a peer (not get silently dropped by
+-- the peer's dedup rule).
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua")
+dofile("core/Sync.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/CommunityBuilds.lua")
+
+local Codec, Sync = Nexus.Codec, Nexus.Sync
+local CB = Nexus.CommunityBuilds
+local clock = 1000
+GetTime = function() return clock end
+local wallclock = 50000
+time = function() return wallclock end
+UnitName = function() return "Alice" end
+
+NexusDB = {}
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+} }
+H.playerLevel = 5
+local Adapter = Nexus.GameAdapter
+CB.Init(Adapter, Nexus.Model)
+Sync.Init(Codec, Adapter)
+
+local function Drain()
+    for i = 1, 60 do Sync.OnUpdate(0.2) end
+    local m = H.sentChatMessages
+    H.sentChatMessages = {}
+    return m
+end
+H.sentChatMessages = {}
+
+-- 1. POST auto-shares
+local ok, id = CB.PostCurrentWishlist("Original Title", "Original description", H.wishlist)
+assert(ok, "post should succeed")
+local postMsgs = Drain()
+assert(#postMsgs > 0, "posting did not auto-share the build")
+print("posting auto-shares immediately -- OK")
+
+-- 2. EDIT auto-shares
+local ok2 = CB.EditBuild(id, "Edited Title", "Edited description")
+assert(ok2, "edit should succeed")
+local editMsgs = Drain()
+assert(#editMsgs > 0, "editing did not auto-share the updated build")
+print("editing auto-shares immediately -- OK")
+
+-- 3. UPDATE-FROM-WISHLIST auto-shares
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+    { spellId = 200102, quality = 2, stacks = 1 },
+} }
+-- 1.19.3 deliberately refuses to guess which designed wishlist is active.
+-- This test is about propagation, so provide the selected wishlist explicitly.
+local realWishlist = Adapter.Wishlist
+Adapter.Wishlist = function()
+    return { name=H.wishlist.name, class=H.wishlist.class, entries=H.wishlist.echoes }
+end
+local ok3, n = CB.UpdateFromWishlist(id)
+Adapter.Wishlist = realWishlist
+assert(ok3, "update-from-wishlist should succeed: " .. tostring(n))
+assert(n == 2, "should have captured the 2-echo wishlist, got " .. tostring(n))
+local updMsgs = Drain()
+assert(#updMsgs > 0, "update-from-wishlist did not auto-share")
+print("updating from your current wishlist auto-shares immediately -- OK")
+
+-- 4. CRITICAL: each successive edit must actually PROPAGATE to a peer.
+-- Peers reject anything not strictly newer, so if edits didn't bump the
+-- timestamp, edits 2+ would silently vanish. Replay all three onto a
+-- fresh "peer" and confirm the FINAL state wins.
+NexusDB = {}
+Sync.Init(Codec, Adapter)   -- fresh peer state
+clock = clock + 10
+Sync.RequestSync()
+for _, m in ipairs(postMsgs) do Sync.HandleIncoming(m.text, "Alice") end
+for _, m in ipairs(editMsgs) do Sync.HandleIncoming(m.text, "Alice") end
+for _, m in ipairs(updMsgs) do Sync.HandleIncoming(m.text, "Alice") end
+
+local peerCopy = NexusDB.communityBuilds[id]
+assert(peerCopy, "peer never received the build at all")
+assert(peerCopy.title == "Edited Title",
+    "peer did not receive the EDITED title -- edits are not propagating (got '" .. tostring(peerCopy.title) .. "')")
+assert(peerCopy.echoCount == 2,
+    "peer did not receive the UPDATED Echo count -- later edits are being dropped by dedup")
+assert(not peerCopy.echoes or #peerCopy.echoes == 0,
+    "automatic build sync should not include the full Echo list")
+local count = 0
+for _ in pairs(NexusDB.communityBuilds) do count = count + 1 end
+assert(count == 1, "edits created duplicate entries instead of updating in place (got " .. count .. ")")
+print("every successive edit propagates to peers, in place, with no duplicates -- OK")
+
+-- 5. Editing/updating someone ELSE'S build must be refused
+NexusDB.communityBuilds["theirs"] = { id = "theirs", title = "Theirs",
+    description = "d", author = "Bob", class = "ROGUE",
+    echoes = { { spellId = 1, quality = 0, stacks = 1 } },
+    postedAt = 1, lastModified = 1, isMine = false }
+local okE, errE = CB.EditBuild("theirs", "Hijacked", "nope")
+assert(not okE, "editing someone else's build must be refused")
+local okU, errU = CB.UpdateFromWishlist("theirs")
+assert(not okU, "updating someone else's build must be refused")
+assert(NexusDB.communityBuilds["theirs"].title == "Theirs",
+    "someone else's build was modified anyway")
+print("editing/updating another player's build is correctly refused -- OK")
+
+-- 6. Answering a peer's sync request shares the full valid mesh library
+H.sentChatMessages = {}
+clock = clock + 100
+Sync.HandleIncoming("WLRQ|Bob", "Bob")
+local answer = Drain()
+assert(#answer > 0, "a peer's sync request went unanswered -- nobody would ever receive anything")
+local indexes = 0
+local fullBuilds = 0
+for _, m in ipairs(answer) do
+    if m.text:find("^WLBI|") then indexes = indexes + 1 end
+    if m.text:find("^WLRB|") then fullBuilds = fullBuilds + 1 end
+end
+assert(indexes + fullBuilds >= 2,
+    "answering a request must redistribute every valid mesh build")
+print("answering a peer request redistributes complete valid mesh builds -- OK")
+
+-- 7. We must never answer our OWN request (would echo endlessly)
+H.sentChatMessages = {}
+clock = clock + 100
+Sync.HandleIncoming("WLRQ|Alice", "Alice")
+local selfAnswer = Drain()
+for _, m in ipairs(selfAnswer) do
+    assert(not m.text:find("^WLRC|") and not m.text:find("^WLBI|") and not m.text:find("^WLRB|"),
+        "the addon answered its own sync request -- would cause an echo loop")
+end
+print("own sync requests are correctly ignored (no echo loop) -- OK")

--- a/tests/run_sync_basic.lua
+++ b/tests/run_sync_basic.lua
@@ -1,0 +1,53 @@
+-- Basic Sync lifecycle: channel discovery/join, and a small single-chunk
+-- build broadcast/receive round trip end to end.
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua")
+dofile("core/Sync.lua")
+
+local Codec = Nexus.Codec
+local Sync = Nexus.Sync
+
+NexusDB = {}
+UnitName = function() return "Alice" end
+GetTime = function() return 100 end
+
+-- channel not joined yet
+assert(not Sync.IsConnected(), "should not be connected before EnsureChannel")
+Sync.Init(Codec, nil)
+assert(Sync.IsConnected(), "Sync.Init should have joined the channel")
+print("channel discovery/join works -- OK")
+
+-- broadcast a small build (fits in a single chunk)
+local build = { id = "mine-1", title = "Fire Mage AoE", description = "Great farm build",
+    author = "Alice", class = "MAGE", echoes = {
+        { spellId = 200100, quality = 3, stacks = 1 },
+    }, postedAt = 1000 }
+local ok = Sync.BroadcastBuild(build)
+assert(ok, "BroadcastBuild should have succeeded for a small build")
+
+-- pump the send queue until the message actually goes out
+for i = 1, 20 do Sync.OnUpdate(0.2) end
+assert(#H.sentChatMessages >= 1, "no chat message was actually sent")
+local sentText = H.sentChatMessages[1].text
+assert(H.sentChatMessages[1].kind == "CHANNEL", "message should be sent to CHANNEL")
+print("BroadcastBuild sends a real chat message via the sync channel -- OK")
+
+-- Now simulate a DIFFERENT client (Bob) receiving that exact message.
+-- This build spans more than one chunk, so feed ALL queued messages
+-- through in order, exactly as CHAT_MSG_CHANNEL would deliver each one.
+NexusDB = {}  -- fresh DB, as if this were Bob's client
+-- Receiving is opt-in now: Bob must have requested a sync for incoming
+-- builds to be accepted at all.
+assert(Sync.RequestSync(), "RequestSync should succeed")
+assert(Sync.IsReceiving(), "receive window should be open after RequestSync")
+for _, msg in ipairs(H.sentChatMessages) do
+    Sync.HandleIncoming(msg.text, "Alice")
+end
+
+local stored = NexusDB.communityBuilds and NexusDB.communityBuilds["mine-1"]
+assert(stored, "received build was not stored")
+assert(stored.title == "Fire Mage AoE", "wrong title received")
+assert(stored.description == "Great farm build", "wrong description received")
+assert(#stored.echoes == 1 and stored.echoes[1].spellId == 200100, "wrong echoes received")
+assert(stored.isMine == false, "a received build must never be tagged isMine")
+print("a broadcast build is correctly received, decoded, and stored by another client -- OK")

--- a/tests/run_sync_cold_start_complete.lua
+++ b/tests/run_sync_cold_start_complete.lua
@@ -1,0 +1,40 @@
+-- 1.19.3 cold-start reconciliation sends complete builds so a fresh peer is
+-- usable immediately and never depends on the original author remaining online.
+local H=dofile('tests/harness.lua')
+dofile('core/Codec.lua'); dofile('core/Sync.lua'); dofile('core/DpsCapture.lua')
+local Sync=Nexus.Sync
+local clock=1000; GetTime=function() return clock end; time=function() return 50000 end
+local who='Author'; UnitName=function() return who end
+local function Pump(steps) for _=1,steps do clock=clock+0.2; Sync.OnUpdate(0.2) end end
+local echoes={}; for i=1,79 do echoes[i]={spellId=200000+i,stacks=1,quality=3} end
+local build={id='cold-build',title='Gnome Army',description='full guide',author='Author',
+    ownerKey='author@ebonhold',class='MAGE',echoes=echoes,postedAt=10,lastModified=10,isMine=true}
+
+NexusDB={communityBuilds={[build.id]=build},syncTombstones={},dpsCapture={}}
+Sync.Init(Nexus.Codec,{})
+H.sentChatMessages={}
+Sync.HandleIncoming('WLRQ|Fresh|0|0|cold-req','Fresh')
+Pump(260)
+local response={}; local chunks=0
+for _,m in ipairs(H.sentChatMessages) do
+    if m.text:find('^WLRB') then chunks=chunks+1; response[#response+1]=m end
+    assert(#m.text<=255,'wire message exceeds WoW limit')
+end
+assert(chunks>0,'cold-start reconciliation did not send the complete build')
+
+who='Fresh'; NexusDB={communityBuilds={},syncTombstones={},dpsCapture={}}
+clock=2000; Sync.Init(Nexus.Codec,{})
+for _,m in ipairs(response) do Sync.HandleIncoming(m.text,'Author') end
+local loaded=NexusDB.communityBuilds['cold-build']
+assert(loaded and loaded.echoes and #loaded.echoes==79 and loaded.description=='full guide',
+    'fresh client did not receive the complete build')
+assert(loaded.ownerVerified==true,'direct author build was not marked owner-verified')
+
+-- Once hashes match, another request produces no duplicate build payload.
+H.sentChatMessages={}; clock=clock+100
+local request=Sync.RequestSync(); assert(request,'follow-up reconciliation did not start')
+Pump(10)
+for _,m in ipairs(H.sentChatMessages) do
+    assert(not m.text:find('^WLRB'),'matching local state queued a duplicate full build')
+end
+print('cold-start complete-build reconciliation and owner verification -- OK')

--- a/tests/run_sync_completion_compat.lua
+++ b/tests/run_sync_completion_compat.lua
@@ -1,0 +1,38 @@
+-- The compatibility hashes must exactly reflect current build/DPS state and
+-- suppress duplicate reconciliation without changing any data.
+local H=dofile('tests/harness.lua')
+dofile('core/Codec.lua'); dofile('core/Sync.lua'); dofile('core/DpsCapture.lua')
+local Sync,DPS=Nexus.Sync,Nexus.DpsCapture
+local clock=1000; GetTime=function() return clock end; time=function() return 50000 end
+UnitName=function() return 'Valentine' end; UnitClass=function() return 'Mage','MAGE' end
+GetNormalizedRealmName=function() return 'Ebonhold' end
+local function Pump(seconds) for _=1,math.ceil(seconds/0.2) do clock=clock+0.2; Sync.OnUpdate(0.2) end end
+local echoes={{spellId=200101,stacks=1}}
+local build={id='compat-build',title='Compat',author='Valentine',ownerKey='valentine@ebonhold',
+    class='MAGE',echoes=echoes,lastModified=101,postedAt=101,isMine=true}
+NexusDB={communityBuilds={[build.id]=build},syncTombstones={},dpsCapture={}}
+Sync.Init(Nexus.Codec,{}); DPS.Init({},Sync)
+Pump(100); H.sentChatMessages={}
+local b1,d1=Sync.GetCompatibilityHashes()
+local b2,d2=Sync.GetCompatibilityHashes()
+assert(b1==b2 and d1==d2,'compatibility hashes were nondeterministic')
+
+H.sentChatMessages={}
+Sync.HandleIncoming('WLRQ|Current|'..b1..'|'..d1..'|same-state','Current')
+Pump(8)
+assert(#H.sentChatMessages==0,'matching compatibility hashes produced duplicate traffic')
+
+build.lastModified=102
+local b3,d3=Sync.GetCompatibilityHashes()
+assert(b3~=b1 and d3==d1,'build-only change did not isolate the build hash')
+
+local fp,hash=DPS.GetEchoKey(echoes),DPS.GetEchoHash(echoes)
+assert(DPS.ReceiveRecord({v=7,f=fp,h=hash,e=echoes,c='dummy',d=25000000,u=60,t=49000,
+    p='Valentine',k='MAGE',o='valentine@ebonhold',r='ebonhold',l=80,b=build.id},'Valentine'))
+local b4,d4=Sync.GetCompatibilityHashes()
+assert(b4==b3 and d4~=d3,'DPS-only change did not isolate the DPS hash')
+
+Sync.Init(Nexus.Codec,{})
+local b5,d5=Sync.GetCompatibilityHashes()
+assert(b5==b4 and d5==d4,'reinitialization changed compatibility hashes')
+print('deterministic build/DPS compatibility hashes and duplicate suppression -- OK')

--- a/tests/run_sync_dedup.lua
+++ b/tests/run_sync_dedup.lua
@@ -1,0 +1,94 @@
+-- Verifies the core correctness requirement: no duplicates, correct
+-- update-vs-stale handling, and safe rejection of malformed data.
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua")
+dofile("core/Sync.lua")
+local Codec, Sync = Nexus.Codec, Nexus.Sync
+
+NexusDB = {}
+UnitName = function() return "Alice" end
+fakeClock = 100
+GetTime = function() return fakeClock end
+Sync.Init(Codec, nil)
+
+local function BroadcastAndCollect(build)
+    H.sentChatMessages = {}
+    Sync.BroadcastBuild(build)
+    for i = 1, 30 do Sync.OnUpdate(0.2) end
+    return H.sentChatMessages
+end
+
+-- Receiving is opt-in: every delivery in these tests happens inside an
+-- explicitly-opened receive window, since that's the only state in which
+-- builds are accepted at all.
+local function DeliverAll(msgs)
+    fakeClock = (fakeClock or 100) + 10   -- clear the request cooldown
+    Sync.RequestSync()
+    for _, msg in ipairs(msgs) do Sync.HandleIncoming(msg.text, "Alice") end
+end
+
+-- 1. Sending the exact same build twice must NOT create a duplicate or
+-- double-count as newly received.
+NexusDB = {}
+local build = { id = "b1", title = "Build One", description = "d", author = "Alice",
+    class = "MAGE", echoes = { { spellId = 200100, quality = 3, stacks = 1 } }, postedAt = 1000 }
+DeliverAll(BroadcastAndCollect(build))
+local receivedAfterFirst = Sync.Stats().received
+DeliverAll(BroadcastAndCollect(build))  -- identical rebroadcast
+assert(Sync.Stats().received == receivedAfterFirst,
+    "identical rebroadcast should NOT count as a new receive")
+assert(Sync.Stats().duplicatesSkipped >= 1, "duplicate rebroadcast should be counted as skipped")
+local count = 0
+for _ in pairs(NexusDB.communityBuilds) do count = count + 1 end
+assert(count == 1, "expected exactly 1 stored build after receiving the same one twice, got " .. count)
+print("identical rebroadcast is correctly deduplicated, no double-entry -- OK")
+
+-- 2. A NEWER version of the same build (higher postedAt) must update the
+-- stored copy.
+local buildV2 = { id = "b1", title = "Build One (updated)", description = "d2", author = "Alice",
+    class = "MAGE", echoes = { { spellId = 200100, quality = 3, stacks = 2 } }, postedAt = 2000 }
+DeliverAll(BroadcastAndCollect(buildV2))
+assert(NexusDB.communityBuilds["b1"].title == "Build One (updated)",
+    "newer version should have updated the stored title")
+assert(NexusDB.communityBuilds["b1"].echoes[1].stacks == 2,
+    "newer version should have updated the stored echoes")
+count = 0
+for _ in pairs(NexusDB.communityBuilds) do count = count + 1 end
+assert(count == 1, "update should replace, not add a second entry")
+print("a newer version correctly updates the existing entry, still no duplicate -- OK")
+
+-- 3. An OLDER/stale rebroadcast must NOT overwrite the newer stored copy
+-- (protects against a stale peer's old data clobbering something newer).
+local staleReplay = { id = "b1", title = "Build One (STALE)", description = "old", author = "Alice",
+    class = "MAGE", echoes = { { spellId = 200100, quality = 3, stacks = 1 } }, postedAt = 1000 }
+DeliverAll(BroadcastAndCollect(staleReplay))
+assert(NexusDB.communityBuilds["b1"].title == "Build One (updated)",
+    "a stale/older replay must NOT overwrite the newer stored version")
+print("stale/older replays are correctly rejected, newer data is protected -- OK")
+
+-- 4. Malformed payloads must be safely rejected, never crash, never stored.
+NexusDB = {}
+local before = Sync.Stats().malformedRejected
+local ok1 = pcall(Sync.HandleIncoming, "WLRB|Alice|bad-id|1000|1/1|not-valid-base64!!!", "Alice")
+assert(ok1, "malformed base64 payload should not error")
+assert(NexusDB.communityBuilds == nil or NexusDB.communityBuilds["bad-id"] == nil,
+    "malformed payload must not be stored")
+local ok2 = pcall(Sync.HandleIncoming, "garbage that is not our protocol at all", "Mallory")
+assert(ok2, "unrecognized message format should not error")
+local ok3 = pcall(Sync.HandleIncoming, "WLRB|Alice|bad-id2|1000|1/1|" .. Codec.Base64Encode("not json{{{"), "Alice")
+assert(ok3, "valid base64 but invalid JSON should not error")
+assert(Sync.Stats().malformedRejected > before, "malformed payloads should be counted as rejected")
+print("malformed/malicious payloads are safely rejected without crashing or storing -- OK")
+
+-- 5. A build claiming a mismatched id (payload.id != the id in the
+-- envelope) must be rejected -- prevents a peer from spoofing envelope
+-- routing while smuggling a different id inside the payload.
+NexusDB = {}
+local spoofPayload = Codec.JSONEncode({ id = "real-id", title = "T", echoes = {
+    { spellId = 1, quality = 0, stacks = 1 } } })
+local spoofB64 = Codec.Base64Encode(spoofPayload)
+Sync.HandleIncoming("WLRB|Alice|different-envelope-id|1000|1/1|" .. spoofB64, "Alice")
+assert(NexusDB.communityBuilds == nil or
+    NexusDB.communityBuilds["different-envelope-id"] == nil,
+    "mismatched envelope/payload id must be rejected, not silently accepted")
+print("mismatched envelope/payload id is correctly rejected -- OK")

--- a/tests/run_sync_delete_update.lua
+++ b/tests/run_sync_delete_update.lua
@@ -1,0 +1,158 @@
+-- Covers the three issues seen live (2026-07-24):
+--   1. A build deleted by its author lingered forever on other clients.
+--   2. Updates needed to be clearly distinguishable from duplicates.
+--   3. Nothing may ever appear twice in the library.
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua")
+dofile("core/Sync.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Relay.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/Readout.lua")
+dofile("ui/Panel.lua")
+local provider
+Nexus.LogViewer = { Init = function(p) provider = p end,
+    Show = function() end, Toggle = function() end }
+dofile("ui/CommunityBuilds.lua")
+dofile("core/Main.lua")
+
+local Codec, Sync = Nexus.Codec, Nexus.Sync
+local CB = Nexus.CommunityBuilds
+local clock = 1000
+GetTime = function() return clock end
+local wall = 50000
+time = function() return wall end
+UnitName = function() return "Solkr" end
+
+NexusDB = {}
+H.playerLevel = 5
+H.wishlist = { name = "W", class = "ROGUE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 } } }
+H.FireEvent("ADDON_LOADED", "Nexus")
+H.FireEvent("SPELLS_CHANGED")
+H.FireEvent("PLAYER_ENTERING_WORLD")
+H.Advance(2)
+
+local function Deliver(msgs, fromName)
+    for _, m in ipairs(msgs) do
+        H.FireEvent("CHAT_MSG_CHANNEL", m.text, fromName, "Common",
+            "5. " .. Sync.ChannelName(), nil, nil, nil, 5, Sync.ChannelName())
+    end
+end
+local function Drain()
+    H.Advance(4)
+    local m = {}
+    for _, x in ipairs(H.sentChatMessages) do m[#m + 1] = x end
+    H.sentChatMessages = {}
+    return m
+end
+
+-- Author (Solkr) posts a build
+H.sentChatMessages = {}
+local ok, id = CB.PostCurrentWishlist("Rogue Double Strike", "the good one", H.wishlist)
+assert(ok, "post failed")
+local postMsgs = Drain()
+
+-- Now act as the RECEIVING client: clear the library, receive it fresh
+NexusDB.communityBuilds = nil
+Sync.ClearLog()
+clock = clock + 10
+Sync.RequestSync()
+Deliver(postMsgs, "Solkr")
+local lib = NexusDB.communityBuilds
+assert(lib and lib[id], "build was not received")
+assert(lib[id].isMine == false, "a received build must not be marked mine")
+print("build received from author -- OK")
+
+local receiverBeforeEdit = {}
+for k, v in pairs(lib[id]) do receiverBeforeEdit[k] = v end
+receiverBeforeEdit.isMine = false
+
+-- 1. UPDATE must be logged as an update, not a duplicate, and must not
+--    create a second entry.
+wall = wall + 100
+UnitName = function() return "Solkr" end
+-- rebuild the author's copy so we can edit and re-share it
+NexusDB.communityBuilds[id].isMine = true
+CB.EditBuild(id, "Rogue Double Strike v2", "now even better")
+local editMsgs = Drain()
+-- Restore the receiver's older copy before delivering the author's update.
+NexusDB.communityBuilds[id] = receiverBeforeEdit
+
+Sync.ClearLog()
+clock = clock + 10
+Sync.RequestSync()
+Deliver(editMsgs, "Solkr")
+local text = provider("sync")
+assert(text:find("UPDATED") or text:find("DUPLICATE"), "updated build was neither accepted nor recognized as already current")
+assert(NexusDB.communityBuilds[id].title == "Rogue Double Strike v2",
+    "the update did not actually apply")
+local count = 0
+for _ in pairs(NexusDB.communityBuilds) do count = count + 1 end
+assert(count == 1, "the update created a duplicate entry (" .. count .. " entries)")
+print("an update is logged as UPDATED, applies in place, creates no duplicate -- OK")
+
+-- 2. Re-delivering the SAME version must log DUPLICATE, not update
+Sync.ClearLog()
+clock = clock + 10
+Sync.RequestSync()
+Deliver(editMsgs, "Solkr")
+text = provider("sync")
+assert(text:find("DUPLICATE"), "a replay of the same version was not logged as DUPLICATE")
+count = 0
+for _ in pairs(NexusDB.communityBuilds) do count = count + 1 end
+assert(count == 1, "a duplicate replay created a second entry")
+print("re-delivering the same version logs DUPLICATE, still one entry -- OK")
+
+-- 3. DELETE from the author must remove it here
+Sync.ClearLog()
+clock = clock + 10
+H.FireEvent("CHAT_MSG_CHANNEL", "WLRD||Solkr||" .. id .. "||99999",
+    "Solkr", "Common", "5. " .. Sync.ChannelName(), nil, nil, nil, 5, Sync.ChannelName())
+assert(NexusDB.communityBuilds[id] == nil,
+    "the author's delete did not remove the build -- it would linger forever")
+text = provider("sync")
+assert(text:find("DELETED"), "the delete was not logged")
+print("a delete from the author removes the build here too -- OK")
+
+-- 4. A tombstoned build must NOT come back on the next sync
+Sync.ClearLog()
+clock = clock + 10
+Sync.RequestSync()
+Deliver(editMsgs, "Solkr")
+assert(NexusDB.communityBuilds[id] == nil,
+    "a deleted build was resurrected by a stale copy still in flight")
+text = provider("sync")
+assert(text:find("tombstoned"), "the tombstone rejection was not logged")
+print("a deleted build stays deleted, even if a stale copy arrives later -- OK")
+
+-- 5. A delete from someone who is NOT the author must be REFUSED
+NexusDB.communityBuilds = { ["victim"] = { id = "victim",
+    title = "Someone Else's Build", description = "d", author = "Solkr",
+    class = "ROGUE", echoes = { { spellId = 1, quality = 0, stacks = 1 } },
+    postedAt = 1, lastModified = 1, isMine = false } }
+Sync.ClearLog()
+H.FireEvent("CHAT_MSG_CHANNEL", "WLRD||Griefer||victim||99999",
+    "Griefer", "Common", "5. " .. Sync.ChannelName(), nil, nil, nil, 5, Sync.ChannelName())
+assert(NexusDB.communityBuilds["victim"],
+    "a non-author was allowed to delete someone else's shared build")
+text = provider("sync")
+assert(text:find("is not the author"), "the refused delete was not logged with a reason")
+print("a delete from a non-author is refused and logged -- OK")
+
+-- 6. Nobody can delete YOUR OWN build out from under you
+NexusDB.communityBuilds = { ["mine"] = { id = "mine", title = "My Build",
+    description = "d", author = "Solkr", class = "ROGUE",
+    echoes = { { spellId = 1, quality = 0, stacks = 1 } },
+    postedAt = 1, lastModified = 1, isMine = true } }
+Sync.ClearLog()
+H.FireEvent("CHAT_MSG_CHANNEL", "WLRD||Solkr||mine||99999",
+    "Solkr", "Common", "5. " .. Sync.ChannelName(), nil, nil, nil, 5, Sync.ChannelName())
+assert(NexusDB.communityBuilds["mine"],
+    "an incoming delete removed one of MY OWN builds")
+print("incoming deletes can never remove your own builds -- OK")

--- a/tests/run_sync_index_on_demand.lua
+++ b/tests/run_sync_index_on_demand.lua
@@ -1,0 +1,46 @@
+-- Current peers reconcile complete builds; compact indexes remain a safe
+-- compatibility path for an older summary-only peer.
+local H=dofile('tests/harness.lua')
+dofile('core/Codec.lua'); dofile('core/Sync.lua'); dofile('core/DpsCapture.lua')
+local Sync=Nexus.Sync
+local clock=1000; GetTime=function() return clock end; time=function() return 50000 end
+local function Pump(steps) for _=1,steps do clock=clock+0.2; Sync.OnUpdate(0.2) end end
+local who='Source'; UnitName=function() return who end
+local echoes={}; for i=1,79 do echoes[i]={spellId=200000+i,stacks=(i%3)+1,quality=3} end
+local build={id='build-79',title='Full Record Build',description=string.rep('description ',50),
+    author='Source',ownerKey='source@ebonhold',class='MAGE',echoes=echoes,
+    postedAt=10,lastModified=10,isMine=true}
+NexusDB={communityBuilds={[build.id]=build},syncTombstones={},dpsCapture={}}
+Sync.Init(Nexus.Codec,{}); Nexus.DpsCapture.Init({},Sync)
+
+H.sentChatMessages={}
+Sync.HandleIncoming('WLRQ|Receiver|0|0|req-current','Receiver')
+Pump(300)
+local complete={}; for _,m in ipairs(H.sentChatMessages) do
+    if m.text:find('^WLRB') then complete[#complete+1]=m end
+    assert(#m.text<=255,'full-loadout chunk exceeded 255 chars')
+end
+assert(#complete>1,'complete 79-Echo reconciliation was not chunked')
+
+who='Receiver'; NexusDB={communityBuilds={},syncTombstones={},dpsCapture={}}
+clock=1200; Sync.Init(Nexus.Codec,{})
+for _,m in ipairs(complete) do Sync.HandleIncoming(m.text,'Source') end
+local loaded=NexusDB.communityBuilds['build-79']
+assert(loaded and loaded.echoes and #loaded.echoes==79,'complete loadout did not reassemble')
+assert(loaded.description:find('description'),'full description was not restored')
+
+-- Legacy compact summaries are accepted only from their direct author and
+-- remain explicitly incomplete until a background recovery succeeds.
+who='Source'; NexusDB={communityBuilds={[build.id]=build},syncTombstones={},dpsCapture={}}
+clock=1400; Sync.Init(Nexus.Codec,{})
+H.sentChatMessages={}; assert(Sync.BroadcastBuildSummary(build)); Pump(10)
+local summaries=H.sentChatMessages
+who='Receiver'; NexusDB={communityBuilds={},syncTombstones={},dpsCapture={}}
+Sync.Init(Nexus.Codec,{})
+for _,m in ipairs(summaries) do Sync.HandleIncoming(m.text,'Source') end
+local placeholder=NexusDB.communityBuilds['build-79']
+assert(placeholder and not placeholder.loadoutAvailable and not placeholder.echoes,
+    'legacy summary was incorrectly treated as exact evidence')
+local immediate,why=Sync.RequestLoadout('build-79')
+assert(not immediate and why,'legacy recovery request did not remain background-only')
+print('complete current sync and safe legacy-summary compatibility -- OK')

--- a/tests/run_sync_integration.lua
+++ b/tests/run_sync_integration.lua
@@ -1,0 +1,64 @@
+-- Full integration: posting a build through the real CommunityBuilds UI
+-- actually broadcasts via Sync, and CHAT_MSG_CHANNEL events get routed
+-- to Sync.HandleIncoming only when they're really our sync channel (not
+-- some unrelated channel a player happens to be in).
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua")
+dofile("core/Sync.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Relay.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/Readout.lua")
+dofile("ui/Panel.lua")
+Nexus.LogViewer = { Init = function() end }
+dofile("ui/CommunityBuilds.lua")
+dofile("core/Main.lua")
+
+NexusDB = {}
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+} }
+H.playerLevel = 5
+UnitName = function() return "Alice" end
+
+H.FireEvent("ADDON_LOADED", "Nexus")
+H.FireEvent("SPELLS_CHANGED")
+H.FireEvent("PLAYER_ENTERING_WORLD")
+H.Advance(2)
+
+assert(Nexus.Sync.IsConnected(), "sync channel should be connected after PLAYER_ENTERING_WORLD")
+print("sync channel connects automatically on login -- OK")
+
+-- Post through the real UI-facing function
+local CB = Nexus.CommunityBuilds
+local ok, id = CB.PostCurrentWishlist("My Shared Build", "Check this out", H.wishlist)
+assert(ok, "posting should succeed")
+H.Advance(3)  -- let the send queue pump
+assert(#H.sentChatMessages >= 1, "posting did not actually broadcast anything")
+print("posting a wishlist through the real UI genuinely broadcasts it -- OK")
+
+-- Simulate CHAT_MSG_CHANNEL from an UNRELATED channel -- must be ignored
+local before = Nexus.Sync.Stats().received
+local sentMsg = H.sentChatMessages[1].text
+H.FireEvent("CHAT_MSG_CHANNEL", sentMsg, "Alice", "Common", "general")
+assert(Nexus.Sync.Stats().received == before,
+    "a message from an unrelated channel must NOT be processed as sync data")
+print("messages from unrelated channels are correctly ignored -- OK")
+
+-- Now simulate it arriving on the REAL sync channel (as another client
+-- receiving Alice's broadcast) -- must be processed
+NexusDB.communityBuilds = nil  -- pretend this is Bob's fresh client
+-- Receiving is opt-in: Bob must request a sync first.
+Nexus.Sync.RequestSync()
+for _, msg in ipairs(H.sentChatMessages) do
+    H.FireEvent("CHAT_MSG_CHANNEL", msg.text, "Alice", "Common", Nexus.Sync.ChannelName())
+end
+assert(NexusDB.communityBuilds and NexusDB.communityBuilds[id],
+    "a message on the real sync channel should have been processed and stored")
+assert(NexusDB.communityBuilds[id].title == "My Shared Build")
+print("messages on the real sync channel are correctly processed end-to-end -- OK")

--- a/tests/run_sync_late_post.lua
+++ b/tests/run_sync_late_post.lua
@@ -1,0 +1,110 @@
+-- Regression: build posted on A AFTER B's receive window closed must be
+-- received when B syncs again (the "Fire Mage not received" live bug).
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua"); dofile("core/Sync.lua")
+local Codec, Sync = Nexus.Codec, Nexus.Sync
+local clock = 1000; GetTime = function() return clock end
+local wall = 50000; time = function() return wall end
+UnitName = function() return "explore" end
+
+local function deliver(chunks)
+    for _,m in ipairs(chunks) do Sync.HandleIncoming(m.text, "explore") end
+end
+local function drain()
+    for i=1,60 do clock=clock+0.2; Sync.OnUpdate(0.2) end
+    local out={}; for _,m in ipairs(H.sentChatMessages) do out[#out+1]=m end
+    H.sentChatMessages={}; return out
+end
+
+local rogueB = {id="r1",title="Rogue ST",author="explore",class="ROGUE",
+    echoes={{spellId=200100,quality=3,stacks=1}},postedAt=50000,lastModified=50000,isMine=true}
+local mageB  = {id="m1",title="Fire Mage",author="explore",class="MAGE",
+    echoes={{spellId=200044,quality=3,stacks=1}},postedAt=50100,lastModified=50100,isMine=true}
+
+-- 1. Both builds received in a single sync
+NexusDB = { communityBuilds={}, syncTombstones={} }
+Sync.Init(Codec, nil)
+H.sentChatMessages={}
+Sync.BroadcastBuild(rogueB); Sync.BroadcastBuild(mageB)
+local allChunks = drain()
+assert(#allChunks > 0, "no chunks produced")
+Sync.RequestSync()
+deliver(allChunks)
+assert(NexusDB.communityBuilds["r1"], "rogue not received in single sync")
+assert(NexusDB.communityBuilds["m1"], "mage not received in single sync")
+print("both builds received in a single sync -- OK")
+
+-- 2. Late post: mage posted after B's window closed, received on 2nd sync
+NexusDB = { communityBuilds={}, syncTombstones={} }
+Sync.Init(Codec, nil)
+
+-- Rogue broadcast (will be "hot")
+H.sentChatMessages={}
+Sync.BroadcastBuild(rogueB)
+local rogueChunks = drain()
+-- B opens window, receives rogue
+Sync.RequestSync()
+deliver(rogueChunks)
+assert(NexusDB.communityBuilds["r1"], "rogue not received on 1st sync")
+
+-- Window expires
+clock = clock + 70
+assert(not Sync.IsReceiving(), "window should be closed")
+
+-- Mage posted now. Valid direct-author updates are accepted even when the
+-- manual-sync status window is closed; the window is diagnostics, not trust.
+wall = wall + 100
+H.sentChatMessages={}
+Sync.BroadcastBuild(mageB)  -- marks mageB hot
+local mageChunks = drain()
+deliver(mageChunks)
+assert(NexusDB.communityBuilds["m1"],
+    "valid direct-author mage build was dropped outside the status window")
+
+-- B presses Sync Now again
+clock = clock + 10
+Sync.RequestSync()
+-- Simulate A answering: BroadcastMine includes hot mageB
+NexusDB.communityBuilds["r1"] = rogueB  -- A has rogue in its DB
+H.sentChatMessages={}
+local n = Sync.BroadcastMine()
+local answer2 = drain()
+NexusDB.communityBuilds["r1"] = nil  -- restore B's view
+assert(n >= 2, "BroadcastMine should include hot mage: got "..n)
+print("BroadcastMine answers 2nd sync with "..n.." builds ("..#answer2.." chunks) -- OK")
+
+deliver(answer2)
+assert(NexusDB.communityBuilds["m1"],
+    "mage must arrive on B's 2nd sync -- this was the live bug")
+print("late direct-author build remains available across the next sync -- OK")
+
+-- 3. Library hash: peer with same build set gets nothing
+NexusDB = { communityBuilds={
+    ["r1"]={id="r1",title="Rogue ST",author="explore",class="ROGUE",
+            echoes={{spellId=200100,quality=3,stacks=1}},
+            postedAt=50000,lastModified=50000,isMine=true}
+}, syncTombstones={} }
+Sync.Init(Codec, nil)
+Sync.ClearLog()
+H.sentChatMessages={}
+
+-- Compute the same hash the answering side would compute
+local function bucketHash(builds)
+    local buckets={}; for i=1,8 do buckets[i]={} end
+    local function bucket(id) local h=5381; for i=1,#id do h=((h*33)+id:byte(i))%2147483648 end; return (h%8)+1 end
+    for id,b in pairs(builds) do local n=bucket(id); local complete=(type(b.echoes)=="table" and #b.echoes>0) and "F" or "S"; local fp=tostring(b.fingerprintHash or b.fingerprint or "0"); buckets[n][#buckets[n]+1]=id..":"..tostring(b.lastModified or b.postedAt or 0)..":"..complete..":"..fp end
+    local out={}
+    for n=1,8 do
+        table.sort(buckets[n]); local h=5381
+        for _,text in ipairs(buckets[n]) do for i=1,#text do h=((h*33)+text:byte(i))%2147483648 end end
+        out[n]=#buckets[n]>0 and string.format("%x",h) or "0"
+    end
+    return table.concat(out,",")
+end
+-- Hash that matches A's isMine builds
+local matchHash = bucketHash({ ["r1"]={lastModified=50000,echoes={{spellId=200100,quality=3,stacks=1}}} })
+Sync.HandleIncoming("WLRQ|peer2|"..matchHash.."|0|matching-state", "peer2")
+for i=1,20 do Sync.OnUpdate(0.2) end
+local skipped = Sync.Stats().skippedUpToDate or 0
+assert(skipped > 0, "peer with matching hash should have been skipped, got "..skipped)
+print("peer already up to date gets nothing (library hash match) -- OK")

--- a/tests/run_sync_logging.lua
+++ b/tests/run_sync_logging.lua
@@ -1,0 +1,134 @@
+-- Verifies the sync diagnostic log captures BOTH directions and, crucially,
+-- records a DISTINCT reason for every failure mode -- so a broken sync can
+-- be diagnosed from the log alone instead of by guesswork.
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua")
+dofile("core/Sync.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Relay.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/Readout.lua")
+dofile("ui/Panel.lua")
+local provider
+Nexus.LogViewer = { Init = function(p) provider = p end,
+    Show = function() end, Toggle = function() end }
+dofile("ui/CommunityBuilds.lua")
+dofile("core/Main.lua")
+
+local Codec, Sync = Nexus.Codec, Nexus.Sync
+local clock = 1000
+GetTime = function() return clock end
+time = function() return 50000 end
+UnitName = function() return "Alice" end
+
+NexusDB = {}
+H.playerLevel = 5
+H.wishlist = { name = "W", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 } } }
+H.FireEvent("ADDON_LOADED", "Nexus")
+H.FireEvent("SPELLS_CHANGED")
+H.FireEvent("PLAYER_ENTERING_WORLD")
+H.Advance(2)
+
+local function LogText() return provider("sync") end
+local function LogHas(pattern)
+    return LogText():find(pattern) ~= nil
+end
+
+-- Channel join must be recorded
+assert(LogHas("joined") or LogHas("already in"),
+    "channel join was not logged")
+print("channel join is logged -- OK")
+
+-- SEND side: posting must log the broadcast and the actual wire sends
+local CB = Nexus.CommunityBuilds
+local ok, id = CB.PostCurrentWishlist("Logged Build", "desc", H.wishlist)
+assert(ok, "post should succeed")
+H.Advance(3)
+assert(LogHas("queuing") or LogHas("broadcasting"), "broadcast was not logged")
+assert(LogHas("sent %d+ chars") or LogHas("TX"), "actual wire sends were not logged")
+print("send side is fully logged (broadcast + each wire message) -- OK")
+
+-- Valid owner-authored updates are accepted even outside a manual sync window.
+-- Sender identity must match the payload author.
+local msgs = {}
+for _, m in ipairs(H.sentChatMessages) do msgs[#msgs + 1] = m end
+NexusDB.communityBuilds = nil
+Sync.ClearLog()
+clock = clock + 3600   -- ensure any window is closed
+for _, m in ipairs(msgs) do
+    H.FireEvent("CHAT_MSG_CHANNEL", m.text, "Alice", "Common",
+        "5. " .. Sync.ChannelName(), nil, nil, nil, 5, Sync.ChannelName())
+end
+assert(NexusDB.communityBuilds and NexusDB.communityBuilds[id],
+    "a valid owner-authored update was dropped outside a sync window")
+assert(LogHas("STORED"), "outside-window owner update was not logged")
+print("valid owner update is accepted and logged outside a sync window -- OK")
+
+-- RECEIVE side, success: with a window open, the store must be logged
+NexusDB.communityBuilds = {}
+Sync.Init(Codec, Nexus.GameAdapter or {})
+Sync.ClearLog()
+clock = clock + 10
+Sync.RequestSync()
+assert(LogHas("requested sync"), "the sync request itself was not logged")
+for _, m in ipairs(msgs) do
+    H.FireEvent("CHAT_MSG_CHANNEL", m.text, "Alice", "Common",
+        "5. " .. Sync.ChannelName(), nil, nil, nil, 5, Sync.ChannelName())
+end
+assert(LogHas("STORED"), "a successful store was not logged")
+print("successful receive+store is logged -- OK")
+
+-- RECEIVE side, failure mode 2: duplicate must log a distinct reason
+Sync.ClearLog()
+clock = clock + 10
+Sync.RequestSync()
+for _, m in ipairs(msgs) do
+    H.FireEvent("CHAT_MSG_CHANNEL", m.text, "Alice", "Common",
+        "5. " .. Sync.ChannelName(), nil, nil, nil, 5, Sync.ChannelName())
+end
+assert(LogHas("DUPLICATE") or LogHas("duplicate"),
+    "a duplicate skip was not logged with its own distinct reason")
+print("duplicate skip is logged distinctly from other failures -- OK")
+
+-- RECEIVE side, failure mode 3: corrupt payload must log its own reason
+Sync.ClearLog()
+clock = clock + 10
+Sync.RequestSync()
+H.FireEvent("CHAT_MSG_CHANNEL", "WLRB||Bob||corrupt-id||999||1/1||!!!notbase64!!!",
+    "Bob", "Common", "5. " .. Sync.ChannelName(), nil, nil, nil, 5, Sync.ChannelName())
+assert(LogHas("base64") or LogHas("bad base64"),
+    "a corrupt payload was not logged with a decode-failure reason")
+print("corrupt payload logs a decode-failure reason -- OK")
+
+-- The CRITICAL diagnostic: protocol seen on an unmatched channel must
+-- record the actual arg values (this is what would have instantly
+-- revealed the arg4/arg9 bug)
+Sync.ClearLog()
+H.FireEvent("CHAT_MSG_CHANNEL", "WLRQ||Bob", "Bob", "Common",
+    "9. someotherchannel", nil, nil, nil, 9, "someotherchannel")
+assert(LogHas("MISMATCH"),
+    "protocol traffic on an unmatched channel was not flagged")
+assert(LogHas("someotherchannel"),
+    "the mismatch log does not include the actual channel values seen")
+print("channel MISMATCH is logged with the real arg values -- OK")
+
+-- Peer request handling must be logged
+Sync.ClearLog()
+clock = clock + 100
+H.FireEvent("CHAT_MSG_CHANNEL", "WLRQ||Bob", "Bob", "Common",
+    "5. " .. Sync.ChannelName(), nil, nil, nil, 5, Sync.ChannelName())
+assert(LogHas("request from Bob"), "answering a peer request was not logged")
+print("answering a peer's sync request is logged -- OK")
+
+-- The tab must also summarise state and library contents
+local text = LogText()
+assert(text:find("connected%s+:"), "tab missing connection summary")
+assert(text:find("sent"), "tab missing counters")
+assert(text:find("builds in my library"), "tab missing library summary")
+print("Sync tab includes connection state, counters, and library summary -- OK")

--- a/tests/run_sync_mesh_optimized.lua
+++ b/tests/run_sync_mesh_optimized.lua
@@ -1,0 +1,52 @@
+-- Optimized mesh: state hashes skip current peers and responder claims suppress duplicates.
+local H=dofile("tests/harness.lua")
+dofile("core/Codec.lua"); dofile("core/Sync.lua"); dofile("core/DpsCapture.lua")
+local Sync,DPS=Nexus.Sync,Nexus.DpsCapture
+local clock=1000; GetTime=function() return clock end; time=function() return 50000 end
+local function Pump(steps) for _=1,steps do clock=clock+0.2; Sync.OnUpdate(0.2) end end
+local playerName="RelayB"; UnitName=function() return playerName end; UnitLevel=function() return 80 end
+local echoes={{spellId=200001,stacks=2},{spellId=200002,stacks=1}}
+local build={id="manual-build",title="Real Build",description="Real description",author="Author",class="MAGE",echoes=echoes,postedAt=10,lastModified=10,isMine=false}
+NexusDB={communityBuilds={[build.id]=build},syncTombstones={},dpsCapture={}}
+Sync.Init(Nexus.Codec,{})
+DPS.Init({},Sync)
+-- Let the login-time automatic sync fire and drain, then clear it before targeted claims.
+Pump(100)
+H.sentChatMessages={}
+local fp=DPS.GetEchoKey(echoes)
+assert(DPS.ReceiveRecord({v=4,f=fp,e=echoes,c="dummy",d=24000000,u=65,t=50000,p="Winner",k="MAGE",l=80,b=build.id}))
+local function buildHash(builds)
+  local buckets={}; for i=1,8 do buckets[i]={} end
+  local function bucket(id) local h=5381; for i=1,#id do h=((h*33)+id:byte(i))%2147483648 end; return (h%8)+1 end
+  for id,b in pairs(builds) do local n=bucket(id); local complete=(type(b.echoes)=="table" and #b.echoes>0) and "F" or "S"; local fp=tostring(b.fingerprintHash or b.fingerprint or "0"); buckets[n][#buckets[n]+1]=id..":"..tostring(b.lastModified or b.postedAt or 0)..":"..complete..":"..fp end
+  local out={}
+  for n=1,8 do table.sort(buckets[n]); local h=5381; for _,text in ipairs(buckets[n]) do for i=1,#text do h=((h*33)+text:byte(i))%2147483648 end end; out[n]=#buckets[n]>0 and string.format("%x",h) or "0" end
+  return table.concat(out,",")
+end
+local bh=buildHash(NexusDB.communityBuilds)
+local dh=DPS.GetSyncHash()
+-- Fully current requester receives nothing.
+H.sentChatMessages={}
+Sync.HandleIncoming("WLRQ|Current|"..bh.."|"..dh.."|req-current","Current")
+Pump(20)
+assert(#H.sentChatMessages==0,"current requester should receive no duplicate traffic")
+-- Identical peer claims the response first, so this peer suppresses its queued copy.
+H.sentChatMessages={}
+Sync.HandleIncoming("WLRQ|NewPeer|0|0|req-claim","NewPeer")
+Sync.HandleIncoming("WLRC|RelayA|NewPeer|req-claim|"..bh.."|"..dh,"RelayA")
+Pump(20)
+assert(#H.sentChatMessages==0,"identical responder claim did not suppress duplicate reply")
+-- A claim advertising different state must not suppress our useful contribution.
+H.sentChatMessages={}
+Sync.HandleIncoming("WLRQ|OtherPeer|0|0|req-different","OtherPeer")
+Sync.HandleIncoming("WLRC|PartialPeer|OtherPeer|req-different|different|different","PartialPeer")
+Pump(100)
+local claim,buildMsg,dpsMsg=false,false,false
+for _,m in ipairs(H.sentChatMessages) do
+  claim=claim or not not m.text:find("^WLBC|")
+  buildMsg=buildMsg or not not m.text:find("^WLRB|")
+  dpsMsg=dpsMsg or not not m.text:find("^WLD2|")
+end
+assert(claim and buildMsg,"different-state peer incorrectly suppressed useful build contribution")
+assert(not dpsMsg,"relay redistributed a verified DPS row without origin evidence")
+print("mesh hashes, claims, complete builds, and DPS origin authority -- OK")

--- a/tests/run_sync_mesh_optimized.lua
+++ b/tests/run_sync_mesh_optimized.lua
@@ -30,12 +30,21 @@ H.sentChatMessages={}
 Sync.HandleIncoming("WLRQ|Current|"..bh.."|"..dh.."|req-current","Current")
 Pump(20)
 assert(#H.sentChatMessages==0,"current requester should receive no duplicate traffic")
--- Identical peer claims the response first, so this peer suppresses its queued copy.
+-- A matching per-build bucket claim suppresses only that safely relayable
+-- build bucket. Legacy whole-state claims cannot suppress owner-only state.
 H.sentChatMessages={}
 Sync.HandleIncoming("WLRQ|NewPeer|0|0|req-claim","NewPeer")
-Sync.HandleIncoming("WLRC|RelayA|NewPeer|req-claim|"..bh.."|"..dh,"RelayA")
+local buildParts={}; for p in bh:gmatch("([^,]+)") do buildParts[#buildParts+1]=p end
+local buildBucket,buildBucketHash
+for i,value in ipairs(buildParts) do if value~="0" then buildBucket,buildBucketHash=i,value break end end
+assert(buildBucket,"test build did not occupy a reconciliation bucket")
+Sync.HandleIncoming("WLBC|RelayA|NewPeer|req-claim|B|"..buildBucket.."|"..buildBucketHash,"RelayA")
 Pump(20)
-assert(#H.sentChatMessages==0,"identical responder claim did not suppress duplicate reply")
+local duplicateBuild=false
+for _,m in ipairs(H.sentChatMessages) do
+  duplicateBuild=duplicateBuild or not not m.text:find("^WLRB|")
+end
+assert(not duplicateBuild,"matching build-bucket claim did not suppress duplicate build reply")
 -- A claim advertising different state must not suppress our useful contribution.
 H.sentChatMessages={}
 Sync.HandleIncoming("WLRQ|OtherPeer|0|0|req-different","OtherPeer")

--- a/tests/run_sync_optin.lua
+++ b/tests/run_sync_optin.lua
@@ -1,0 +1,65 @@
+-- Login sync opens one bounded receive window automatically. Outside that
+-- window, unsolicited build traffic is ignored; manual Sync Now reopens it.
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua")
+dofile("core/Sync.lua")
+local Codec, Sync = Nexus.Codec, Nexus.Sync
+local clock = 1000
+GetTime = function() return clock end
+time = function() return 50000 end
+local currentName = "Alice"
+UnitName = function() return currentName end
+local function Pump(steps) for _=1,steps do clock=clock+0.2; Sync.OnUpdate(0.2) end end
+
+local function EncodeBob(id, title, stamp)
+    local saved = H.sentChatMessages
+    H.sentChatMessages = {}
+    local prior = currentName; currentName = "Bob"
+    Sync.BroadcastBuild({ id=id, title=title, description="d", author="Bob",
+        ownerKey="bob@ebonhold", class="ROGUE",
+        echoes={{spellId=200100,quality=3,stacks=1}}, postedAt=stamp,lastModified=stamp })
+    Pump(100)
+    currentName = prior
+    local msgs=H.sentChatMessages; H.sentChatMessages=saved
+    return msgs
+end
+
+NexusDB = {}
+Sync.Init(Codec,nil)
+-- Generate payload before the automatic receive window fires.
+local msgs=EncodeBob("bob-1","Bob's Build",100)
+-- Login-time sync fires within the bounded 8-16 second startup delay above.
+assert(Sync.IsReceiving(),"automatic login sync should open the receive window")
+for _,m in ipairs(msgs) do Sync.HandleIncoming(m.text,"Bob") end
+assert(NexusDB.communityBuilds and NexusDB.communityBuilds["bob-1"],
+    "automatic login sync did not accept current build metadata")
+print("automatic login sync receives current mesh metadata -- OK")
+
+-- Once the status window expires, direct-author traffic is still accepted.
+clock=clock+70
+assert(not Sync.IsReceiving(),"automatic receive window should expire")
+local msgs2=EncodeBob("bob-2","Bob's Second",200)
+for _,m in ipairs(msgs2) do Sync.HandleIncoming(m.text,"Bob") end
+assert(NexusDB.communityBuilds["bob-2"],"direct-author data was dropped outside a sync window")
+print("direct-author updates remain accepted after the status window -- OK")
+
+-- Manual Sync Now reopens convergence.
+clock=clock+10
+assert(Sync.RequestSync(),"manual sync should succeed")
+for _,m in ipairs(msgs2) do Sync.HandleIncoming(m.text,"Bob") end
+assert(NexusDB.communityBuilds["bob-2"],"manual sync lost existing metadata")
+print("manual sync reconciles already accepted metadata -- OK")
+
+-- Convergence may run several bounded passes. Once it reports idle it must stop.
+Pump(20)
+clock=clock+70
+H.sentChatMessages={}
+for i=1,500 do clock=clock+1; Sync.OnUpdate(1.0) end
+local phase=Sync.GetLeaderboardSyncStatus()
+assert(phase=="idle","bounded convergence did not reach idle")
+H.sentChatMessages={}
+Pump(100)
+for _,m in ipairs(H.sentChatMessages) do
+    assert(not m.text:find("^WLRQ"),"idle addon restarted convergence")
+end
+print("bounded convergence reaches idle and stays quiet -- OK")

--- a/tests/run_sync_owner_claims.lua
+++ b/tests/run_sync_owner_claims.lua
@@ -1,0 +1,65 @@
+-- Owner-only DPS records and tombstones must never be suppressed by a peer
+-- that knows the same state but lacks authority to retransmit it.
+local H=dofile("tests/harness.lua")
+dofile("core/Codec.lua"); dofile("core/Sync.lua"); dofile("core/DpsCapture.lua")
+local Sync,DPS=Nexus.Sync,Nexus.DpsCapture
+local clock=1000; GetTime=function() return clock end; time=function() return 50000 end
+local currentName="Relay"; UnitName=function() return currentName end
+UnitClass=function() return "Mage","MAGE" end
+GetNormalizedRealmName=function() return "Ebonhold" end
+local function Pump(steps) for _=1,steps do clock=clock+0.2; Sync.OnUpdate(0.2) end end
+local function NonzeroBucket(hash)
+  local i=0
+  for value in tostring(hash):gmatch("([^,]+)") do
+    i=i+1; if value~="0" then return i,value end
+  end
+end
+
+-- DPS: a relay knows Owner's row. Matching new/legacy claims must not stop
+-- this client once it is acting as the actual owner from answering.
+local echoes={{spellId=200100,stacks=1}}
+NexusDB={communityBuilds={},syncTombstones={},dpsCapture={}}
+Sync.Init(Nexus.Codec,{}); DPS.Init({},Sync); Pump(100); H.sentChatMessages={}
+local fp,hash=DPS.GetEchoKey(echoes),DPS.GetEchoHash(echoes)
+assert(DPS.ReceiveRecord({v=7,f=fp,h=hash,e=echoes,c="dummy",d=25000000,u=65,
+  t=49000,p="Owner",k="MAGE",o="owner@ebonhold",r="ebonhold",l=80},"Owner"))
+local _,dpsHash=Sync.GetCompatibilityHashes()
+local dpsBucket,dpsBucketHash=NonzeroBucket(dpsHash)
+assert(dpsBucket,"DPS row did not occupy a reconciliation bucket")
+Sync.HandleIncoming("WLRQ|Requester|0|0|dps-owner","Requester")
+Sync.HandleIncoming("WLBC|RelayTwo|Requester|dps-owner|D|"..dpsBucket.."|"..dpsBucketHash,"RelayTwo")
+Sync.HandleIncoming("WLRC|RelayTwo|Requester|dps-owner|0|"..dpsHash,"RelayTwo")
+currentName="Owner"; Pump(100)
+local sawDps,sawDpsClaim=false,false
+for _,m in ipairs(H.sentChatMessages) do
+  sawDps=sawDps or not not m.text:find("^WLD2|")
+  sawDpsClaim=sawDpsClaim or not not m.text:find("^WLBC|[^|]+|[^|]+|[^|]+|D|")
+end
+assert(sawDps,"non-owner claim suppressed the actual DPS owner")
+assert(not sawDpsClaim,"owner-only DPS bucket emitted a suppressible claim")
+
+-- Tombstone: a relay holds Origin's valid delete. Claims from another relay
+-- cannot suppress Origin's later authoritative WLRD response.
+currentName="Relay"; clock=clock+100
+NexusDB={communityBuilds={gone={id="gone",title="Gone",author="Origin",
+  ownerKey="origin@ebonhold",class="MAGE",echoes=echoes,postedAt=10,lastModified=10}},
+  syncTombstones={},dpsCapture={}}
+Sync.Init(Nexus.Codec,{}); DPS.Init({},Sync); Pump(100); H.sentChatMessages={}
+Sync.HandleIncoming("WLRD|Origin|gone|20|Origin","Origin")
+assert(not NexusDB.communityBuilds.gone,"authoritative delete fixture failed")
+local buildHash=select(1,Sync.GetCompatibilityHashes())
+local buildBucket,buildBucketHash=NonzeroBucket(buildHash)
+assert(buildBucket,"tombstone did not occupy a reconciliation bucket")
+Sync.HandleIncoming("WLRQ|RequesterTwo|0|0|delete-owner","RequesterTwo")
+Sync.HandleIncoming("WLBC|RelayTwo|RequesterTwo|delete-owner|B|"..buildBucket.."|"..buildBucketHash,"RelayTwo")
+Sync.HandleIncoming("WLRC|RelayTwo|RequesterTwo|delete-owner|"..buildHash.."|0","RelayTwo")
+currentName="Origin"; Pump(100)
+local sawDelete,sawDeleteClaim=false,false
+for _,m in ipairs(H.sentChatMessages) do
+  sawDelete=sawDelete or not not m.text:find("^WLRD|")
+  sawDeleteClaim=sawDeleteClaim or not not m.text:find("^WLBC|[^|]+|[^|]+|[^|]+|B|")
+end
+assert(sawDelete,"non-owner claim suppressed the actual deletion owner")
+assert(not sawDeleteClaim,"tombstone bucket emitted a suppressible claim")
+
+print("owner-only DPS and tombstone claims cannot suppress authoritative sync -- OK")

--- a/tests/run_sync_wire_limits.lua
+++ b/tests/run_sync_wire_limits.lua
@@ -1,0 +1,146 @@
+-- Regressions for the two live bugs that made receiving fail entirely
+-- (2026-07-24):
+--   1. CHAT_MSG_CHANNEL arg4 carries the channel name WITH a number
+--      prefix ("5. wrbuildssync"); the bare name is arg9. Matching only
+--      against arg4 never fired, so nothing was ever received AND peers
+--      never saw each other's sync requests.
+--   2. A fixed 200-byte chunk + header + pipe-escaping came to 259 chars
+--      against WoW's 255 limit, so every multi-chunk build was silently
+--      truncated and arrived as corrupt base64.
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua")
+dofile("core/Sync.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Relay.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/Readout.lua")
+dofile("ui/Panel.lua")
+Nexus.LogViewer = { Init = function() end }
+dofile("ui/CommunityBuilds.lua")
+dofile("core/Main.lua")
+
+local Codec, Sync = Nexus.Codec, Nexus.Sync
+local clock = 1000
+GetTime = function() return clock end
+local function Pump(steps)
+    for _ = 1, steps do clock = clock + 0.2; Sync.OnUpdate(0.2) end
+end
+time = function() return 50000 end
+UnitName = function() return "Boganicc" end   -- realistic long-ish name
+
+NexusDB = {}
+H.playerLevel = 5
+H.wishlist = { name = "W", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 } } }
+H.FireEvent("ADDON_LOADED", "Nexus")
+H.FireEvent("SPELLS_CHANGED")
+H.FireEvent("PLAYER_ENTERING_WORLD")
+H.Advance(2)
+
+------------------------------------------------------------------------
+-- BUG 2: no message may ever exceed WoW's 255-char chat limit
+------------------------------------------------------------------------
+-- A realistically large build: 70 echoes and a long description, like a
+-- real endgame wishlist.
+local bigEchoes = {}
+for i = 1, 70 do
+    bigEchoes[i] = { spellId = 200000 + i, quality = 3, stacks = 9 }
+end
+local bigBuild = {
+    id = "mine-1784886552-123456",       -- realistic generated id length
+    title = "Full Endgame Rogue Wishlist",
+    description = string.rep("This is a long description explaining the build. ", 6),
+    author = "Boganicc", class = "ROGUE",
+    echoes = bigEchoes, postedAt = 1784886552, lastModified = 1784886552,
+}
+
+H.sentChatMessages = {}
+assert(Sync.BroadcastBuild(bigBuild), "broadcasting a realistic large build should succeed")
+Pump(400)
+assert(#H.sentChatMessages > 1, "a 70-echo build should span multiple chunks")
+
+local longest = 0
+for _, m in ipairs(H.sentChatMessages) do
+    if #m.text > longest then longest = #m.text end
+end
+print(string.format("largest wire message: %d chars (limit 255, %d chunks)",
+    longest, #H.sentChatMessages))
+assert(longest <= 255,
+    "a chat message exceeded the 255-char limit and would be TRUNCATED: " .. longest)
+assert((Sync.Stats().oversizeDropped or 0) == 0,
+    "some messages were dropped as oversize -- chunk sizing is still wrong")
+print("all wire messages fit within WoW's 255-char chat limit -- OK")
+
+------------------------------------------------------------------------
+-- BUG 1: the channel filter must match 3.3.5's actual arg layout
+------------------------------------------------------------------------
+local msgs = H.sentChatMessages
+NexusDB.communityBuilds = nil
+Sync.RequestSync()
+clock = clock + 1
+
+-- Deliver exactly as 3.3.5 does: arg4 = "5. wrbuildssync" (numbered),
+-- arg9 = "wrbuildssync" (bare).
+for _, m in ipairs(msgs) do
+    H.FireEvent("CHAT_MSG_CHANNEL", m.text, "Boganicc", "Common",
+        "5. " .. Sync.ChannelName(),      -- arg4, numbered
+        nil, nil, nil, 5,                  -- arg5..arg8
+        Sync.ChannelName())                -- arg9, bare
+end
+
+local got = NexusDB.communityBuilds
+    and NexusDB.communityBuilds["mine-1784886552-123456"]
+assert(got, "the build was NOT received -- the 3.3.5 channel arg layout still isn't matched")
+assert(#got.echoes == 70, "received build lost echoes in transit (got " .. #got.echoes .. "/70)")
+assert(got.title == "Full Endgame Rogue Wishlist", "title corrupted in transit")
+assert(got.description:find("long description"), "description corrupted in transit")
+print("a full 70-echo build survives the real 3.3.5 channel path intact -- OK")
+
+------------------------------------------------------------------------
+-- The numbered-only form (no arg9 at all) must also work
+------------------------------------------------------------------------
+-- Fresh timestamp: the dedup guard would (correctly) reject a replay of
+-- the exact same version we already stored above.
+local function RegenMessages(stamp)
+    H.sentChatMessages = {}
+    local b = {}
+    for k, v in pairs(bigBuild) do b[k] = v end
+    b.lastModified = stamp
+    Sync.BroadcastBuild(b)
+    Pump(400)
+    return H.sentChatMessages
+end
+
+NexusDB.communityBuilds = nil
+local msgs2 = RegenMessages(1784886999)
+clock = clock + 10
+Sync.RequestSync()
+for _, m in ipairs(msgs2) do
+    H.FireEvent("CHAT_MSG_CHANNEL", m.text, "Boganicc", "Common",
+        "12. " .. Sync.ChannelName())      -- arg4 only, no arg9
+end
+assert(NexusDB.communityBuilds
+    and NexusDB.communityBuilds["mine-1784886552-123456"],
+    "delivery failed when only the numbered arg4 form was present")
+print("delivery also works when only the numbered channel form is available -- OK")
+
+------------------------------------------------------------------------
+-- Traffic on an UNRELATED channel must still be ignored
+------------------------------------------------------------------------
+NexusDB.communityBuilds = nil
+local msgs3 = RegenMessages(1784887777)
+clock = clock + 10
+Sync.RequestSync()
+for _, m in ipairs(msgs3) do
+    H.FireEvent("CHAT_MSG_CHANNEL", m.text, "Boganicc", "Common",
+        "2. Trade", nil, nil, nil, 2, "Trade")
+end
+assert(not (NexusDB.communityBuilds
+    and NexusDB.communityBuilds["mine-1784886552-123456"]),
+    "traffic from an unrelated channel was processed -- filter is too loose now")
+print("unrelated channel traffic is still correctly ignored -- OK")

--- a/tests/run_tombstone_mesh_relay.lua
+++ b/tests/run_tombstone_mesh_relay.lua
@@ -1,0 +1,19 @@
+-- Unsigned relays cannot delete or redistribute another author's build.
+local H=dofile("tests/harness.lua")
+dofile("core/Codec.lua"); dofile("core/Sync.lua")
+local Sync=Nexus.Sync
+local clock=1000; GetTime=function() return clock end; time=function() return 50000 end
+UnitName=function() return "Relay" end
+NexusDB={communityBuilds={x={id="x",title="Old",author="Origin",class="MAGE",echoes={{spellId=1,stacks=1}},lastModified=10,postedAt=10,isMine=false}},syncTombstones={}}
+Sync.Init(Nexus.Codec,{})
+Sync.HandleIncoming("WLRD|PeerA||x||20||Origin","PeerA")
+assert(NexusDB.communityBuilds.x,"relayed author deletion gained owner authority")
+Sync.HandleIncoming("WLRD|Origin||x||20||Origin","Origin")
+assert(not NexusDB.communityBuilds.x,"direct author deletion was not applied")
+H.sentChatMessages={}; clock=clock+100
+Sync.HandleIncoming("WLRQ|NewPeer|0|0|relay-delete","NewPeer")
+for i=1,100 do Sync.OnUpdate(0.2) end
+local found=false
+for _,m in ipairs(H.sentChatMessages) do if m.text:find("^WLRD|") and m.text:find("||x||20||Origin",1,true) then found=true end end
+assert(not found,"third-party tombstone was redistributed without owner proof")
+print("only direct owners can delete; third-party tombstones do not relay -- OK")

--- a/tests/run_tome_and_popup_ui.lua
+++ b/tests/run_tome_and_popup_ui.lua
@@ -1,0 +1,18 @@
+local H=dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua"); dofile("logic/Model.lua"); dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua"); dofile("logic/Policy.lua"); dofile("core/Store.lua")
+dofile("core/GameAdapter.lua"); dofile("ui/WishlistOverlay.lua"); dofile("ui/WishlistEditor.lua")
+local A=Nexus.GameAdapter
+H.discovered={[200100]=true}
+H.FireEvent("SPELLS_CHANGED"); H.FireEvent("PLAYER_ENTERING_WORLD"); H.Advance(1)
+local missing=A.UnknownTomesForEchoes({{spellId=200100},{spellId=200104},{spellId=200700}})
+assert(#missing==2,"unknown tome detector should exclude learned tomes and report two unknown gates")
+NexusDB=NexusDB or {}
+Nexus.WishlistEditor.Init(A,Nexus.Model)
+Nexus.WishlistEditor.Show()
+Nexus.WishlistEditor.ToggleDisplayPopup()
+local popup=_G.NexusDisplayPopup
+assert(popup and popup:IsShown(),"display settings popup did not open")
+assert(popup:GetFrameStrata()=="TOOLTIP","display settings must render above the editor")
+assert((popup:GetFrameLevel() or 0)>50,"display settings frame level is not above the editor")
+print("unknown tome tracking and editor popup z-order -- OK")

--- a/tests/run_wishlist_editor.lua
+++ b/tests/run_wishlist_editor.lua
@@ -1,0 +1,47 @@
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/WishlistEditor.lua")
+
+NexusDB = {}
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+    { spellId = 200104, quality = 2, stacks = 3 },
+} }
+H.playerLevel = 5
+IsSpellKnown = function(id) return id == 300100 end
+
+local Adapter, Model = Nexus.GameAdapter, Nexus.Model
+Adapter.Wishlist = function()
+    return { name=H.wishlist.name, class=H.wishlist.class, entries=H.wishlist.echoes }
+end
+local EW = Nexus.WishlistEditor
+EW.Init(Adapter, Model)
+
+local ok = pcall(EW.OpenForCandidate, {title=H.wishlist.name, echoes=H.wishlist.echoes})
+assert(ok, "Show() threw")
+local frame = _G.NexusEditorFrame
+assert(frame:IsShown(), "editor frame not shown after Show()")
+
+-- pending list should be seeded from the real wishlist: 2 entries
+assert(EW.DebugPendingCount() == 2,
+    "expected pending seeded with 2 entries, got " .. EW.DebugPendingCount())
+
+-- toggle hides/shows correctly
+EW.Toggle()
+assert(not frame:IsShown(), "Toggle() did not hide")
+EW.Toggle()
+assert(frame:IsShown(), "Toggle() did not re-show")
+
+-- refresh never throws across repeated calls (search/filter changes etc.)
+for i = 1, 5 do
+    local ok2 = pcall(EW.Refresh)
+    assert(ok2, "Refresh() threw on iteration " .. i)
+end
+
+print("wishlist editor: lifecycle + seeding OK (checks=5)")

--- a/tests/run_wishlist_overlay.lua
+++ b/tests/run_wishlist_overlay.lua
@@ -1,0 +1,95 @@
+-- Overlay lifecycle: Show/Hide/Toggle, owned-vs-missing coloring, and
+-- lock/drag/position-persistence behavior.
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/WishlistOverlay.lua")
+
+NexusDB = {}
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1, family="s200100" }, -- owned
+    { spellId = 200102, quality = 2, stacks = 1, family="s200102" }, -- missing
+    { spellId = 200104, quality = 2, stacks = 3, family="s200104" }, -- partial
+} }
+H.playerLevel = 5
+H.granted = { ["Alpha Strike"] = { { spellId = 200100, stack = 1, maxStack = 1, quality = 3 } },
+    ["Double Strike"] = { { spellId = 200104, stack = 1, maxStack = 5, quality = 2 } } }
+
+local Adapter, Model = Nexus.GameAdapter, Nexus.Model
+Adapter.Wishlist = function()
+    return { name=H.wishlist.name, class=H.wishlist.class, entries=H.wishlist.echoes }
+end
+Adapter.Owned = function()
+    return { bySpell={[200100]=1,[200104]=1},
+        byFamily={s200100=1,s200104=1}, synced=true }
+end
+local OV = Nexus.WishlistOverlay
+OV.Init(Adapter, Model)
+
+local ok = pcall(OV.Show)
+assert(ok, "Show() threw")
+assert(OV.IsShown(), "overlay not shown after Show()")
+assert(NexusDB.overlayShown == true, "shown-state not persisted")
+
+OV.Toggle()
+assert(not OV.IsShown(), "Toggle() did not hide")
+assert(NexusDB.overlayShown == false, "hidden-state not persisted")
+OV.Toggle()
+assert(OV.IsShown(), "Toggle() did not re-show")
+
+local ok2 = pcall(OV.Refresh)
+assert(ok2, "Refresh() threw")
+
+print("overlay lifecycle (Show/Hide/Toggle/persistence) OK")
+
+-- lock state defaults to locked (click-through)
+local frame = _G.NexusOverlay
+assert(frame, "overlay frame missing")
+print("overlay frame + lock button created without error -- OK")
+
+-- Verify actual line CONTENT: owned/partial/missing must render distinctly.
+local allTexts = {}
+local realCreateFrame2 = CreateFrame
+CreateFrame = function(...)
+    local f = realCreateFrame2(...)
+    local realCFS = f.CreateFontString
+    f.CreateFontString = function(self, ...)
+        local fs = realCFS(self, ...)
+        allTexts[#allTexts + 1] = fs
+        return fs
+    end
+    return f
+end
+
+-- fresh overlay instance to pick up the intercepted CreateFrame
+package.loaded = package.loaded or {}
+dofile("ui/WishlistOverlay.lua")
+local OV2 = Nexus.WishlistOverlay
+OV2.Init(Adapter, Model)
+OV2.Show()
+
+local foundOwned, foundPartial, foundMissing = false, false, false
+for _, fs in ipairs(allTexts) do
+    local t = fs.text
+    if type(t) == "string" then
+        if t:find("%[X%]") and t:find("Alpha Strike") then foundOwned = true end
+        if t:find("%[~%]") and t:find("Double Strike") then foundPartial = true end
+        if t:find("%[ %]") and t:find("Beta Guard") then foundMissing = true end
+    end
+end
+assert(foundOwned, "owned echo (Alpha Strike) not shown as [X]")
+assert(foundPartial, "partially-owned stacking echo (Double Strike) not shown as [~]")
+assert(foundMissing, "missing echo (Beta Guard) not shown as [ ]")
+print("owned/partial/missing states render with correct markers -- OK")
+
+-- The whole point of the rewrite: a large wishlist must fit on screen,
+-- not run to 1000+ px tall in a single column.
+local w, h = frame:GetWidth(), frame:GetHeight()
+print(string.format("overlay footprint: %dx%d (was ~300x1200 before the fix)", w or 0, h or 0))
+assert((h or 9999) < 500, "overlay is still too tall -- multi-column layout isn't working")
+print("overlay fits comfortably on screen regardless of wishlist size -- OK")

--- a/tests/run_wishlist_tracking.lua
+++ b/tests/run_wishlist_tracking.lua
@@ -1,0 +1,98 @@
+-- Regression for the exact live bug (2026-07-24): two designed wishlist
+-- slots existed (from a community import + a raw-string import), neither
+-- marked active, so Adapter.Wishlist() correctly returned nil -- but the
+-- UI just said "no wishlist" with no explanation, reading as "you have
+-- none" when really it meant "you have two, pick one."
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/WishlistEditor.lua")
+
+NexusDB = {}
+H.playerLevel = 1
+
+-- One active Snapshot plus two designed wishlists, with no association yet.
+H.DeliverSlots({
+    [1] = { slot = 1, name = "Snapshot", verified = true, echoes = {
+        { spellId = 200100, quality = 3, stacks = 1, locked = false },
+    } },
+    [6] = { slot = 6, name = "WISHLIST", verified = false, echoes = {
+        { spellId = 200100, quality = 3, stacks = 1, locked = false },
+    } },
+    [7] = { slot = 7, name = "WISHLIST2", verified = false, echoes = {
+        { spellId = 200102, quality = 2, stacks = 1, locked = false },
+    } },
+}, 1)
+
+local Adapter, Model = Nexus.GameAdapter, Nexus.Model
+
+-- 1. Adapter.Wishlist() correctly returns nil (genuinely ambiguous)
+local wl = Adapter.Wishlist()
+assert(wl == nil, "expected nil (ambiguous) wishlist, got one anyway")
+print("Adapter.Wishlist() correctly returns nil when ambiguous -- OK")
+
+-- 2. But GetWishlistCandidates() must surface BOTH real candidates
+local candidates = Adapter.GetWishlistCandidates()
+assert(#candidates == 2, "expected 2 candidates, got " .. #candidates)
+local names = {}
+for _, c in ipairs(candidates) do names[c.name] = true end
+assert(names["WISHLIST"] and names["WISHLIST2"],
+    "candidate list is missing one of the two real designed slots")
+print("GetWishlistCandidates() surfaces both real candidates -- OK")
+
+-- 3. The editor's tracking display must show the ambiguous-count
+-- message, not a bare "no wishlist"
+local EW = Nexus.WishlistEditor
+EW.Init(Adapter, Model)
+EW.Show()
+
+-- find the tracking text and candidate buttons via a CreateFrame/
+-- CreateFontString interceptor installed retroactively isn't possible
+-- post-hoc, so re-open with fresh interception instead
+local allWidgets = {}
+local realCreateFrame = CreateFrame
+CreateFrame = function(...)
+    local f = realCreateFrame(...)
+    allWidgets[#allWidgets + 1] = f
+    local realCFS = f.CreateFontString
+    f.CreateFontString = function(self, ...)
+        local fs = realCFS(self, ...)
+        allWidgets[#allWidgets + 1] = fs
+        return fs
+    end
+    return f
+end
+_G.NexusEditorFrame = nil
+dofile("ui/WishlistEditor.lua")
+local EW2 = Nexus.WishlistEditor
+EW2.Init(Adapter, Model)
+EW2.Show()
+
+local foundTrackingMsg, foundCandidateBtn = false, false
+local associatedLoadout, associatedWishlist
+local realAssociate = Adapter.SetLoadoutWishlist
+Adapter.SetLoadoutWishlist = function(loadoutSlot, wishlistSlot)
+    associatedLoadout, associatedWishlist = loadoutSlot, wishlistSlot
+    return realAssociate(loadoutSlot, wishlistSlot)
+end
+
+for _, w in ipairs(allWidgets) do
+    if type(w.text) == "string" and w.text:find("2 wishlists found") then
+        foundTrackingMsg = true
+    end
+    if type(w.text) == "string" and (w.text:find("WISHLIST2") or w.text == "WISHLIST (1)") then
+        foundCandidateBtn = true
+        if w.scripts and w.scripts.OnClick then w.scripts.OnClick(w) end
+    end
+end
+assert(foundTrackingMsg, "editor did not show the '2 wishlists found' message")
+print("editor shows the ambiguous-wishlist count instead of a bare 'no wishlist' -- OK")
+assert(foundCandidateBtn, "no candidate picker button was rendered")
+assert(associatedLoadout == 1 and (associatedWishlist == 6 or associatedWishlist == 7),
+    "clicking a candidate did not associate it with the active Snapshot")
+print("clicking a candidate associates the correct active Snapshot -- OK")

--- a/tests/run_wishlist_upload.lua
+++ b/tests/run_wishlist_upload.lua
@@ -1,0 +1,81 @@
+-- Verifies the real write path discovered via /wr sniff (2026-07-24):
+-- UploadServerBuildSlot(slot, name, echoes), confirmed by two independent
+-- live captures. Tests the full chain: editor pending list -> confirmation
+-- popup -> Adapter.UploadWishlist -> the actual PerkService call.
+local H = dofile("tests/harness.lua")
+dofile("data/DefaultProfile.lua")
+dofile("logic/Model.lua")
+dofile("logic/Strategy.lua")
+dofile("logic/Ratchet.lua")
+dofile("logic/Policy.lua")
+dofile("core/Store.lua")
+dofile("core/GameAdapter.lua")
+dofile("ui/WishlistEditor.lua")
+
+NexusDB = {}
+H.wishlist = { name = "MyBuild", class = "MAGE", echoes = {
+    { spellId = 200100, quality = 3, stacks = 1 },
+    { spellId = 200104, quality = 2, stacks = 3 },
+} }
+H.playerLevel = 5
+
+-- capture what the real PerkService call actually receives
+local captured = nil
+ProjectEbonhold.PerkService.UploadServerBuildSlot = function(slot, name, echoes)
+    captured = { slot = slot, name = name, echoes = echoes }
+    return true
+end
+
+local Adapter, Model = Nexus.GameAdapter, Nexus.Model
+local EW = Nexus.WishlistEditor
+EW.Init(Adapter, Model)
+EW.Show()
+
+-- pending is seeded from the real wishlist (2 entries) -- click Apply
+local applyBtn = _G.NexusEditorFrame -- just ensure frame exists
+assert(applyBtn, "editor frame missing")
+
+-- directly exercise Adapter.UploadWishlist (unit-level check)
+local ok1, err1 = Adapter.UploadWishlist(0, "Test", {
+    { spellId = 200672, quality = 1, stacks = 9 },
+})
+assert(ok1, "UploadWishlist failed: " .. tostring(err1))
+assert(captured, "PerkService.UploadServerBuildSlot was never actually called")
+assert(captured.slot == 0, "expected slot 0, got " .. tostring(captured.slot))
+assert(captured.echoes[1].spellId == 200672, "spellId not passed through correctly")
+assert(captured.echoes[1].stacks == 9, "stacks not passed through correctly")
+print("Adapter.UploadWishlist calls the real PerkService function with correct args -- OK")
+
+-- reject empty/malformed input safely
+local ok2, err2 = Adapter.UploadWishlist(0, "Test", {})
+assert(not ok2 and err2 == "no echoes", "empty echo list should be rejected cleanly")
+print("empty echo list correctly rejected -- OK")
+
+-- spacing guard: a second call immediately after must be rejected
+local ok3, err3 = Adapter.UploadWishlist(0, "Test", { { spellId = 1, quality = 0, stacks = 1 } })
+assert(not ok3 and err3 == "spacing", "back-to-back uploads should be spacing-guarded")
+print("spacing guard correctly prevents back-to-back uploads -- OK")
+
+print("full upload chain OK (checks=3)")
+
+-- Full chain: the Apply button must show a confirmation popup (not fire
+-- immediately), and accepting it must call the real upload.
+captured = nil
+H.lastStaticPopup = nil
+-- reset the spacing guard by advancing time
+H.now = H.now + 10
+EW.Refresh()
+
+-- Find the Apply button by walking the frame's known structure isn't
+-- exposed, so invoke the click path via the popup mechanism directly:
+-- ApplyPending() (private) is exercised through the button's OnClick,
+-- which we can't reach directly without exposing it -- instead confirm
+-- the CONTRACT: clicking Apply must never call UploadServerBuildSlot
+-- synchronously, only after StaticPopup_Show + OnAccept.
+assert(StaticPopupDialogs["WISHLISTREALIZER_UPDATE_WISHLIST"]
+    and StaticPopupDialogs["WISHLISTREALIZER_CREATE_WISHLIST"],
+    "1.19.3 create/update confirmation dialogs were not registered")
+assert(type(StaticPopupDialogs["WISHLISTREALIZER_UPDATE_WISHLIST"].OnAccept) == "function"
+    and type(StaticPopupDialogs["WISHLISTREALIZER_CREATE_WISHLIST"].OnAccept) == "function",
+    "wishlist confirmation dialog has no OnAccept handler")
+print("confirmation dialog properly registered with an OnAccept handler -- OK")

--- a/tests/run_wrong_quality_guarantee.lua
+++ b/tests/run_wrong_quality_guarantee.lua
@@ -1,0 +1,140 @@
+-- Regression: a guarantee from a wished family is still unusable when the
+-- exact offered quality is below the wishlist target.
+dofile("logic/Model.lua")
+dofile("logic/Policy.lua")
+
+local rows = {
+    [210] = {
+        spellId=210, name="Quality Target", quality=0, maxStack=10,
+    },
+    [211] = {
+        spellId=211, name="Quality Target", quality=2, maxStack=10,
+    },
+    [400] = {
+        spellId=400, name="Filler A", quality=1, maxStack=1,
+    },
+    [401] = {
+        spellId=401, name="Filler B", quality=1, maxStack=1,
+    },
+}
+local catalog = {
+    rows=rows,
+    familyOf={
+        [210]="quality", [211]="quality",
+        [400]="fillerA", [401]="fillerB",
+    },
+    familyMembers={
+        quality={210,211}, fillerA={400}, fillerB={401},
+    },
+}
+local plan = {
+    advisorOnly=false,
+    wishedFamilies={ quality=true },
+    targets={
+        quality={ targetStacks=1, wishedQuality=2, spellId=211 },
+    },
+}
+
+local function card(spellId, guaranteed)
+    return {
+        spellId=spellId,
+        family=catalog.familyOf[spellId],
+        quality=rows[spellId].quality,
+        isGuaranteed=guaranteed or nil,
+    }
+end
+
+local function decide(charges)
+    return Nexus.Policy.Decide({
+        board={
+            cards={ card(400), card(210, true), card(401) },
+            guaranteedIndex=2,
+        },
+        owned={ synced=true, bySpell={}, byFamily={} },
+        charges=charges,
+        plan=plan,
+        queue={ entries={} },
+        catalog=catalog,
+        level=20,
+    })
+end
+
+local forced = decide({
+    freeze=0, banish=0, reroll=0, trustworthy=true,
+})
+assert(forced.type == "take" and forced.index ~= 2
+        and forced.spellId ~= 210,
+    "below-target-quality guaranteed Echo must be rejected")
+
+local searched = decide({
+    freeze=0, banish=1, reroll=0, trustworthy=true,
+})
+assert(searched.type == "banish"
+        and searched.index ~= 2
+        and searched.spellId ~= 210,
+    "search may Banish filler but never the wished quality family")
+
+local tieredPlan = {
+    advisorOnly=false,
+    wishedFamilies={ quality=true },
+    targets={
+        quality={
+            targetStacks=2, wishedQuality=0, spellId=210,
+            qualityTiers={
+                { q=0, n=1, spellId=210 },
+                { q=2, n=1, spellId=211 },
+            },
+        },
+    },
+}
+local tiered = Nexus.Policy.Decide({
+    board={
+        cards={ card(400), card(210, true), card(401) },
+        guaranteedIndex=2,
+    },
+    owned={ synced=true, bySpell={}, byFamily={} },
+    charges={ freeze=0, banish=0, reroll=0, trustworthy=true },
+    plan=tieredPlan,
+    queue={ entries={} },
+    catalog=catalog,
+    level=20,
+})
+assert(tiered.type == "take" and tiered.index == 2,
+    "an explicitly requested lower quality tier must remain a usable guarantee")
+
+local tierOwned = {
+    synced=true,
+    bySpell={ [210]=1 },
+    byFamily={ quality=1 },
+}
+local surplusLowTier = Nexus.Policy.Decide({
+    board={
+        cards={ card(400), card(210, true), card(401) },
+        guaranteedIndex=2,
+    },
+    owned=tierOwned,
+    charges={ freeze=0, banish=0, reroll=0, trustworthy=true },
+    plan=tieredPlan,
+    queue={ entries={} },
+    catalog=catalog,
+    level=20,
+})
+assert(surplusLowTier.type == "take" and surplusLowTier.index ~= 2,
+    "a filled low-quality tier must not absorb a higher-quality tier quota")
+
+local neededHighTier = Nexus.Policy.Decide({
+    board={
+        cards={ card(400), card(211, true), card(401) },
+        guaranteedIndex=2,
+    },
+    owned=tierOwned,
+    charges={ freeze=0, banish=0, reroll=0, trustworthy=true },
+    plan=tieredPlan,
+    queue={ entries={} },
+    catalog=catalog,
+    level=20,
+})
+assert(neededHighTier.type == "take" and neededHighTier.index == 2,
+    "the remaining exact quality tier must stay guarantee-eligible")
+
+print("wrong-quality guarantee regression OK")

--- a/ui/CommunityBuilds.lua
+++ b/ui/CommunityBuilds.lua
@@ -10,6 +10,8 @@ Nexus = Nexus or {}
 local M = {}
 Nexus.CommunityBuilds = M
 
+local RefreshBuildIdentity
+
 ------------------------------------------------------------------------
 -- Constants / lookup tables
 ------------------------------------------------------------------------
@@ -117,6 +119,16 @@ local CLASS_MASK = {
     DEATHKNIGHT=32, SHAMAN=64, MAGE=128, WARLOCK=256, DRUID=1024,
 }
 
+local VALID_CLASS = {}
+for class in pairs(CLASS_MASK) do VALID_CLASS[class] = true end
+
+local function NormalizeClass(class)
+    class = type(class) == "string" and class:upper() or nil
+    return class and VALID_CLASS[class] and class or nil
+end
+
+-- Infer only from Echoes restricted to one class. Shared Echoes are ignored:
+-- counting them makes the result depend on unordered table iteration.
 local function InferBuildClass(echoes)
     local scores = {}
     local cat = Adapter and Adapter.Catalog and Adapter.Catalog()
@@ -126,20 +138,45 @@ local function InferBuildClass(echoes)
             local row = rows[tonumber(e.spellId)]
             local mask = row and tonumber(row.classMask) or 0
             if mask > 0 then
+                local matched, onlyClass = 0, nil
                 for class, classMask in pairs(CLASS_MASK) do
                     if bit.band(mask, classMask) ~= 0 then
-                        scores[class] = (scores[class] or 0) + 1
+                        matched = matched + 1
+                        onlyClass = class
                     end
+                end
+                if matched == 1 and onlyClass then
+                    scores[onlyClass] = (scores[onlyClass] or 0) + 1
                 end
             end
         end
     end
-    local best, bestScore = nil, 0
+    local best, bestScore, tied = nil, 0, false
     for class, score in pairs(scores) do
-        if score > bestScore then best, bestScore = class, score end
+        if score > bestScore then
+            best, bestScore, tied = class, score, false
+        elseif score == bestScore and score > 0 then
+            tied = true
+        end
     end
-    if best then return best end
-    return (select(2, UnitClass and UnitClass("player"))) or nil
+    return (bestScore > 0 and not tied) and best or nil
+end
+
+local function CurrentRealm()
+    local realm = GetNormalizedRealmName and GetNormalizedRealmName()
+    if not realm or realm == "" then realm = GetRealmName and GetRealmName() end
+    return tostring(realm or "unknown"):lower():gsub("%s+", "")
+end
+
+local function OwnerKey(name, realm)
+    name = tostring(name or ""):lower():gsub("^%s+", ""):gsub("%s+$", "")
+    if name == "" then return nil end
+    realm = tostring(realm or CurrentRealm()):lower():gsub("%s+", "")
+    return name .. "@" .. realm
+end
+
+local function CurrentOwnerKey()
+    return OwnerKey(UnitName and UnitName("player"), CurrentRealm())
 end
 
 ------------------------------------------------------------------------
@@ -321,14 +358,22 @@ end
 
 IsOwnBuild = function(build)
     if not build then return false end
+    local mine = CurrentOwnerKey()
+    if not mine then return false end
+    if build.ownerKey then
+        return tostring(build.ownerKey):lower() == mine
+    end
+    -- Legacy builds predate ownerKey. They remain editable only when both
+    -- their local marker and author name match the current character.
     if not build.isMine then return false end
-    -- Double-check: the author field must also match the current player.
-    -- isMine can be stale (set on character A, then the DB was copied to
-    -- character B, or EnsureDpsBuildForEchoes set it based on a name
-    -- comparison that was true at the time but is now wrong).
-    local me = UnitName and UnitName("player") or ""
-    local author = tostring(build.author or "")
-    return author:lower() == tostring(me):lower()
+    local me = tostring((UnitName and UnitName("player")) or ""):lower()
+    return me ~= "" and tostring(build.author or ""):lower() == me
+end
+
+function M.IsOwnBuild(idOrBuild)
+    local build = type(idOrBuild) == "table" and idOrBuild
+        or Store()[idOrBuild]
+    return IsOwnBuild(build)
 end
 
 local function NormalizeTitle(text)
@@ -458,7 +503,7 @@ local function ImportCurrentSavedLoadouts(force)
             local signature = table.concat(signatureParts, "|")
             if not old or old._savedSignature ~= signature then
                 local stamp = NextStamp(old and old.lastModified or 0)
-                Store()[id] = {
+                local record = {
                     id=id, title=title,
                     serverTitle=serverTitle,
                     userTitle=old and old.userTitle or nil,
@@ -468,19 +513,23 @@ local function ImportCurrentSavedLoadouts(force)
                     userDescription=old and old.userDescription or nil,
                     publishedBuildId=old and old.publishedBuildId or nil,
                     lastPublishedAt=old and old.lastPublishedAt or nil,
-                    author=me, class=class, echoes=echoes,
+                    author=me, ownerKey=CurrentOwnerKey(), class=class, echoes=echoes,
                     postedAt=(old and old.postedAt) or stamp, lastModified=stamp,
                     isMine=true, importedSavedBuild=true, serverSlot=slot, recordBuildId=recordBuildId,
                     destinationWishlistName=destinationName, destinationWishlistSlot=linked and linked.slot or nil,
                     destinationProgress=progress, destinationTotal=destinationTotal,
                     activeServerBuild=(slots.activeSlot == slot), _savedSignature=signature,
                 }
-                changed = changed + 1
+                if RefreshBuildIdentity(record) then
+                    Store()[id] = record
+                    changed = changed + 1
+                end
             elseif old then
                 old.activeServerBuild = slots.activeSlot == slot
                 old.serverSlot = slot
                 old.serverTitle = serverTitle
                 old.class = class
+                old.ownerKey = old.ownerKey or CurrentOwnerKey()
                 old.recordBuildId = recordBuildId
                 if not old.userTitle or old.userTitle == "" then old.title = serverTitle end
                 old.importedSavedBuild = true
@@ -536,6 +585,69 @@ local function FingerprintHash(text)
     return string.format("%08x%08x", h1, h2)
 end
 
+local function NormalizeDiscordBuildLink(value)
+    local link = tostring(value or ""):gsub("^%s+",""):gsub("%s+$","")
+    if link == "" then return nil end
+    link = link:gsub("^<",""):gsub(">$","")
+    link = link:gsub("^http://", "https://")
+    link = link:gsub("^https://www%.discord%.com/", "https://discord.com/")
+    link = link:gsub("^https://discordapp%.com/", "https://discord.com/")
+    local guildId, channelId, messageId =
+        link:match("^https://discord%.com/channels/(%d+)/(%d+)/(%d+)/?$")
+    if guildId then
+        return string.format("https://discord.com/channels/%s/%s/%s",
+            guildId, channelId, messageId)
+    end
+    guildId, channelId =
+        link:match("^https://discord%.com/channels/(%d+)/(%d+)/?$")
+    if guildId then
+        return string.format("https://discord.com/channels/%s/%s",
+            guildId, channelId)
+    end
+    return nil,
+        "Paste a Discord channel or message link from discord.com/channels/."
+end
+
+RefreshBuildIdentity = function(build)
+    if type(build) ~= "table" or type(build.echoes) ~= "table"
+        or #build.echoes == 0 then return false, "invalid Echo list" end
+    local D = Nexus.DpsCapture
+    local count = 0
+    for i = 1, #build.echoes do
+        local e = build.echoes[i]
+        local id = type(e) == "table" and tonumber(e.spellId or e.id) or nil
+        local stacks = type(e) == "table"
+            and tonumber(e.stacks or e.count) or nil
+        if not id or not stacks or stacks < 1 or stacks ~= math.floor(stacks) then
+            return false, "invalid Echo list"
+        end
+        count = count + stacks
+        if count > 120 then return false, "too many Echoes" end
+    end
+    local fingerprint = D and D.GetEchoKey and D.GetEchoKey(build.echoes) or nil
+    if type(fingerprint) ~= "string" or fingerprint == "" then
+        local counts, ids = {}, {}
+        for i = 1, #build.echoes do
+            local e = build.echoes[i]
+            local id = tonumber(e.spellId or e.id)
+            counts[id] = (counts[id] or 0) + tonumber(e.stacks or e.count)
+        end
+        for id in pairs(counts) do ids[#ids + 1] = id end
+        table.sort(ids)
+        local parts = {}
+        for i = 1, #ids do
+            parts[#parts + 1] = tostring(ids[i]) .. "x" .. tostring(counts[ids[i]])
+        end
+        fingerprint = table.concat(parts, ",")
+    end
+    build.fingerprint = fingerprint
+    build.fingerprintHash = FingerprintHash(fingerprint)
+    build.echoCount = count
+    build.loadoutAvailable = true
+    build.needsFullBuild = false
+    return true
+end
+
 -- Ensure a personal-best Echo snapshot has a copyable community build page.
 -- Existing manual or automatic builds with the exact fingerprint are reused;
 -- a new deterministic record-loadout page is created only when none exists.
@@ -544,14 +656,82 @@ function M.EnsureDpsBuildForEchoes(echoes, category, record)
     if not (D and D.GetEchoKey) then return nil end
     local key = D.GetEchoKey(echoes)
     if not key then return nil end
-    local fallbackId, fallbackBuild
-    for id, build in pairs(Store()) do
-        if D.GetEchoKey(build.echoes) == key then
-            if not build.autoDps then return id, build end
-            fallbackId, fallbackBuild = fallbackId or id, fallbackBuild or build
+    local explicitClass = NormalizeClass(record and (record.class or record.k))
+    local player = tostring(record and record.player
+        or (UnitName and UnitName("player")) or "Unknown")
+    local recordOwner = record and record.ownerKey
+    local explicitId = record and (record.buildId or record.b)
+    if type(explicitId) ~= "string" or explicitId == "" then explicitId = nil end
+
+    -- A protocol build ID is an identity, not a derived alias. Never attach
+    -- its record to a different loadout or owner merely because IDs collide.
+    local explicitExisting = explicitId and Store()[explicitId] or nil
+    if explicitExisting then
+        local existingKey = explicitExisting.fingerprint
+            or D.GetEchoKey(explicitExisting.echoes)
+        if existingKey and existingKey ~= key then return nil end
+        if recordOwner and explicitExisting.ownerKey
+            and tostring(recordOwner):lower()
+                ~= tostring(explicitExisting.ownerKey):lower() then
+            return nil
+        end
+        if type(explicitExisting.echoes) ~= "table"
+            or #explicitExisting.echoes == 0 then
+            local copied = {}
+            for _, e in ipairs(echoes or {}) do
+                copied[#copied + 1] = {
+                    spellId=e.spellId or e.id,
+                    stacks=e.count or e.stacks or 1,
+                }
+            end
+            local refreshed = { echoes=copied }
+            if not RefreshBuildIdentity(refreshed) then return nil end
+            explicitExisting.echoes = copied
+            explicitExisting.fingerprint = refreshed.fingerprint
+            explicitExisting.fingerprintHash = refreshed.fingerprintHash
+            explicitExisting.echoCount = refreshed.echoCount
+            explicitExisting.loadoutAvailable = #copied > 0
+            explicitExisting.needsFullBuild = false
+            explicitExisting.tombstoned = nil
+            explicitExisting.autoDps = true
+            explicitExisting.author = explicitExisting.author or player
+            explicitExisting.ownerKey = explicitExisting.ownerKey or recordOwner
+            explicitExisting.class = explicitClass or explicitExisting.class
+                or InferBuildClass(copied) or "UNKNOWN"
+            if explicitExisting.title == "Loadout pending" then
+                explicitExisting.title = (CLASS_LABEL[explicitExisting.class]
+                    or explicitExisting.class) .. " Record Loadout"
+            end
+            explicitExisting.description = "Automatically completed from a compatible DPS record. Exact Echo IDs and stack quantities are preserved for copying and comparison."
+            explicitExisting.lastModified = NextStamp(
+                explicitExisting.lastModified or explicitExisting.postedAt or 0)
+            BroadcastIfPossible(explicitExisting)
+        end
+        return explicitId, explicitExisting
+    end
+
+    local ownAutoId, ownAutoBuild
+    local manualId, manualBuild
+    if not explicitId then
+        for id, build in pairs(Store()) do
+            if D.GetEchoKey(build.echoes) == key then
+                if not build.autoDps then
+                    if IsOwnBuild(build) then return id, build end
+                    manualId, manualBuild = manualId or id, manualBuild or build
+                else
+                    local sameOwner = recordOwner and build.ownerKey
+                        and tostring(recordOwner):lower()
+                            == tostring(build.ownerKey):lower()
+                    local sameLegacyAuthor = not recordOwner
+                        and tostring(build.author or ""):lower() == player:lower()
+                    if sameOwner or sameLegacyAuthor then
+                        ownAutoId, ownAutoBuild = id, build
+                    end
+                end
+            end
         end
     end
-    if fallbackId then return fallbackId, fallbackBuild end
+    if manualId then return manualId, manualBuild end
 
     local copied, seen = {}, {}
     for _, e in ipairs(echoes or {}) do
@@ -574,17 +754,43 @@ function M.EnsureDpsBuildForEchoes(echoes, category, record)
             end
         end
     end
-    local class = InferBuildClass(copied) or (select(2, UnitClass and UnitClass("player"))) or "UNKNOWN"
-    local player = tostring(record and record.player or (UnitName and UnitName("player")) or "Unknown")
     local me = tostring((UnitName and UnitName("player")) or "")
+    local playerIsLocal = player:lower() == me:lower()
+    local localClass
+    if playerIsLocal and UnitClass then
+        local _, token = UnitClass("player")
+        localClass = NormalizeClass(token)
+    end
+    local class = explicitClass or InferBuildClass(copied)
+        or localClass or "UNKNOWN"
+
+    if ownAutoId then
+        if explicitClass and ownAutoBuild.class ~= explicitClass then
+            ownAutoBuild.class = explicitClass
+            ownAutoBuild.title = (CLASS_LABEL[explicitClass] or explicitClass)
+                .. " Record Loadout"
+            ownAutoBuild.lastModified = NextStamp(
+                ownAutoBuild.lastModified or ownAutoBuild.postedAt)
+            BroadcastIfPossible(ownAutoBuild)
+        end
+        return ownAutoId, ownAutoBuild
+    end
+
     local stamp = NextStamp(0)
-    local id = "dps-" .. FingerprintHash(key)
+    local ownerKey = recordOwner or (playerIsLocal and CurrentOwnerKey() or nil)
+    local identity = ownerKey or player:lower()
+    local id = explicitId or ("dps-" .. FingerprintHash(key) .. "-"
+        .. FingerprintHash(identity):sub(1, 8))
     local build = {
         id=id, title=(CLASS_LABEL[class] or class) .. " Record Loadout",
         description="Automatically created from a verified DPS record. Exact Echo IDs and stack quantities are preserved for copying and comparison.",
-        author=player, class=class, echoes=copied, postedAt=stamp,
-        lastModified=stamp, isMine=(player == me), autoDps=true, fingerprint=key,
+        author=player, ownerKey=ownerKey, class=class, echoes=copied,
+        postedAt=stamp, lastModified=stamp,
+        isMine=(ownerKey and ownerKey == CurrentOwnerKey()) or false,
+        autoDps=true, fingerprint=key, loadoutAvailable=true,
+        needsFullBuild=false,
     }
+    if not RefreshBuildIdentity(build) then return nil end
     Store()[id] = build
     BroadcastIfPossible(build)
     return id, build
@@ -622,6 +828,9 @@ function M.PostCurrentWishlist(title, description, selectedWishlist, selectedCla
     end
     title = (title or ""):gsub("^%s+",""):gsub("%s+$","")
     if title == "" then title = (wl.name ~= "" and wl.name) or "Untitled" end
+    description = tostring(description or "")
+    if #title > 80 then return false, "title is too long" end
+    if #description > 2000 then return false, "description is too long" end
     local echoes = {}
     for _, e in ipairs(sourceEchoes) do
         echoes[#echoes+1] = { spellId=e.spellId, quality=e.quality, stacks=e.stacks or 1 }
@@ -629,11 +838,15 @@ function M.PostCurrentWishlist(title, description, selectedWishlist, selectedCla
     local stamp = NextStamp(0)
     local id = string.format("mine-%d-%d", stamp, math.random(100000,999999))
     local record = {
-        id=id, title=title, description=description or "",
+        id=id, title=title, description=description,
         author=(UnitName and UnitName("player")) or "You",
-        class=(selectedClass and tostring(selectedClass):upper()) or InferBuildClass(echoes) or wl.class,
+        ownerKey=CurrentOwnerKey(),
+        class=NormalizeClass(selectedClass) or InferBuildClass(echoes)
+            or NormalizeClass(wl.class),
         echoes=echoes, postedAt=stamp, lastModified=stamp, isMine=true,
     }
+    local identityOk, identityErr = RefreshBuildIdentity(record)
+    if not identityOk then return false, identityErr end
     Store()[id] = record
     BroadcastIfPossible(record)
     local D = Nexus.DpsCapture
@@ -673,19 +886,23 @@ function M.PublishImportedBuild(id)
         echoes[#echoes + 1] = { spellId=e.spellId, quality=e.quality, stacks=e.stacks or e.count or 1,
             locked = e.locked and true or false }
     end
-    local record = old or {}
-    record.id = publishedId
-    record.title = source.title or "Saved Build"
-    record.description = source.userDescription or source.description or ""
-    record.author = (UnitName and UnitName("player")) or "You"
-    record.class = source.class
-    record.echoes = echoes
-    record.postedAt = old and old.postedAt or stamp
-    record.lastModified = stamp
-    record.isMine = true
-    record.importedSavedBuild = nil
-    record.sourceSavedBuildId = id
-    record.serverSlot = nil
+    -- Build and validate a complete replacement before changing either record.
+    local record = {
+        id=publishedId,
+        title=source.title or "Saved Build",
+        description=source.userDescription or source.description or "",
+        author=(UnitName and UnitName("player")) or "You",
+        ownerKey=CurrentOwnerKey(),
+        class=NormalizeClass(source.class) or InferBuildClass(echoes),
+        echoes=echoes,
+        postedAt=old and old.postedAt or stamp,
+        lastModified=stamp,
+        isMine=true,
+        sourceSavedBuildId=id,
+        link=old and old.link or nil,
+    }
+    local identityOk, identityErr = RefreshBuildIdentity(record)
+    if not identityOk then return false, identityErr end
     Store()[publishedId] = record
     source.publishedBuildId = publishedId
     source.lastPublishedAt = stamp
@@ -695,18 +912,37 @@ function M.PublishImportedBuild(id)
     return true, publishedId
 end
 
-function M.EditBuild(id, title, description)
+function M.EditBuild(id, title, description, discordLink)
     local b = Store()[id]
     if not b then return false, "not found" end
     if not IsOwnBuild(b) then return false, "not your build" end
-    title = (title or ""):gsub("^%s+",""):gsub("%s+$","")
-    if title ~= "" then
-        b.title = title
-        if b.importedSavedBuild then b.userTitle = title end
+
+    -- Validate every candidate field before mutating any part of the record.
+    local nextTitle = tostring(title or ""):gsub("^%s+",""):gsub("%s+$","")
+    local nextDescription = description ~= nil
+        and tostring(description) or tostring(b.description or "")
+    if nextTitle == "" then nextTitle = tostring(b.title or "Untitled") end
+    if #nextTitle > 80 then return false, "title is too long" end
+    if #nextDescription > 2000 then return false, "description is too long" end
+    local nextLink = b.link
+    if discordLink ~= nil then
+        local raw = tostring(discordLink or "")
+        local normalized, linkErr = NormalizeDiscordBuildLink(raw)
+        if raw:match("^%s*$") then
+            nextLink = nil
+        elseif not normalized then
+            return false, linkErr or "invalid Discord build link"
+        else
+            nextLink = normalized
+        end
     end
-    if description ~= nil then
-        b.description = description
-        if b.importedSavedBuild then b.userDescription = description end
+
+    b.title = nextTitle
+    b.description = nextDescription
+    b.link = nextLink
+    if b.importedSavedBuild then
+        b.userTitle = nextTitle
+        b.userDescription = nextDescription
     end
     b.lastModified = NextStamp(b.lastModified or b.postedAt)
     -- Editing a server Saved Build mirror is local-only. It reaches the
@@ -735,7 +971,15 @@ function M.UpdateFromWishlist(id)
     for _, e in ipairs(wl.entries) do
         echoes[#echoes+1] = { spellId=e.spellId, quality=e.quality, stacks=e.stacks or 1 }
     end
+    local candidate = { echoes = echoes }
+    local identityOk, identityErr = RefreshBuildIdentity(candidate)
+    if not identityOk then return false, identityErr end
     b.echoes = echoes
+    b.fingerprint = candidate.fingerprint
+    b.fingerprintHash = candidate.fingerprintHash
+    b.echoCount = candidate.echoCount
+    b.loadoutAvailable = candidate.loadoutAvailable
+    b.needsFullBuild = candidate.needsFullBuild
     b.lastModified = NextStamp(b.lastModified or b.postedAt)
     BroadcastIfPossible(b)
     local D = Nexus.DpsCapture
@@ -809,7 +1053,6 @@ end
 
 function M.IsLockInPending() return pendingLockIn ~= nil end
 
-StaticPopupDialogs = StaticPopupDialogs or {}
 StaticPopupDialogs["NEXUS_LOCKIN_BUILD"] = {
     text = "Lock in '%s'?\nThis overwrites your current active wishlist.",
     button1 = "Lock In", button2 = "Cancel",
@@ -920,7 +1163,7 @@ local function EnsureDetailPanel(parent)
     -- get a box they can copy out in one click. Field is hidden when empty.
     local linkLabel = p:CreateFontString(nil,"OVERLAY","GameFontDisableSmall")
     linkLabel:SetPoint("TOPLEFT",10,-108)
-    linkLabel:SetText("|cff888888LINK TO BUILD|r")
+    linkLabel:SetText("|cff888888DISCORD BUILD LINK|r")
     p.linkLabel = linkLabel
 
     local linkBox = CreateFrame("EditBox",nil,p,"InputBoxTemplate")
@@ -951,11 +1194,14 @@ local function EnsureDetailPanel(parent)
         local link = linkBox:GetText():gsub("^%s+",""):gsub("%s+$","")
         local build = selectedId and Store()[selectedId]
         if not build or not IsOwnBuild(build) then return end
-        build.link = (link ~= "") and link or nil
-        build.lastModified = NextStamp(build.lastModified or build.postedAt)
-        BroadcastIfPossible(build)
-        print("|cff4dff80Nexus:|r build link saved.")
-        M.Refresh()
+        local ok, err = M.EditBuild(
+            selectedId, build.title, build.description, link)
+        if ok then
+            print("|cff4dff80Nexus:|r Discord build link saved.")
+            M.Refresh()
+        else
+            print("|cffff6060Nexus:|r " .. tostring(err))
+        end
     end)
     linkSaveBtn:SetScript("OnEnter", function(self)
         GameTooltip:SetOwner(self,"ANCHOR_TOP")
@@ -1619,8 +1865,9 @@ local function EnsureFrame()
     -- Main browser window: list and detail panel live together in one surface.
     frame = CreateFrame("Frame","NexusCommunityBuildsFrame",UIParent)
     frame:SetClampedToScreen(true)
-    UISpecialFrames = UISpecialFrames or {}
-    table.insert(UISpecialFrames, "NexusCommunityBuildsFrame")
+    if type(UISpecialFrames) == "table" then
+        table.insert(UISpecialFrames, "NexusCommunityBuildsFrame")
+    end
     frame:SetSize(1040,640)
     frame:SetPoint("CENTER")
     frame:SetFrameStrata("DIALOG")
@@ -2697,4 +2944,3 @@ function M.Toggle()
     if frame:IsShown() then frame:Hide()
     else M.Show() end
 end
-

--- a/ui/CommunityBuilds.lua
+++ b/ui/CommunityBuilds.lua
@@ -585,6 +585,15 @@ local function FingerprintHash(text)
     return string.format("%08x%08x", h1, h2)
 end
 
+local function CanonicalFingerprintHash(text)
+    if type(text) ~= "string" or text == "" then return nil end
+    local h = 5381
+    for i = 1, #text do
+        h = ((h * 33) + text:byte(i)) % 2147483648
+    end
+    return string.format("%x", h)
+end
+
 local function NormalizeDiscordBuildLink(value)
     local link = tostring(value or ""):gsub("^%s+",""):gsub("%s+$","")
     if link == "" then return nil end
@@ -641,7 +650,9 @@ RefreshBuildIdentity = function(build)
         fingerprint = table.concat(parts, ",")
     end
     build.fingerprint = fingerprint
-    build.fingerprintHash = FingerprintHash(fingerprint)
+    build.fingerprintHash = D and D.GetEchoHash
+        and D.GetEchoHash(build.echoes)
+        or CanonicalFingerprintHash(fingerprint)
     build.echoCount = count
     build.loadoutAvailable = true
     build.needsFullBuild = false
@@ -2898,6 +2909,13 @@ end
 function M.Init(adapter, model)
     Adapter, Model = adapter, model
     RemoveLegacyBuilds()  -- once at startup, not on every Store() access
+    -- Repair hashes written by the short-lived two-part hash implementation.
+    -- This is metadata-only: no timestamps or ownership fields are changed.
+    for _, build in pairs(Store()) do
+        if type(build.echoes) == "table" and #build.echoes > 0 then
+            RefreshBuildIdentity(build)
+        end
+    end
 end
 
 function M.Select(id)

--- a/ui/JournalTab.lua
+++ b/ui/JournalTab.lua
@@ -1149,7 +1149,7 @@ local function ShowWishlistPicker(anchor, wishes, linked, active, loadoutName, A
             row:SetHeight(20)
             row.text = row:CreateFontString(nil,"OVERLAY","GameFontDisableSmall")
             row.text:SetPoint("LEFT",6,0); row.text:SetText("Clear association")
-            row:SetHighlightTexture("Interface\QuestFrame\UI-QuestTitleHighlight", "ADD")
+            row:SetHighlightTexture("Interface\\QuestFrame\\UI-QuestTitleHighlight", "ADD")
             wishlistPicker.clearRow = row
         end
         row:ClearAllPoints(); row:SetPoint("TOPLEFT",6,-24-#wishes*rowH); row:SetPoint("RIGHT",-6,0)

--- a/ui/Leaderboard.lua
+++ b/ui/Leaderboard.lua
@@ -301,7 +301,7 @@ end
 
 local function EnsureFrame()
     if frame then return frame end
-    frame=CreateFrame("Frame","NexusLeaderboardFrame",UIParent); frame:SetClampedToScreen(true); UISpecialFrames=UISpecialFrames or {}; table.insert(UISpecialFrames,"NexusLeaderboardFrame")
+    frame=CreateFrame("Frame","NexusLeaderboardFrame",UIParent); frame:SetClampedToScreen(true); if type(UISpecialFrames)=="table" then table.insert(UISpecialFrames,"NexusLeaderboardFrame") end
     frame:SetSize(980,640); frame:SetPoint("CENTER"); frame:SetFrameStrata("DIALOG"); frame:SetFrameLevel(55); frame:EnableMouse(true); frame:SetMovable(true); frame:RegisterForDrag("LeftButton")
     frame:SetScript("OnDragStart",function(self) self:StartMoving() end); frame:SetScript("OnDragStop",function(self) self:StopMovingOrSizing() end); frame:Hide()
     pcall(function() frame:SetBackdrop({bgFile="Interface\\DialogFrame\\UI-DialogBox-Background",edgeFile="Interface\\DialogFrame\\UI-DialogBox-Border",tile=true,tileSize=32,edgeSize=32,insets={left=11,right=12,top=12,bottom=11}}) end)

--- a/ui/LogViewer.lua
+++ b/ui/LogViewer.lua
@@ -99,16 +99,16 @@ local function StartExport()
     StopExport()
     activeTab = "ai_export"
     for _, b in ipairs(tabButtons or {}) do b:UnlockHighlight() end
-    editBox:SetText("Preparing full AI diagnostic log...\n\nNexus is building this over multiple frames so gameplay stays responsive.")
+    editBox:SetText("Preparing full diagnostic log...\n\nNexus is building this over multiple frames so gameplay stays responsive.")
     statusFS:SetText("Preparing export...")
     local factory = Nexus and Nexus.NewAIExportCoroutine
     if type(factory) ~= "function" then
-        editBox:SetText("AI export builder is unavailable.")
+        editBox:SetText("Diagnostic export builder is unavailable.")
         return
     end
     local ok, job = pcall(factory)
     if not ok or type(job) ~= "thread" then
-        editBox:SetText("Could not start AI export: " .. tostring(job))
+        editBox:SetText("Could not start diagnostic export: " .. tostring(job))
         return
     end
     exportJob = job
@@ -128,7 +128,7 @@ local function StartExport()
             if not okResume then
                 exportJob = nil
                 self:SetScript("OnUpdate", nil); self:Hide()
-                editBox:SetText("AI export failed: " .. tostring(value))
+                editBox:SetText("Diagnostic export failed: " .. tostring(value))
                 statusFS:SetText("export failed")
                 return
             end
@@ -148,7 +148,7 @@ local function StartExport()
                 return
             end
             if updateElapsed >= 0.12 then
-                statusFS:SetText(tostring(value or "Building full AI log...") .. " -- you may keep playing")
+                statusFS:SetText(tostring(value or "Building full diagnostic log...") .. " -- you may keep playing")
                 updateElapsed = 0
             end
         end
@@ -159,8 +159,9 @@ local function EnsureFrame()
     if frame then return frame end
     frame = CreateFrame("Frame", "NexusLogViewer", UIParent)
     frame:SetClampedToScreen(true)
-    UISpecialFrames = UISpecialFrames or {}
-    table.insert(UISpecialFrames, "NexusLogViewer")
+    if type(UISpecialFrames) == "table" then
+        table.insert(UISpecialFrames, "NexusLogViewer")
+    end
     frame:SetSize(700, 440)
     frame:SetPoint("CENTER", UIParent, "CENTER", 0, 40)
     frame:SetMovable(true)
@@ -228,12 +229,12 @@ local function EnsureFrame()
     exportButton = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
     exportButton:SetSize(148, 22)
     exportButton:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -12, 7)
-    exportButton:SetText("Copy Full AI Log")
+    exportButton:SetText("Copy Full Diagnostic Log")
     exportButton:SetScript("OnClick", StartExport)
     exportButton:SetScript("OnEnter", function(self)
         GameTooltip:SetOwner(self, "ANCHOR_TOP")
         GameTooltip:SetText("Copy every retained decision and mismatch")
-        GameTooltip:AddLine("Creates one compact AI-ready block and selects it for Ctrl-C. The normal tabs stay shortened to prevent freezes.", 1, 1, 1, true)
+        GameTooltip:AddLine("Creates one compact diagnostic block and selects it for Ctrl-C. The normal tabs stay shortened to prevent freezes.", 1, 1, 1, true)
         GameTooltip:Show()
     end)
     exportButton:SetScript("OnLeave", function() GameTooltip:Hide() end)

--- a/ui/QuickStart.lua
+++ b/ui/QuickStart.lua
@@ -55,6 +55,7 @@ local function EnsureFrame()
     subtitle:SetText("Choose the path that matches where your character is now.")
 
     local body = frame:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    frame.body = body
     body:SetPoint("TOPLEFT", 24, -62)
     body:SetSize(372, 58)
     body:SetJustifyH("LEFT")

--- a/ui/WishlistEditor.lua
+++ b/ui/WishlistEditor.lua
@@ -815,7 +815,6 @@ end
 -- string import) both used it. This is destructive (it overwrites
 -- whatever's currently in that slot), so it goes through a confirmation
 -- popup rather than firing on click.
-StaticPopupDialogs = StaticPopupDialogs or {}
 local APPLY_FRIENDLY = {
     spacing = "the server is busy with another build operation -- try again in a moment",
     refused = "the server refused the change (are you in a state that allows editing your build?)",
@@ -1558,8 +1557,9 @@ local function EnsureFrame()
     if frame then return frame end
     frame = CreateFrame("Frame", "NexusEditorFrame", UIParent)
     frame:SetClampedToScreen(true)
-    UISpecialFrames = UISpecialFrames or {}
-    table.insert(UISpecialFrames, "NexusEditorFrame")
+    if type(UISpecialFrames) == "table" then
+        table.insert(UISpecialFrames, "NexusEditorFrame")
+    end
     frame:SetSize(1040, 680)
     frame:SetPoint("CENTER")
     frame:SetFrameStrata("DIALOG")


### PR DESCRIPTION
## Summary

- forward-port the proven Echo convergence, exact-quality wishlist, guarantee, Freeze, Banish, final-search, refusal-recovery, and wishlist-rotation behavior onto the Nexus 1.19.3 base
- add pre-click rare Tome of Echo protection while leaving Blizzard's bind confirmation fully client-owned
- harden chunked synchronization, transport-sender authority, DPS evidence, locked-Echo migration, current-run ownership, and Community Build identity/edit integrity
- add a development-only Lua 5.1-compatible regression harness with 70 runnable test programs

## Why

The working fixes existed against the older 1.19.2-private.2 implementation, while the actual player base had advanced to Nexus 1.19.3. Copying the older files wholesale would have overwritten newer UI, synchronization, diagnostics, and data protections. This ports the required behavior semantically while retaining the 1.19.3 architecture and version metadata.

The rare Tome failure was caused by automatic ToggleTomeEcho traffic beginning before the stock bind-on-use confirmation appeared. Synchronization and DPS paths also accepted insufficiently bounded or insufficiently owner-bound legacy input.

## Player and developer impact

Players keep the Nexus 1.19.3 interface and data while receiving deterministic quality-aware Echo selection, safer final-run behavior, rare Tome transaction protection, and stronger community-data integrity. Developers gain deterministic offline coverage for policy, lifecycle, Tome, sync, DPS, migration, ownership, and UI behavior.

## Validation

- Lua 5.1 parse: 96 passed, 0 failed
- all `tests/run_*.lua` programs: 70 passed, 0 failed
- installed player-file parse after local deployment: 25 passed, 0 failed
- `git diff --check`: passed
- production scans found no conflict markers, modern Lua syntax, named Echo priorities, fixed-position guarantee assumptions, protected popup ownership, or standalone AI text

## Live verification still required

- `/reload`
- consume a real rare Tome of Echo through the stock confirmation
- verify frozen-card persistence across RequestReroll
- watch for Lua errors, frame stalls, repeated refusal loops, incorrect freezes, or stale ownership