### PR TITLE
Harden Sync transport and fix Wishlist editor opening

### DIFF
--- a/core/DpsCapture.lua
+++ b/core/DpsCapture.lua
@@ -865,46 +865,69 @@ function DPS.BroadcastBestForBuild(buildId)
     return sent
 end
 
-function DPS.BroadcastAllBuildBests(peerHash, onlyBucket)
+function DPS.BroadcastAllBuildBests(peerHash, onlyBucket, progress)
     if peerHash and tostring(peerHash) == tostring(DPS.GetSyncHash()) then
         return 0, true
     end
+    progress = type(progress) == "table" and progress or {}
     MigrateLegacyLeaderboard()
     local peerBuckets = SplitBucketHash(peerHash)
     local myBuckets = SplitBucketHash(DPS.GetSyncHash())
     local legacyPeer = #peerBuckets ~= DPS_BUCKETS
     local n, complete = 0, true
     local store = CharacterBestStore()
+    local candidates = {}
     for _, category in ipairs({ "dummy", "lk" }) do
         for playerKey, row in pairs(store[category] or {}) do
             local bucket = DpsBucket(category, playerKey)
             if (not onlyBucket or bucket == onlyBucket) and (legacyPeer or tostring(peerBuckets[bucket] or "") ~= tostring(myBuckets[bucket] or ""))
                 and row and (tonumber(row.dps) or 0) > 0 and Sync and Sync.BroadcastDpsRecord then
-                local record = {
-                    protocolVersion=PROTOCOL_VERSION, fingerprint=row.fingerprint,
-                    loadoutHash=row.loadoutHash or EchoHashFromKey(row.fingerprint or ""),
-                    category=category, dps=math.floor(tonumber(row.dps) or 0),
-                    duration=tonumber(row.duration) or 0, ts=tonumber(row.ts) or 0,
-                    player=row.player or "?", level=tonumber(row.level) or 0, buildId=row.buildId,
-                    class=row.class, ownerKey=row.ownerKey, realm=row.realm,
-                    echoes=row.echoes,
-                    lockedEchoes=row.lockedEchoes,
+                local loadoutHash = row.loadoutHash
+                    or EchoHashFromKey(row.fingerprint or "")
+                candidates[#candidates + 1] = {
+                    key=table.concat({ category, tostring(playerKey),
+                        tostring(math.floor(tonumber(row.dps) or 0)),
+                        tostring(loadoutHash or "0") }, "|"),
+                    category=category, row=row, loadoutHash=loadoutHash,
                 }
-                local ok, result, why=pcall(Sync.BroadcastDpsRecord,record)
-                if ok and result~=false then
-                    n=n+1
-                    -- Also broadcast the build's echo list so peers can view
-                    -- and copy the exact loadout without needing the original
-                    -- player to be online.
-                    local build = row.buildId and (NexusDB and NexusDB.communityBuilds or {})[row.buildId]
-                    if build and type(build.echoes)=="table" and #build.echoes>0 and Sync.BroadcastBuild then
-                        pcall(Sync.BroadcastBuild, build)
-                    end
-                elseif not ok or why == "sync queue full" then
-                    -- Queue backpressure is temporary. Tell the mesh responder
-                    -- to retain this bucket so every owner record gets retried.
-                    complete=false
+            end
+        end
+    end
+    table.sort(candidates, function(a, b) return a.key < b.key end)
+    for _, item in ipairs(candidates) do
+        if not progress[item.key] then
+            local row, category = item.row, item.category
+            local record = {
+                protocolVersion=PROTOCOL_VERSION, fingerprint=row.fingerprint,
+                loadoutHash=item.loadoutHash,
+                category=category, dps=math.floor(tonumber(row.dps) or 0),
+                duration=tonumber(row.duration) or 0, ts=tonumber(row.ts) or 0,
+                player=row.player or "?", level=tonumber(row.level) or 0,
+                buildId=row.buildId, class=row.class, ownerKey=row.ownerKey,
+                realm=row.realm, echoes=row.echoes,
+                lockedEchoes=row.lockedEchoes,
+            }
+            local ok, result, why=pcall(Sync.BroadcastDpsRecord,record)
+            if ok and result~=false then
+                progress[item.key] = "admitted"
+                n=n+1
+                -- Also broadcast the build's echo list so peers can view and
+                -- copy it. DPS progress does not depend on this convenience
+                -- copy because the record already carries exact Echo evidence.
+                local build = row.buildId
+                    and (NexusDB and NexusDB.communityBuilds or {})[row.buildId]
+                if build and type(build.echoes)=="table"
+                    and #build.echoes>0 and Sync.BroadcastBuild then
+                    pcall(Sync.BroadcastBuild, build)
                 end
+            elseif not ok or why == "sync queue full" then
+                -- Stop at the first transient failure. The caller preserves
+                -- progress so the next attempt resumes here.
+                complete=false
+                break
+            else
+                -- Invalid/non-owner records are not retryable queue work.
+                progress[item.key] = "skipped"
             end
         end
     end

--- a/core/DpsCapture.lua
+++ b/core/DpsCapture.lua
@@ -866,12 +866,14 @@ function DPS.BroadcastBestForBuild(buildId)
 end
 
 function DPS.BroadcastAllBuildBests(peerHash, onlyBucket)
-    if peerHash and tostring(peerHash) == tostring(DPS.GetSyncHash()) then return 0 end
+    if peerHash and tostring(peerHash) == tostring(DPS.GetSyncHash()) then
+        return 0, true
+    end
     MigrateLegacyLeaderboard()
     local peerBuckets = SplitBucketHash(peerHash)
     local myBuckets = SplitBucketHash(DPS.GetSyncHash())
     local legacyPeer = #peerBuckets ~= DPS_BUCKETS
-    local n = 0
+    local n, complete = 0, true
     local store = CharacterBestStore()
     for _, category in ipairs({ "dummy", "lk" }) do
         for playerKey, row in pairs(store[category] or {}) do
@@ -888,7 +890,7 @@ function DPS.BroadcastAllBuildBests(peerHash, onlyBucket)
                     echoes=row.echoes,
                     lockedEchoes=row.lockedEchoes,
                 }
-                local ok, result=pcall(Sync.BroadcastDpsRecord,record)
+                local ok, result, why=pcall(Sync.BroadcastDpsRecord,record)
                 if ok and result~=false then
                     n=n+1
                     -- Also broadcast the build's echo list so peers can view
@@ -898,11 +900,15 @@ function DPS.BroadcastAllBuildBests(peerHash, onlyBucket)
                     if build and type(build.echoes)=="table" and #build.echoes>0 and Sync.BroadcastBuild then
                         pcall(Sync.BroadcastBuild, build)
                     end
+                elseif not ok or why == "sync queue full" then
+                    -- Queue backpressure is temporary. Tell the mesh responder
+                    -- to retain this bucket so every owner record gets retried.
+                    complete=false
                 end
             end
         end
     end
-    return n
+    return n, complete
 end
 
 -- Public board: one row per character for the selected encounter. The row is

--- a/core/Sync.lua
+++ b/core/Sync.lua
@@ -317,11 +317,16 @@ local function FiniteNumber(value)
         and value < math.huge and value > -math.huge
 end
 
-local function ValidField(value, maxBytes, allowEmpty)
+local function ValidText(value, maxBytes, allowEmpty)
     return type(value) == "string"
         and (allowEmpty or value ~= "")
         and #value <= maxBytes
-        and not value:find("[%c|]")
+        and not value:find("[%c]")
+end
+
+local function ValidField(value, maxBytes, allowEmpty)
+    return ValidText(value, maxBytes, allowEmpty)
+        and not value:find("|", 1, true)
 end
 
 local function ValidIdentifier(value, maxBytes)
@@ -868,7 +873,7 @@ local QueueLegacyRecovery
 local function StoreSummary(data, transportSender)
     if type(data) ~= "table" or not Codec.IsSafeTree(data, 4, 80)
         or not ValidIdentifier(data.id, MAX_BUILD_ID_BYTES)
-        or not ValidField(data.t, 120, false)
+        or not ValidText(data.t, 120, false)
         or not ValidPeerName(data.a)
         or not ValidHash(tostring(data.h or ""))
         or (data.lh ~= nil and not ValidHash(tostring(data.lh)))
@@ -1273,7 +1278,8 @@ function Sync.BroadcastDpsRecord(record)
         messages[#messages + 1] = string.format("%s|%s|%s|%d/%d|%s",
             CODE_DPS2, MyName(), transferId, i, total, data)
     end
-    if not EnqueueBatch(messages) then return false end
+    local queued, queueWhy = EnqueueBatch(messages)
+    if not queued then return false, queueWhy end
     LogEvent("TX","DPS2 [%s] %.0f by %s (%d chunks)",
         tostring(payload.c), payload.d, payload.p, total)
     return true
@@ -1539,9 +1545,10 @@ local function SendBucketResponse(entry, kind, bucket)
     else
         local D = Nexus.DpsCapture
         if D and D.BroadcastAllBuildBests then
-            local ok, result = pcall(D.BroadcastAllBuildBests, entry.peerDpsHash, bucket)
+            local ok, result, allAdmitted = pcall(
+                D.BroadcastAllBuildBests, entry.peerDpsHash, bucket)
             if ok then dpsN = tonumber(result) or 0 end
-            if not ok then complete = false end
+            complete = ok and allAdmitted == true
         end
     end
     LogEvent("RX", "mesh bucket %s%d for %s: %d build(s), %d record(s)",

--- a/core/Sync.lua
+++ b/core/Sync.lua
@@ -330,6 +330,14 @@ local function ValidIdentifier(value, maxBytes)
         and value:match("^[%w%._:@%+%-]+$") ~= nil
 end
 
+local function ValidTransferIdentifier(value)
+    -- Transfer IDs embed a player name, and valid WoW names may contain
+    -- non-ASCII UTF-8 bytes. Keep the wire delimiter/control protections
+    -- without applying the ASCII-oriented identifier character class.
+    return ValidField(value, MAX_TRANSFER_ID_BYTES, false)
+        and not value:find("%s")
+end
+
 local function ValidPeerName(value)
     return ValidField(value, 80, false)
         and not value:find("%s")
@@ -939,12 +947,12 @@ QueueLegacyRecovery = function(buildId)
     if build and type(build.echoes) == "table" and #build.echoes > 0 then return false end
     local now = Now()
     if requestedLoadouts[buildId] and now - requestedLoadouts[buildId] < 120 then return false end
-    requestedLoadouts[buildId] = now
     local depth = QueueDepth(legacyRecoveryHead, legacyRecoveryTail)
     if depth >= MAX_RECOVERY_QUEUE then
         RejectQueueOverflow("recovery", 1, depth, MAX_RECOVERY_QUEUE)
         return false
     end
+    requestedLoadouts[buildId] = now
     legacyRecoveryTail = legacyRecoveryTail + 1
     legacyRecoveryQueue[legacyRecoveryTail] = tostring(buildId)
     return true
@@ -1209,7 +1217,7 @@ function Sync.BroadcastDpsRecord(record)
     }
     local encoded = Codec.Base64Encode(Codec.JSONEncode(payload))
     local transferId = tostring(payload.p) .. ":" .. tostring(payload.t) .. ":" .. tostring(payload.d)
-    if not ValidIdentifier(transferId, MAX_TRANSFER_ID_BYTES)
+    if not ValidTransferIdentifier(transferId)
         or #encoded > MAX_ENCODED_BYTES then return false end
     local header = CODE_DPS2 .. "|" .. MyName() .. "|" .. transferId .. "|999/999|"
     local chunkSize = CHAT_LIMIT - CHAT_SAFETY - EscapedLen(header)
@@ -1248,7 +1256,7 @@ end
 local function HandleDps2(parts)
     local sender, transferId, spec, data = parts[2], parts[3], parts[4], parts[5]
     if not ValidPeerName(sender)
-        or not ValidIdentifier(transferId, MAX_TRANSFER_ID_BYTES)
+        or not ValidTransferIdentifier(transferId)
         or not ValidField(spec, 16, false)
         or not ValidField(data, MAX_CHUNK_BYTES, false) then return false end
     local idx, total = spec:match("^(%d+)/(%d+)$")
@@ -1621,10 +1629,20 @@ local function ProcessPendingResponses(elapsed)
     for _,entry in ipairs(loadoutReady) do
         local b=NexusDB and NexusDB.communityBuilds and NexusDB.communityBuilds[entry.buildId]
         if b and type(b.echoes)=="table" and #b.echoes>0 then
-            local claimed = EnqueueControl(string.format("%s|%s|%s|%s",
-                CODE_LOADOUT_CLAIM,MyName(),entry.requester,entry.buildId))
-            if claimed then
-                Sync.BroadcastBuild(b)
+            -- Queue the payload before publishing the prioritized claim. If
+            -- bulk backpressure rejects the build, keep this response pending
+            -- so another attempt or responder can still satisfy the request.
+            local sent, sendWhy = Sync.BroadcastBuild(b)
+            if sent and sendWhy ~= "duplicate suppressed" then
+                local claimed, claimWhy = EnqueueControl(string.format(
+                    "%s|%s|%s|%s",CODE_LOADOUT_CLAIM,MyName(),
+                    entry.requester,entry.buildId))
+                if not claimed then
+                    -- The payload is already retained in the bulk queue. It is
+                    -- safer to allow a duplicate response than to discard it.
+                    LogEvent("TX","loadout claim skipped for '%s': %s",
+                        tostring(entry.buildId),tostring(claimWhy or "control queue full"))
+                end
                 LogEvent("TX","answered on-demand loadout '%s' for %s",
                     tostring(entry.buildId),tostring(entry.requester))
             else

--- a/core/Sync.lua
+++ b/core/Sync.lua
@@ -84,7 +84,6 @@ local ANSWER_COOLDOWN  = 2     -- minimum gap between completed peer responses
 local CLAIM_DELAY_MIN  = 0.35  -- deterministic responder-election delay
 local CLAIM_DELAY_MAX  = 1.75
 local BUCKET_CLAIM_MAX = 5.50 -- wide deterministic window lets different peers win different buckets
-local BUCKET_SETTLE    = 1.50 -- allow a winning claim to propagate before payload queueing
 local HOT_WINDOW       = 120   -- seconds a just-posted build is re-included in answers
 local JOIN_RETRY_INTERVAL = 10
 local JOIN_MAX_ATTEMPTS   = 30
@@ -1081,17 +1080,50 @@ local function BroadcastMineFiltered(peerHash, onlyBucket)
     for id, h in pairs(hotBuilds) do
         if not myMine[id] and (Now()-h.t) <= HOT_WINDOW then myMine[id] = h.build end
     end
-    if not next(myMine) and not next(tombstones or {}) then LogEvent("TX","nothing to share"); return 0 end
+    if not next(myMine) and not next(tombstones or {}) then
+        LogEvent("TX","nothing to share")
+        return 0, true
+    end
     local myHash = LibraryHash(myMine)
     if peerHash and tostring(peerHash) == tostring(myHash) then
         LogEvent("TX","peer build buckets match -- sending nothing")
         stats.skippedUpToDate = (stats.skippedUpToDate or 0) + 1
-        return 0
+        return 0, true
     end
     local peerBuckets = SplitHashes(peerHash)
     local myBuckets = SplitHashes(myHash)
     local legacyPeer = #peerBuckets ~= BUILD_BUCKETS
     local n = 0
+    local queueTailBefore = sendQueueTail
+    local recentBefore, hotBefore = {}, {}
+    local function SnapshotBuildState(build)
+        local buildKey = tostring(build.id or build.fingerprintHash
+            or build.fingerprint or "")
+        if buildKey ~= "" and recentBefore[buildKey] == nil then
+            recentBefore[buildKey] = {
+                present = recentBuildBroadcast[buildKey] ~= nil,
+                value = recentBuildBroadcast[buildKey],
+            }
+        end
+        local id = build.id
+        if id ~= nil and hotBefore[id] == nil then
+            hotBefore[id] = {
+                present = hotBuilds[id] ~= nil,
+                value = hotBuilds[id],
+            }
+        end
+    end
+    local function RollBackBucketQueue()
+        for i = queueTailBefore + 1, sendQueueTail do sendQueue[i] = nil end
+        sendQueueTail = queueTailBefore
+        for key, prior in pairs(recentBefore) do
+            recentBuildBroadcast[key] = prior.present and prior.value or nil
+        end
+        for id, prior in pairs(hotBefore) do
+            hotBuilds[id] = prior.present and prior.value or nil
+        end
+    end
+    local complete = true
     for id, b in pairs(myMine) do
         local bucket = BuildBucket(id)
         if (not onlyBucket or bucket == onlyBucket)
@@ -1099,27 +1131,38 @@ local function BroadcastMineFiltered(peerHash, onlyBucket)
             -- Send the complete build during reconciliation so receivers never
             -- need to click a menu item to fetch its Echo list. Summary is only
             -- a compatibility fallback for legacy/incomplete local rows.
-            local ok = false
+            local ok, why = false, nil
             if type(b.echoes) == "table" and #b.echoes > 0 then
-                ok = Sync.BroadcastBuild(b)
+                SnapshotBuildState(b)
+                ok, why = Sync.BroadcastBuild(b)
             else
                 ok = BroadcastSummary(b)
             end
-            if ok then n=n+1 end
+            if not ok or why == "duplicate suppressed" then
+                complete = false
+                break
+            end
+            n=n+1
         end
     end
-    for id, tomb in pairs(tombstones or {}) do
+    for id, tomb in pairs(complete and (tombstones or {}) or {}) do
         local bucket = BuildBucket(id)
         if SamePeer(TombAuthor(tomb), MyName())
             and (not onlyBucket or bucket == onlyBucket)
             and (legacyPeer or tostring(peerBuckets[bucket] or "") ~= tostring(myBuckets[bucket] or "")) then
-            if Enqueue(string.format("%s|%s|%s|%s|%s", CODE_DELETE,
+            if not Enqueue(string.format("%s|%s|%s|%s|%s", CODE_DELETE,
                 MyName(), id, tostring(TombStamp(tomb)), TombAuthor(tomb))) then
-                n=n+1
+                complete = false
+                break
             end
+            n=n+1
         end
     end
-    return n
+    if not complete then
+        RollBackBucketQueue()
+        return 0, false
+    end
+    return n, true
 end
 
 local function BucketDelay(key, kind, bucket)
@@ -1490,18 +1533,20 @@ local function HandleComplete(buildId, lastMod, fullData, transportSender)
 end
 
 local function SendBucketResponse(entry, kind, bucket)
-    local n, dpsN = 0, 0
+    local n, dpsN, complete = 0, 0, true
     if kind == "B" then
-        n = BroadcastMineFiltered(entry.peerBuildHash, bucket)
+        n, complete = BroadcastMineFiltered(entry.peerBuildHash, bucket)
     else
         local D = Nexus.DpsCapture
         if D and D.BroadcastAllBuildBests then
             local ok, result = pcall(D.BroadcastAllBuildBests, entry.peerDpsHash, bucket)
             if ok then dpsN = tonumber(result) or 0 end
+            if not ok then complete = false end
         end
     end
     LogEvent("RX", "mesh bucket %s%d for %s: %d build(s), %d record(s)",
         kind, bucket, tostring(entry.requester), n, dpsN)
+    return complete
 end
 
 local function HandleRequest(requester, peerBuildHash, peerDpsHash, requestId)
@@ -1541,7 +1586,7 @@ local function HandleRequest(requester, peerBuildHash, peerDpsHash, requestId)
     for i=1,BUILD_BUCKETS do
         if tostring(peerB[i] or "") ~= tostring(myB[i] or "") then
             entry.buckets["B"..i]={kind="B",bucket=i,hash=tostring(myB[i] or "0"),
-                claimable=peerBuildBuckets and not BucketContainsTombstone(i),phase="wait",
+                claimable=peerBuildBuckets and not BucketContainsTombstone(i),
                 remaining=BucketDelay(key,"B",i)}
         end
         if tostring(peerD[i] or "") ~= tostring(myD[i] or "") then
@@ -1549,7 +1594,7 @@ local function HandleRequest(requester, peerBuildHash, peerDpsHash, requestId)
             -- same row cannot retransmit it, so DPS buckets are never elected
             -- through suppressible claims.
             entry.buckets["D"..i]={kind="D",bucket=i,hash=tostring(myD[i] or "0"),
-                claimable=false,phase="wait",remaining=BucketDelay(key,"D",i)}
+                claimable=false,remaining=BucketDelay(key,"D",i)}
         end
     end
     if next(entry.buckets) then pendingResponses[key]=entry end
@@ -1595,27 +1640,33 @@ local function ProcessPendingResponses(elapsed)
             for id,b in pairs(entry.buckets or {}) do
                 b.remaining=(tonumber(b.remaining) or 0)-elapsed
                 if b.remaining<=0 then
-                    if b.phase=="wait" and b.claimable ~= false then
-                        local queued = EnqueueControl(string.format(
-                            "%s|%s|%s|%s|%s|%d|%s",CODE_BUCKET_CLAIM,
-                            MyName(),entry.requester,entry.requestId,b.kind,
-                            b.bucket,b.hash))
-                        if queued then
-                            b.phase="settle"; b.remaining=BUCKET_SETTLE
-                        else
-                            b.remaining=1
-                        end
-                    else
-                        entry.buckets[id]=nil
-                        sends[#sends+1]={entry=entry,kind=b.kind,bucket=b.bucket}
-                    end
+                    sends[#sends+1]={key=key,id=id,entry=entry,bucketState=b,
+                        kind=b.kind,bucket=b.bucket}
                 end
             end
-            if not next(entry.buckets or {}) then pendingResponses[key]=nil end
         end
     end
     table.sort(sends,function(a,b) return (a.kind..a.bucket)<(b.kind..b.bucket) end)
-    for _,x in ipairs(sends) do SendBucketResponse(x.entry,x.kind,x.bucket) end
+    for _,x in ipairs(sends) do
+        if SendBucketResponse(x.entry,x.kind,x.bucket) then
+            if x.bucketState.claimable ~= false then
+                local claimed, claimWhy = EnqueueControl(string.format(
+                    "%s|%s|%s|%s|%s|%d|%s",CODE_BUCKET_CLAIM,
+                    MyName(),x.entry.requester,x.entry.requestId,x.kind,
+                    x.bucket,x.bucketState.hash))
+                if not claimed then
+                    -- The complete bucket payload is already retained. Sending
+                    -- it without a claim is safe; peers may only duplicate it.
+                    LogEvent("TX","bucket claim skipped for %s%d: %s",x.kind,
+                        x.bucket,tostring(claimWhy or "control queue full"))
+                end
+            end
+            x.entry.buckets[x.id]=nil
+            if not next(x.entry.buckets) then pendingResponses[x.key]=nil end
+        else
+            x.bucketState.remaining=1
+        end
+    end
     local loadoutReady={}
     for key,entry in pairs(pendingLoadouts) do
         if Now() - (tonumber(entry.createdAt) or Now()) > PENDING_TTL then

--- a/core/Sync.lua
+++ b/core/Sync.lua
@@ -125,6 +125,8 @@ local lastRequestAt  = -math.huge
 local lastAnsweredAt = -math.huge
 local pendingResponses = {} -- requester:requestId -> deferred response candidate
 local pendingLoadouts = {}  -- requester:buildId -> staggered on-demand response
+local pendingDeletes = {}   -- local tombstone ids awaiting direct notification
+local pendingDeleteTicker = 0
 local requestedLoadouts = {} -- buildId -> last recovery request time
 local legacyRecoveryQueue = {} -- incomplete summaries learned from older peers
 local legacyRecoveryHead = 1
@@ -234,7 +236,8 @@ local stats = {
 
 function Sync.WorkState()
     local buildCount, buildBytes, dpsCount, dpsBytes = 0, 0, 0, 0
-    local pendingResponseCount, pendingLoadoutCount, peerCount = 0, 0, 0
+    local pendingResponseCount, pendingLoadoutCount, pendingDeleteCount = 0, 0, 0
+    local peerCount = 0
     for _, entry in pairs(inflight) do
         buildCount = buildCount + 1
         buildBytes = buildBytes + (tonumber(entry.bytes) or 0)
@@ -249,6 +252,13 @@ function Sync.WorkState()
     for _ in pairs(pendingLoadouts) do
         pendingLoadoutCount = pendingLoadoutCount + 1
     end
+    for id in pairs(pendingDeletes) do
+        local tomb = tombstones and tombstones[id]
+        local author = type(tomb) == "table" and tostring(tomb.author or "") or ""
+        if tomb and SamePeer(author, MyName()) then
+            pendingDeleteCount = pendingDeleteCount + 1
+        end
+    end
     for _ in pairs(knownPeers) do peerCount = peerCount + 1 end
     local sending = math.max(0, sendQueueTail - sendQueueHead + 1)
     local control = math.max(0, controlQueueTail - controlQueueHead + 1)
@@ -262,6 +272,7 @@ function Sync.WorkState()
         recovery=recovery,
         pendingResponses=pendingResponseCount,
         pendingLoadouts=pendingLoadoutCount,
+        pendingDeletes=pendingDeleteCount,
         knownPeers=peerCount,
         maxOutboundQueue=MAX_OUTBOUND_QUEUE,
         maxControlQueue=MAX_CONTROL_QUEUE,
@@ -876,6 +887,67 @@ local function BroadcastSummary(build)
 end
 Sync.BroadcastBuildSummary = BroadcastSummary
 
+local function DeleteWireMessage(id, tomb)
+    return string.format("%s|%s|%s|%s|%s", CODE_DELETE, MyName(),
+        tostring(id), tostring(TombStamp(tomb)), TombAuthor(tomb))
+end
+
+local function MarkDeletePending(id, tomb)
+    pendingDeletes[id] = true
+    if type(tomb) == "table" then tomb.pending = true end
+end
+
+local function ClearPendingDelete(id, tomb)
+    pendingDeletes[id] = nil
+    if type(tomb) == "table" and tombstones[id] == tomb then
+        tomb.pending = nil
+    end
+end
+
+local function PendingDeleteCount()
+    local count = 0
+    for id in pairs(pendingDeletes) do
+        local tomb = tombstones[id]
+        if tomb and SamePeer(TombAuthor(tomb), MyName()) then
+            count = count + 1
+        end
+    end
+    return count
+end
+
+local function PumpPendingDeletes(elapsed)
+    if not next(pendingDeletes) then return end
+    pendingDeleteTicker = pendingDeleteTicker + (tonumber(elapsed) or 0)
+    if pendingDeleteTicker < 1 then return end
+    if QueueDepth(sendQueueHead, sendQueueTail) >= MAX_OUTBOUND_QUEUE then
+        pendingDeleteTicker = 1
+        return
+    end
+    local selectedId, selectedTomb
+    for id in pairs(pendingDeletes) do
+        local tomb = tombstones[id]
+        if not tomb then
+            pendingDeletes[id] = nil
+        elseif SamePeer(TombAuthor(tomb), MyName())
+            and (not selectedId or tostring(id) < tostring(selectedId)) then
+            selectedId, selectedTomb = id, tomb
+        end
+    end
+    if not selectedId then return end
+    pendingDeleteTicker = 0
+    local queued, why = Enqueue(DeleteWireMessage(selectedId, selectedTomb))
+    if queued then
+        ClearPendingDelete(selectedId, selectedTomb)
+        LogEvent("TX", "queued pending delete '%s'", tostring(selectedId))
+    elseif why ~= "sync queue full" then
+        -- A permanent local serialization failure cannot be helped by retrying;
+        -- the tombstone remains available to normal reconciliation.
+        ClearPendingDelete(selectedId, selectedTomb)
+        LogEvent("TX", "dropping unsendable pending delete '%s': %s",
+            tostring(selectedId), tostring(why or "invalid packet"))
+    end
+end
+
 local QueueLegacyRecovery
 
 local function StoreSummary(data, transportSender)
@@ -1157,6 +1229,9 @@ local function BroadcastMineFiltered(peerHash, onlyBucket, progress)
             end
             if ok and why ~= "duplicate suppressed" then
                 progress[item.token] = "admitted"
+                if item.kind == "tomb" then
+                    ClearPendingDelete(item.id, item.tomb)
+                end
                 n = n + 1
             elseif why == "sync queue full"
                 or why == "duplicate suppressed" then
@@ -1382,11 +1457,21 @@ function Sync.BroadcastDelete(build)
     local stamp = tostring((time and time()) or 0)
     local author = tostring(build.author or MyName())
     if not SamePeer(author, MyName()) then return false end
-    tombstones[build.id] = { stamp=tonumber(stamp) or 0, author=author }
-    local queued = Enqueue(string.format("%s|%s|%s|%s|%s",
-        CODE_DELETE, MyName(), build.id, stamp, author))
-    LogEvent("TX","delete '%s'", tostring(build.title or build.id))
-    return queued and true or false
+    local tomb = { stamp=tonumber(stamp) or 0, author=author }
+    tombstones[build.id] = tomb
+    local queued, why = Enqueue(DeleteWireMessage(build.id, tomb))
+    if queued then
+        ClearPendingDelete(build.id, tomb)
+        LogEvent("TX","delete '%s'", tostring(build.title or build.id))
+        return true
+    end
+    if why == "sync queue full" then
+        MarkDeletePending(build.id, tomb)
+        LogEvent("TX", "delete '%s' queued for retry",
+            tostring(build.title or build.id))
+        return false, "queued for retry"
+    end
+    return false, why
 end
 
 ------------------------------------------------------------------------
@@ -2066,6 +2151,7 @@ local function QueueBusy()
     if sendQueue[sendQueueHead] then return true end
     if next(inflight) or next(dpsInflight) then return true end
     if next(pendingResponses) or next(pendingLoadouts) then return true end
+    if PendingDeleteCount() > 0 then return true end
     if legacyRecoveryHead <= legacyRecoveryTail
         and legacyRecoveryQueue[legacyRecoveryHead] then return true end
     return false
@@ -2121,6 +2207,7 @@ local function SyncWorkCounts()
     for _ in pairs(dpsInflight) do work.receivingRecords = work.receivingRecords + 1 end
     for _ in pairs(pendingResponses) do work.preparing = work.preparing + 1 end
     for _ in pairs(pendingLoadouts) do work.preparing = work.preparing + 1 end
+    work.preparing = work.preparing + PendingDeleteCount()
     if legacyRecoveryHead <= legacyRecoveryTail
         and legacyRecoveryQueue[legacyRecoveryHead] then
         for i = legacyRecoveryHead, legacyRecoveryTail do
@@ -2184,6 +2271,7 @@ function Sync.OnUpdate(elapsed)
     CleanExpiredInflight()
     ProcessPendingResponses(elapsed)
     PumpLegacyRecovery(elapsed)
+    PumpPendingDeletes(elapsed)
     PumpQueue(elapsed)
     if Sync.FlushStatusReply then Sync.FlushStatusReply() end
     if autoSyncPending then
@@ -2302,6 +2390,8 @@ function Sync.Init(codec, adapter)
     hotBuilds    = {}  -- clear on init
     pendingResponses = {}
     pendingLoadouts = {}
+    pendingDeletes = {}
+    pendingDeleteTicker = 0
     requestedLoadouts = {}
     legacyRecoveryQueue = {}
     legacyRecoveryHead = 1
@@ -2315,6 +2405,11 @@ function Sync.Init(codec, adapter)
     NexusDB = NexusDB or {}
     NexusDB.syncTombstones = NexusDB.syncTombstones or {}
     tombstones = NexusDB.syncTombstones
+    for id, tomb in pairs(tombstones) do
+        if type(tomb) == "table" and tomb.pending then
+            pendingDeletes[id] = true
+        end
+    end
     autoSyncPending = true
     autoSyncElapsed = 0
     InstallTransportFilters()

--- a/core/Sync.lua
+++ b/core/Sync.lua
@@ -56,15 +56,29 @@ local PEER_PROTOCOL_CODES = {
 }
 local CHAT_LIMIT      = 255    -- WoW SendChatMessage hard cap
 local CHAT_SAFETY     = 8      -- conservative margin
-local MAX_BYTES       = 32768  -- refuse builds larger than this
+local MAX_WIRE_BYTES  = CHAT_LIMIT
+local MAX_BYTES       = 32768  -- maximum encoded bytes per transfer
 local MAX_CHUNKS      = 999
 local MAX_CHUNK_BYTES = CHAT_LIMIT
-local MAX_ENCODED_BYTES = math.ceil(MAX_BYTES * 4 / 3) + 32
+local MAX_ENCODED_BYTES = MAX_BYTES
+local MAX_BUILD_ID_BYTES = 96
+local MAX_BUILD_ECHOES = 256
+local MAX_TRANSFER_ID_BYTES = 160
+local MAX_REQUEST_ID_BYTES = 96
+local MAX_HASH_BYTES = 192
+local MAX_VERSION_BYTES = 32
 local MAX_INFLIGHT_GLOBAL = 24
 local MAX_INFLIGHT_PER_SENDER = 4
+local MAX_OUTBOUND_QUEUE = 8192
+local MAX_CONTROL_QUEUE = 512
+local MAX_RECOVERY_QUEUE = 512
+local MAX_PENDING_RESPONSES = 128
+local MAX_PENDING_LOADOUTS = 128
+local MAX_KNOWN_PEERS = 512
 local SEND_INTERVAL   = 1.10   -- conservative channel pacing; avoids server chat spam/mutes
 local RECEIVE_WINDOW  = 60     -- compatibility/status timer; receiving is always enabled
 local INFLIGHT_GRACE  = 30     -- seconds to finish an interrupted chunk transfer
+local INFLIGHT_MAX_AGE = 300   -- absolute cap even if duplicate chunks keep arriving
 local REQUEST_COOLDOWN = 6     -- min seconds between our own Sync Now presses
 local ANSWER_COOLDOWN  = 2     -- minimum gap between completed peer responses
 local CLAIM_DELAY_MIN  = 0.35  -- deterministic responder-election delay
@@ -80,6 +94,7 @@ local AUTO_SYNC_DELAY      = 6
 local AUTO_SYNC_MIN_PASS    = 60  -- allow throttled peers time to begin/drain large responses
 local AUTO_SYNC_QUIET       = 15  -- require a real quiet period before judging a pass stable
 local AUTO_SYNC_MAX_PASSES  = 0   -- retained for diagnostics; convergence now ends only when stable
+local PENDING_TTL           = 30
 
 ------------------------------------------------------------------------
 -- Module state
@@ -89,8 +104,10 @@ local Codec, Adapter
 local channelIndex
 local sendQueue      = {}
 local sendQueueHead  = 1
+local sendQueueTail  = 0
 local controlQueue   = {} -- tiny election/control packets; always drain before bulk chunks
 local controlQueueHead = 1
+local controlQueueTail = 0
 local inflight       = {}
 local dpsInflight    = {}   -- "sender:id" -> { chunks, total, t0, lastMod }
 local seenRemoteIds  = {}   -- id -> lastModified we already hold
@@ -111,6 +128,7 @@ local pendingLoadouts = {}  -- requester:buildId -> staggered on-demand response
 local requestedLoadouts = {} -- buildId -> last recovery request time
 local legacyRecoveryQueue = {} -- incomplete summaries learned from older peers
 local legacyRecoveryHead = 1
+local legacyRecoveryTail = 0
 local legacyRecoveryTicker = 0
 local lastSyncNewCount = 0
 local autoSyncPending = false
@@ -160,16 +178,41 @@ local function CanStartTransfer(map, sender)
 end
 
 local function MarkPeer(name, version)
-    if not name or name == "" then return end
+    if not name or name == "" then return false end
     local me = MyName and MyName() or ""
-    if NormalizePeerName(name) == NormalizePeerName(me) then return end
+    if NormalizePeerName(name) == NormalizePeerName(me) then return false end
     local key = NormalizePeerName(name)
-    if key == "" then return end
+    if key == "" then return false end
+    local now = Now and Now() or ((GetTime and GetTime()) or 0)
+    if not knownPeers[key] then
+        local count = 0
+        for peerKey, peer in pairs(knownPeers) do
+            if now - (tonumber(peer.lastSeen) or 0) > 7200 then
+                knownPeers[peerKey] = nil
+            else
+                count = count + 1
+            end
+        end
+        if count >= MAX_KNOWN_PEERS then return false end
+    end
     local peer = knownPeers[key] or {}
     peer.name = tostring(name):match("^([^%-]+)") or tostring(name)
     if version and version ~= "" then peer.version = tostring(version) end
-    peer.lastSeen = Now and Now() or ((GetTime and GetTime()) or 0)
+    peer.lastSeen = now
     knownPeers[key] = peer
+    return true
+end
+
+local function SameTransportSender(declared, actual)
+    local declaredText = tostring(declared or ""):gsub("%s+", ""):lower()
+    local actualText = tostring(actual or ""):gsub("%s+", ""):lower()
+    if declaredText:find("-", 1, true)
+        and actualText:find("-", 1, true) then
+        return declaredText == actualText
+    end
+    -- Current wire senders use UnitName("player") without a realm. Preserve
+    -- that legacy form while requiring exact realms when both sides carry one.
+    return SamePeer(declaredText, actualText)
 end
 
 function Sync.GetPeerInfo(name)
@@ -186,10 +229,12 @@ local stats = {
     sent=0, received=0, duplicatesSkipped=0,
     malformedRejected=0, ignoredOutsideWindow=0,
     oversizeDropped=0, updated=0, skippedUpToDate=0,
+    queueOverflowRejected=0, pendingOverflowRejected=0,
 }
 
 function Sync.WorkState()
     local buildCount, buildBytes, dpsCount, dpsBytes = 0, 0, 0, 0
+    local pendingResponseCount, pendingLoadoutCount, peerCount = 0, 0, 0
     for _, entry in pairs(inflight) do
         buildCount = buildCount + 1
         buildBytes = buildBytes + (tonumber(entry.bytes) or 0)
@@ -198,11 +243,32 @@ function Sync.WorkState()
         dpsCount = dpsCount + 1
         dpsBytes = dpsBytes + (tonumber(entry.bytes) or 0)
     end
+    for _ in pairs(pendingResponses) do
+        pendingResponseCount = pendingResponseCount + 1
+    end
+    for _ in pairs(pendingLoadouts) do
+        pendingLoadoutCount = pendingLoadoutCount + 1
+    end
+    for _ in pairs(knownPeers) do peerCount = peerCount + 1 end
+    local sending = math.max(0, sendQueueTail - sendQueueHead + 1)
+    local control = math.max(0, controlQueueTail - controlQueueHead + 1)
+    local recovery = math.max(0, legacyRecoveryTail - legacyRecoveryHead + 1)
     return {
         buildInflight=buildCount, buildBytes=buildBytes,
         dpsInflight=dpsCount, dpsBytes=dpsBytes,
         maxGlobal=MAX_INFLIGHT_GLOBAL, maxPerSender=MAX_INFLIGHT_PER_SENDER,
         maxEncodedBytes=MAX_ENCODED_BYTES,
+        sending=sending, control=control, outbound=sending + control,
+        recovery=recovery,
+        pendingResponses=pendingResponseCount,
+        pendingLoadouts=pendingLoadoutCount,
+        knownPeers=peerCount,
+        maxOutboundQueue=MAX_OUTBOUND_QUEUE,
+        maxControlQueue=MAX_CONTROL_QUEUE,
+        maxRecoveryQueue=MAX_RECOVERY_QUEUE,
+        maxPendingResponses=MAX_PENDING_RESPONSES,
+        maxPendingLoadouts=MAX_PENDING_LOADOUTS,
+        maxKnownPeers=MAX_KNOWN_PEERS,
     }
 end
 
@@ -250,6 +316,47 @@ end
 local function FiniteNumber(value)
     return type(value) == "number" and value == value
         and value < math.huge and value > -math.huge
+end
+
+local function ValidField(value, maxBytes, allowEmpty)
+    return type(value) == "string"
+        and (allowEmpty or value ~= "")
+        and #value <= maxBytes
+        and not value:find("[%c|]")
+end
+
+local function ValidIdentifier(value, maxBytes)
+    return ValidField(value, maxBytes, false)
+        and value:match("^[%w%._:@%+%-]+$") ~= nil
+end
+
+local function ValidPeerName(value)
+    return ValidField(value, 80, false)
+        and not value:find("%s")
+end
+
+local function ValidHash(value)
+    return ValidField(value, MAX_HASH_BYTES, false)
+        and value:match("^[%x,]+$") ~= nil
+end
+
+local function ValidVersion(value)
+    return ValidField(value, MAX_VERSION_BYTES, false)
+        and value:match("^[%w%.%+%-]+$") ~= nil
+end
+
+local function ValidIntegerText(value, minimum)
+    if not ValidField(value, 24, false)
+        or value:match("^%-?%d+$") == nil then return false end
+    local number = tonumber(value)
+    return FiniteNumber(number) and number == math.floor(number)
+        and number >= (minimum or 0)
+end
+
+local function TableCount(value)
+    local count = 0
+    for _ in pairs(value or {}) do count = count + 1 end
+    return count
 end
 
 -- djb2 hash of the caller's library so peers can skip sends when already
@@ -378,7 +485,12 @@ local function CompactDecode(data)
     local class  = data.c or data.class
     local lastMod = tonumber(data.m or data.lastModified or data.postedAt) or 0
     local rawE   = data.e or data.echoes
-    if not (data.id and title and type(rawE) == "table") then return nil end
+    if not (ValidIdentifier(data.id, MAX_BUILD_ID_BYTES)
+        and type(title) == "string" and title ~= ""
+        and type(author) == "string" and ValidPeerName(author)
+        and type(rawE) == "table" and #rawE <= MAX_BUILD_ECHOES) then
+        return nil
+    end
     if not OwnerKeyMatchesAuthor(ownerKey, author) then return nil end
     local echoes = {}
     for _, e in ipairs(rawE) do
@@ -462,6 +574,7 @@ function Sync.EnsureChannel()
         LogEvent("CHAN","joined '%s' at index %d", SYNC_CHANNEL, idx)
         return true
     end
+    channelIndex = nil
     LogEvent("CHAN","FAILED to join '%s'", SYNC_CHANNEL)
     return false
 end
@@ -470,6 +583,30 @@ function Sync.ChannelName()  return SYNC_CHANNEL end
 function Sync.ChannelIndex() return channelIndex end
 function Sync.IsConnected()  return channelIndex ~= nil and channelIndex > 0 end
 function Sync.Stats()        return stats end
+
+local function ResolveSendChannel()
+    -- Channel numbers are not stable: leaving/joining any channel can move
+    -- wrbuildssync while the old slot is reassigned to General or Trade.
+    -- Re-resolve the name immediately before each queued channel send.
+    local idx = FindSyncChannel()
+    if idx then
+        if channelIndex ~= idx then
+            LogEvent("CHAN", "'%s' moved from slot %s to %d",
+                SYNC_CHANNEL, tostring(channelIndex), idx)
+        end
+        channelIndex = idx
+        return idx
+    end
+    channelIndex = nil
+    if not Sync.EnsureChannel() then return nil end
+    idx = FindSyncChannel()
+    if not idx then
+        channelIndex = nil
+        return nil
+    end
+    channelIndex = idx
+    return idx
+end
 
 ------------------------------------------------------------------------
 -- Receive window
@@ -485,12 +622,70 @@ function Sync.LastSyncNewCount()  return lastSyncNewCount end
 -- Send queue (rate-limited, anti-spam)
 ------------------------------------------------------------------------
 
+local function QueueDepth(head, tail)
+    return math.max(0, (tonumber(tail) or 0) - (tonumber(head) or 1) + 1)
+end
+
+local function ValidateQueuedPayload(payload)
+    if type(payload) ~= "string" or payload == "" then return false end
+    if EscapedLen(payload) > CHAT_LIMIT then
+        stats.oversizeDropped = (stats.oversizeDropped or 0) + 1
+        LogEvent("TX", "REJECT oversize queued msg (%d>%d): %s",
+            EscapedLen(payload), CHAT_LIMIT, payload:sub(1, 40))
+        return false
+    end
+    return true
+end
+
+local function RejectQueueOverflow(kind, need, depth, cap)
+    stats.queueOverflowRejected = (stats.queueOverflowRejected or 0) + 1
+    LogEvent("TX", "REJECT newest %s packet(s): queue full (%d+%d>%d)",
+        tostring(kind), tonumber(depth) or 0, tonumber(need) or 1,
+        tonumber(cap) or 0)
+    return false, "sync queue full"
+end
+
 local function Enqueue(payload)
-    sendQueue[#sendQueue+1] = payload
+    if not ValidateQueuedPayload(payload) then return false, "invalid packet" end
+    local depth = QueueDepth(sendQueueHead, sendQueueTail)
+    if depth >= MAX_OUTBOUND_QUEUE then
+        return RejectQueueOverflow("bulk", 1, depth, MAX_OUTBOUND_QUEUE)
+    end
+    sendQueueTail = sendQueueTail + 1
+    sendQueue[sendQueueTail] = payload
+    return true
+end
+
+local function EnqueueBatch(payloads)
+    if type(payloads) ~= "table" or #payloads == 0 then
+        return false, "empty batch"
+    end
+    for i = 1, #payloads do
+        if not ValidateQueuedPayload(payloads[i]) then
+            return false, "invalid packet"
+        end
+    end
+    local depth = QueueDepth(sendQueueHead, sendQueueTail)
+    if depth + #payloads > MAX_OUTBOUND_QUEUE then
+        return RejectQueueOverflow("bulk batch", #payloads, depth,
+            MAX_OUTBOUND_QUEUE)
+    end
+    for i = 1, #payloads do
+        sendQueueTail = sendQueueTail + 1
+        sendQueue[sendQueueTail] = payloads[i]
+    end
+    return true
 end
 
 local function EnqueueControl(payload)
-    controlQueue[#controlQueue+1] = payload
+    if not ValidateQueuedPayload(payload) then return false, "invalid packet" end
+    local depth = QueueDepth(controlQueueHead, controlQueueTail)
+    if depth >= MAX_CONTROL_QUEUE then
+        return RejectQueueOverflow("control", 1, depth, MAX_CONTROL_QUEUE)
+    end
+    controlQueueTail = controlQueueTail + 1
+    controlQueue[controlQueueTail] = payload
+    return true
 end
 
 local function IsWaitingNotice(text)
@@ -535,6 +730,22 @@ local function InstallTransportFilters()
     end
 end
 
+local function PopQueued(isControl)
+    if isControl then
+        controlQueue[controlQueueHead] = nil
+        controlQueueHead = controlQueueHead + 1
+        if controlQueueHead > controlQueueTail then
+            controlQueue, controlQueueHead, controlQueueTail = {}, 1, 0
+        end
+    else
+        sendQueue[sendQueueHead] = nil
+        sendQueueHead = sendQueueHead + 1
+        if sendQueueHead > sendQueueTail then
+            sendQueue, sendQueueHead, sendQueueTail = {}, 1, 0
+        end
+    end
+end
+
 local function PumpQueue(elapsed)
     local now = Now()
     if now < (throttlePauseUntil or 0) then return end
@@ -546,39 +757,35 @@ local function PumpQueue(elapsed)
     local isControl = payload ~= nil
     if not payload then payload = sendQueue[sendQueueHead] end
     if not payload then
-        -- Compact only after the queue drains. This avoids O(n) table.remove
-        -- shifts for every transmitted chunk during a large mesh sync.
-        if sendQueueHead > 1 then sendQueue = {}; sendQueueHead = 1 end
-        if controlQueueHead > 1 then controlQueue = {}; controlQueueHead = 1 end
+        if sendQueueHead > sendQueueTail then
+            sendQueue, sendQueueHead, sendQueueTail = {}, 1, 0
+        end
+        if controlQueueHead > controlQueueTail then
+            controlQueue, controlQueueHead, controlQueueTail = {}, 1, 0
+        end
         return
     end
-    if not Sync.IsConnected() then
-        Sync.EnsureChannel()
-        if not Sync.IsConnected() then return end
+    local validatedChannel = ResolveSendChannel()
+    if not validatedChannel then
+        -- Retain the head packet. Reconnect/revalidation will retry later.
+        return
     end
     local escaped = payload:gsub("|","||")
     if #escaped > CHAT_LIMIT then
         LogEvent("TX","DROPPED oversize msg (%d>%d): %s",
             #escaped, CHAT_LIMIT, payload:sub(1,40))
         stats.oversizeDropped = (stats.oversizeDropped or 0) + 1
-        if isControl then
-            controlQueue[controlQueueHead] = nil; controlQueueHead = controlQueueHead + 1
-        else
-            sendQueue[sendQueueHead] = nil; sendQueueHead = sendQueueHead + 1
-        end
+        PopQueued(isControl)
         return
     end
     lastTransportAttempt = now
-    local ok = pcall(SendChatMessage, escaped, "CHANNEL", nil, channelIndex)
+    local ok = pcall(SendChatMessage, escaped, "CHANNEL", nil,
+        validatedChannel)
     if ok then
-        if isControl then
-            controlQueue[controlQueueHead] = nil; controlQueueHead = controlQueueHead + 1
-        else
-            sendQueue[sendQueueHead] = nil; sendQueueHead = sendQueueHead + 1
-        end
+        PopQueued(isControl)
         stats.sent = stats.sent + 1
         LogEvent("TX","sent %d chars ch=%s: %s",
-            #escaped, tostring(channelIndex), payload:sub(1,44))
+            #escaped, tostring(validatedChannel), payload:sub(1,44))
     else
         -- Keep the packet queued. A temporary chat/channel failure must not
         -- discard a build, DPS update, deletion, or reconciliation response.
@@ -638,11 +845,12 @@ end
 
 local function BroadcastSummary(build)
     local payload = SummaryEncode(build)
-    if not payload.id or not payload.h then return false end
+    if not ValidIdentifier(payload.id, MAX_BUILD_ID_BYTES)
+        or not ValidHash(tostring(payload.h or "")) then return false end
     local data = Codec.Base64Encode(Codec.JSONEncode(payload))
     local msg = string.format("%s|%s|%s", CODE_INDEX, MyName(), data)
     if EscapedLen(msg) > CHAT_LIMIT - CHAT_SAFETY then return false end
-    Enqueue(msg)
+    if not Enqueue(msg) then return false end
     LogEvent("TX","queuing summary '%s' (%d chars, no Echo list)", tostring(build.title), EscapedLen(msg))
     return true
 end
@@ -651,27 +859,38 @@ Sync.BroadcastBuildSummary = BroadcastSummary
 local QueueLegacyRecovery
 
 local function StoreSummary(data, transportSender)
-    if type(data)~="table" or not data.id or not data.t or not data.h then return false end
+    if type(data) ~= "table" or not Codec.IsSafeTree(data, 4, 80)
+        or not ValidIdentifier(data.id, MAX_BUILD_ID_BYTES)
+        or not ValidField(data.t, 120, false)
+        or not ValidPeerName(data.a)
+        or not ValidHash(tostring(data.h or ""))
+        or (data.lh ~= nil and not ValidHash(tostring(data.lh)))
+        or not FiniteNumber(tonumber(data.m))
+        or tonumber(data.m) < 0
+        or (data.n ~= nil and (not FiniteNumber(tonumber(data.n))
+            or tonumber(data.n) < 0 or tonumber(data.n) > 10000)) then
+        return false, false
+    end
     if not SamePeer(data.a, transportSender)
         or not OwnerKeyMatchesAuthor(data.o or data.ownerKey, data.a) then
-        return false
+        return false, false
     end
     NexusDB.communityBuilds = NexusDB.communityBuilds or {}
     local id = tostring(data.id)
     local old = NexusDB.communityBuilds[id]
-    if old and old.isMine then return false end
+    if old and old.isMine then return false, false end
     if old and old.ownerVerified ~= false
-        and not SamePeer(old.author, data.a) then return false end
+        and not SamePeer(old.author, data.a) then return false, false end
     local stamp = tonumber(data.m) or 0
     local tomb = tombstones[id]
     if tomb and stamp <= TombStamp(tomb) then
         LogEvent("RX","skip summary '%s': tombstoned", tostring(data.t))
-        return false
+        return true, false
     end
     local oldStamp = old and (tonumber(old.lastModified) or tonumber(old.postedAt) or 0) or nil
     if oldStamp and stamp < oldStamp then
         LogEvent("RX","skip summary '%s': older than local copy", tostring(data.t))
-        return false
+        return true, false
     end
     if oldStamp and stamp == oldStamp then
         stats.duplicatesSkipped = stats.duplicatesSkipped + 1
@@ -681,7 +900,7 @@ local function StoreSummary(data, transportSender)
         else
             LogEvent("RX","skip summary '%s': DUPLICATE", tostring(data.t))
         end
-        return false
+        return true, false
     end
     local newHash = tostring(data.h)
     local newLinkHash = type(data.lh) == "string" and data.lh or nil
@@ -711,17 +930,23 @@ local function StoreSummary(data, transportSender)
             tostring(data.t), tostring(data.a or "Unknown"), tonumber(data.n) or 0)
     end
     if not keepEchoes or linkChanged then QueueLegacyRecovery(id) end
-    return true
+    return true, true
 end
 
 QueueLegacyRecovery = function(buildId)
-    if not buildId then return false end
+    if not ValidIdentifier(buildId, MAX_BUILD_ID_BYTES) then return false end
     local build = NexusDB and NexusDB.communityBuilds and NexusDB.communityBuilds[buildId]
     if build and type(build.echoes) == "table" and #build.echoes > 0 then return false end
     local now = Now()
     if requestedLoadouts[buildId] and now - requestedLoadouts[buildId] < 120 then return false end
     requestedLoadouts[buildId] = now
-    legacyRecoveryQueue[#legacyRecoveryQueue + 1] = tostring(buildId)
+    local depth = QueueDepth(legacyRecoveryHead, legacyRecoveryTail)
+    if depth >= MAX_RECOVERY_QUEUE then
+        RejectQueueOverflow("recovery", 1, depth, MAX_RECOVERY_QUEUE)
+        return false
+    end
+    legacyRecoveryTail = legacyRecoveryTail + 1
+    legacyRecoveryQueue[legacyRecoveryTail] = tostring(buildId)
     return true
 end
 
@@ -743,7 +968,13 @@ end
 -- Header-aware chunking: measures the ACTUAL escaped header so no chunk
 -- can ever exceed the hard limit.
 local function SendChunked(buildId, lastMod, data)
-    if type(data) ~= "string" or #data > MAX_BYTES then return false end
+    if not ValidIdentifier(tostring(buildId or ""), MAX_BUILD_ID_BYTES)
+        or not ValidIntegerText(tostring(lastMod or ""), 0)
+        or type(data) ~= "string" or data == "" or #data > MAX_BYTES then
+        return false, "invalid build envelope"
+    end
+    buildId = tostring(buildId)
+    lastMod = tostring(lastMod)
     local sender = MyName()
     -- Worst-case header = largest chunk index digits (999/999)
     local sampleHdr = string.format("%s|%s|%s|%s|999/999|",
@@ -754,17 +985,18 @@ local function SendChunked(buildId, lastMod, data)
     local single = string.format("%s|%s|%s|%s|1/1|%s",
         CODE_BUILD, sender, buildId, lastMod, data)
     if EscapedLen(single) <= CHAT_LIMIT - CHAT_SAFETY then
-        Enqueue(single); return true
+        return Enqueue(single)
     end
     local total = math.ceil(#data / budget)
-    if total > 999 then return false, "build too large" end
+    if total > MAX_CHUNKS then return false, "build too large" end
+    local messages = {}
     for idx = 1, total do
         local s = (idx-1)*budget + 1
-        Enqueue(string.format("%s|%s|%s|%s|%d/%d|%s",
+        messages[#messages + 1] = string.format("%s|%s|%s|%s|%d/%d|%s",
             CODE_BUILD, sender, buildId, lastMod, idx, total,
-            data:sub(s, s+budget-1)))
+            data:sub(s, s+budget-1))
     end
-    return true
+    return EnqueueBatch(messages)
 end
 
 ------------------------------------------------------------------------
@@ -780,6 +1012,9 @@ local BUILD_BROADCAST_DEDUPE = 2
 function Sync.BroadcastBuild(build)
     if not build or type(build.echoes) ~= "table" or #build.echoes == 0 then
         return false, "no echoes"
+    end
+    if not ValidIdentifier(tostring(build.id or ""), MAX_BUILD_ID_BYTES) then
+        return false, "invalid build id"
     end
     local buildKey = tostring(build.id or build.fingerprintHash or build.fingerprint or "")
     local now = Now()
@@ -870,9 +1105,10 @@ local function BroadcastMineFiltered(peerHash, onlyBucket)
         if SamePeer(TombAuthor(tomb), MyName())
             and (not onlyBucket or bucket == onlyBucket)
             and (legacyPeer or tostring(peerBuckets[bucket] or "") ~= tostring(myBuckets[bucket] or "")) then
-            Enqueue(string.format("%s|%s|%s|%s|%s", CODE_DELETE, MyName(), id,
-                tostring(TombStamp(tomb)), TombAuthor(tomb)))
-            n=n+1
+            if Enqueue(string.format("%s|%s|%s|%s|%s", CODE_DELETE,
+                MyName(), id, tostring(TombStamp(tomb)), TombAuthor(tomb))) then
+                n=n+1
+            end
         end
     end
     return n
@@ -905,7 +1141,14 @@ local function RequestSyncOnce()
     local buildHash = CurrentBuildHash()
     local dpsHash = CurrentDpsHash()
     local requestId = tostring(math.floor(now * 1000)) .. "-" .. tostring(math.random(1000,9999))
-    Enqueue(string.format("%s|%s|%s|%s|%s|%s", CODE_REQUEST, MyName(), buildHash, dpsHash, requestId, tostring((Nexus and Nexus.VERSION) or "?")))
+    local queued, queueWhy = Enqueue(string.format("%s|%s|%s|%s|%s|%s",
+        CODE_REQUEST, MyName(), buildHash, dpsHash, requestId,
+        tostring((Nexus and Nexus.VERSION) or "0.0.0-dev")))
+    if not queued then
+        lastRequestAt = -math.huge
+        receiveWindowUntil = 0
+        return false, queueWhy or "sync queue full"
+    end
     LogEvent("SYNC","requested sync (build=%s dps=%s id=%s) -- reconciliation active",
         buildHash, dpsHash, requestId)
     return true
@@ -966,16 +1209,20 @@ function Sync.BroadcastDpsRecord(record)
     }
     local encoded = Codec.Base64Encode(Codec.JSONEncode(payload))
     local transferId = tostring(payload.p) .. ":" .. tostring(payload.t) .. ":" .. tostring(payload.d)
+    if not ValidIdentifier(transferId, MAX_TRANSFER_ID_BYTES)
+        or #encoded > MAX_ENCODED_BYTES then return false end
     local header = CODE_DPS2 .. "|" .. MyName() .. "|" .. transferId .. "|999/999|"
     local chunkSize = CHAT_LIMIT - CHAT_SAFETY - EscapedLen(header)
     if chunkSize < 24 then return false end
     local total = math.ceil(#encoded / chunkSize)
     if total < 1 or total > 999 then return false end
+    local messages = {}
     for i = 1, total do
         local data = encoded:sub((i - 1) * chunkSize + 1, i * chunkSize)
-        Enqueue(string.format("%s|%s|%s|%d/%d|%s",
-            CODE_DPS2, MyName(), transferId, i, total, data))
+        messages[#messages + 1] = string.format("%s|%s|%s|%d/%d|%s",
+            CODE_DPS2, MyName(), transferId, i, total, data)
     end
+    if not EnqueueBatch(messages) then return false end
     LogEvent("TX","DPS2 [%s] %.0f by %s (%d chunks)",
         tostring(payload.c), payload.d, payload.p, total)
     return true
@@ -988,8 +1235,7 @@ function Sync.BroadcastDps(buildId, player, dps, level, category)
         CODE_DPS, MyName(), buildId, tostring(player),
         tostring(math.floor(dps)), tostring(level or 0), category or "dummy")
     if EscapedLen(payload) > CHAT_LIMIT - CHAT_SAFETY then return false end
-    Enqueue(payload)
-    return true
+    return Enqueue(payload)
 end
 
 local function HandleDps(parts)
@@ -1000,46 +1246,52 @@ local function HandleDps(parts)
 end
 
 local function HandleDps2(parts)
-    autoConverge.lastInbound = Now()
     local sender, transferId, spec, data = parts[2], parts[3], parts[4], parts[5]
-    if not (sender and transferId and spec and data) then return end
+    if not ValidPeerName(sender)
+        or not ValidIdentifier(transferId, MAX_TRANSFER_ID_BYTES)
+        or not ValidField(spec, 16, false)
+        or not ValidField(data, MAX_CHUNK_BYTES, false) then return false end
     local idx, total = spec:match("^(%d+)/(%d+)$")
     idx, total = tonumber(idx), tonumber(total)
     if not (idx and total and idx >= 1 and idx <= total
-        and total >= 1 and total <= MAX_CHUNKS
-        and #data <= MAX_CHUNK_BYTES) then return end
+        and total >= 1 and total <= MAX_CHUNKS) then return false end
+    autoConverge.lastInbound = Now()
     local key = sender .. ":" .. transferId
     local e = dpsInflight[key]
     if not e then
         CleanExpiredInflight()
-        if not CanStartTransfer(dpsInflight, sender) then return end
+        if not CanStartTransfer(dpsInflight, sender) then return false end
         e = { chunks = {}, total = total, t0 = Now(), lastSeen = Now(),
-            sender = sender, bytes = 0, received = 0 }
+            sender = sender, transferId=transferId, bytes = 0, received = 0 }
         dpsInflight[key] = e
     end
-    if e.total ~= total then dpsInflight[key] = nil; return end
+    if e.total ~= total or e.sender ~= sender
+        or e.transferId ~= transferId then
+        dpsInflight[key] = nil
+        return false
+    end
     e.lastSeen = Now()
     local prior = e.chunks[idx]
     if prior ~= nil then
         if prior ~= data then dpsInflight[key] = nil end
-        return
+        return false
     end
     if e.bytes + #data > MAX_ENCODED_BYTES then
         dpsInflight[key] = nil
-        return
+        return false
     end
     e.chunks[idx] = data
     e.bytes = e.bytes + #data
     e.received = e.received + 1
-    if e.received ~= total then return end
+    if e.received ~= total then return false end
     dpsInflight[key] = nil
     local raw = Codec.Base64Decode(table.concat(e.chunks, "", 1, total))
     local record = raw and Codec.JSONDecode(raw)
-    if type(record) ~= "table" then return end
+    if type(record) ~= "table" then return false end
     if Nexus.DpsCapture and Nexus.DpsCapture.ReceiveRecord then
         if not SamePeer(record.p or record.player, sender) then
             LogEvent("RX", "DROP DPS owner mismatch from %s", tostring(sender))
-            return
+            return false
         end
         local ok, accepted = pcall(
             Nexus.DpsCapture.ReceiveRecord, record, sender)
@@ -1054,20 +1306,23 @@ local function HandleDps2(parts)
             if build and type(build.echoes) == "table" and #build.echoes > 0 then
                 pcall(Sync.BroadcastBuild, build)
             end
+            return true
         end
     end
+    return false
 end
 
 function Sync.BroadcastDelete(build)
-    if not build or not build.id then return false end
+    if not build or not ValidIdentifier(tostring(build.id or ""),
+        MAX_BUILD_ID_BYTES) then return false end
     local stamp = tostring((time and time()) or 0)
     local author = tostring(build.author or MyName())
     if not SamePeer(author, MyName()) then return false end
     tombstones[build.id] = { stamp=tonumber(stamp) or 0, author=author }
-    Enqueue(string.format("%s|%s|%s|%s|%s",
+    local queued = Enqueue(string.format("%s|%s|%s|%s|%s",
         CODE_DELETE, MyName(), build.id, stamp, author))
     LogEvent("TX","delete '%s'", tostring(build.title or build.id))
-    return true
+    return queued and true or false
 end
 
 ------------------------------------------------------------------------
@@ -1077,12 +1332,14 @@ end
 CleanExpiredInflight = function()
     local now = Now()
     for key, v in pairs(inflight) do
-        if now - (v.lastSeen or v.t0 or now) > INFLIGHT_GRACE then
+        if now - (v.lastSeen or v.t0 or now) > INFLIGHT_GRACE
+            or now - (v.t0 or now) > INFLIGHT_MAX_AGE then
             inflight[key] = nil
         end
     end
     for key, v in pairs(dpsInflight) do
-        if now - (v.lastSeen or v.t0 or now) > INFLIGHT_GRACE then
+        if now - (v.lastSeen or v.t0 or now) > INFLIGHT_GRACE
+            or now - (v.t0 or now) > INFLIGHT_MAX_AGE then
             dpsInflight[key] = nil
         end
     end
@@ -1143,27 +1400,31 @@ local function HandleComplete(buildId, lastMod, fullData, transportSender)
     if not json then
         stats.malformedRejected = stats.malformedRejected + 1
         LogEvent("RX","REJECT '%s': bad base64 (%d bytes -- truncated?)",
-            tostring(buildId), #tostring(fullData)); return
+            tostring(buildId), #tostring(fullData))
+        return false
     end
     local data = Codec.JSONDecode(json)
     if not data then
         stats.malformedRejected = stats.malformedRejected + 1
-        LogEvent("RX","REJECT '%s': JSON decode failed", tostring(buildId)); return
+        LogEvent("RX","REJECT '%s': JSON decode failed", tostring(buildId))
+        return false
     end
     -- Silently drop legacy placeholder builds posted as "WR Team" before the rename
     if tostring(data.a or data.author or ""):lower() == "wr team" then
         LogEvent("RX","REJECT legacy placeholder '%s'", tostring(data.t or data.title))
-        return
+        return false
     end
     local payload = ValidatePayload(data)
     if not payload then
         stats.malformedRejected = stats.malformedRejected + 1
-        LogEvent("RX","REJECT '%s': validation failed", tostring(buildId)); return
+        LogEvent("RX","REJECT '%s': validation failed", tostring(buildId))
+        return false
     end
     if payload.id ~= buildId then
         stats.malformedRejected = stats.malformedRejected + 1
         LogEvent("RX","REJECT id mismatch: envelope='%s' payload='%s'",
-            tostring(buildId), tostring(payload.id)); return
+            tostring(buildId), tostring(payload.id))
+        return false
     end
     local directOwner = SamePeer(payload.author, transportSender)
     local existing = NexusDB and NexusDB.communityBuilds
@@ -1184,22 +1445,22 @@ local function HandleComplete(buildId, lastMod, fullData, transportSender)
             LogEvent("RX","skip '%s': DUPLICATE (have stamp %s)",
                 tostring(payload.title), tostring(seenRemoteIds[payload.id]))
         end
-        return
+        return true
     end
     if existing and not directOwner then
         LogEvent("RX", "REJECT relayed overwrite of '%s' from %s",
             tostring(payload.id), tostring(transportSender))
-        return
+        return false
     end
     if existing and existing.isMine then
         LogEvent("RX", "REJECT remote overwrite of local build '%s'",
             tostring(payload.id))
-        return
+        return false
     end
     if existing and existing.ownerVerified ~= false
         and not SamePeer(existing.author, payload.author) then
         LogEvent("RX", "REJECT owner change for '%s'", tostring(payload.id))
-        return
+        return false
     end
     if why == "updated" then
         stats.updated = (stats.updated or 0) + 1
@@ -1217,6 +1478,7 @@ local function HandleComplete(buildId, lastMod, fullData, transportSender)
     if Nexus.CommunityBuilds and Nexus.CommunityBuilds.Refresh then
         pcall(Nexus.CommunityBuilds.Refresh)
     end
+    return true
 end
 
 local function SendBucketResponse(entry, kind, bucket)
@@ -1235,22 +1497,43 @@ local function SendBucketResponse(entry, kind, bucket)
 end
 
 local function HandleRequest(requester, peerBuildHash, peerDpsHash, requestId)
-    if requester == MyName() then LogEvent("RX","ignoring own request (no echo loop)"); return end
+    if requester == MyName() then
+        LogEvent("RX","ignoring own request (no echo loop)")
+        return true
+    end
     peerBuildHash, peerDpsHash = peerBuildHash or "0", peerDpsHash or "0"
     requestId = requestId or ("legacy-"..tostring(requester).."-"..tostring(math.floor(Now())))
     local myBuildHash, myDpsHash = CurrentBuildHash(), CurrentDpsHash()
     if myBuildHash == peerBuildHash and myDpsHash == peerDpsHash then
         stats.skippedUpToDate=(stats.skippedUpToDate or 0)+1
-        LogEvent("RX","request from %s skipped: both state hashes match", tostring(requester)); return
+        LogEvent("RX","request from %s skipped: both state hashes match", tostring(requester)); return true
     end
     local key=tostring(requester)..":"..tostring(requestId)
+    local prior = pendingResponses[key]
+    if prior then
+        if tostring(prior.peerBuildHash) ~= tostring(peerBuildHash)
+            or tostring(prior.peerDpsHash) ~= tostring(peerDpsHash) then
+            LogEvent("RX", "REJECT conflicting request metadata for %s", key)
+            return false
+        end
+        return true
+    end
+    if TableCount(pendingResponses) >= MAX_PENDING_RESPONSES then
+        stats.pendingOverflowRejected = (stats.pendingOverflowRejected or 0) + 1
+        LogEvent("RX", "REJECT newest request from %s: pending cap %d",
+            tostring(requester), MAX_PENDING_RESPONSES)
+        return false
+    end
     local peerB,myB=SplitHashes(peerBuildHash),SplitHashes(myBuildHash)
     local peerD,myD=SplitHashes(peerDpsHash),SplitHashes(myDpsHash)
-    local entry={key=key,requester=requester,requestId=requestId,peerBuildHash=peerBuildHash,peerDpsHash=peerDpsHash,buckets={}}
+    local peerBuildBuckets = #peerB == BUILD_BUCKETS
+    local entry={key=key,requester=requester,requestId=requestId,
+        peerBuildHash=peerBuildHash,peerDpsHash=peerDpsHash,buckets={},
+        createdAt=Now()}
     for i=1,BUILD_BUCKETS do
         if tostring(peerB[i] or "") ~= tostring(myB[i] or "") then
             entry.buckets["B"..i]={kind="B",bucket=i,hash=tostring(myB[i] or "0"),
-                claimable=not BucketContainsTombstone(i),phase="wait",
+                claimable=peerBuildBuckets and not BucketContainsTombstone(i),phase="wait",
                 remaining=BucketDelay(key,"B",i)}
         end
         if tostring(peerD[i] or "") ~= tostring(myD[i] or "") then
@@ -1263,6 +1546,7 @@ local function HandleRequest(requester, peerBuildHash, peerDpsHash, requestId)
     end
     if next(entry.buckets) then pendingResponses[key]=entry end
     LogEvent("RX","mesh request from %s scheduled by bucket (id=%s)",tostring(requester),tostring(requestId))
+    return true
 end
 
 local function HandleClaim(responder, requester, requestId, buildHash, dpsHash)
@@ -1275,12 +1559,13 @@ local function HandleClaim(responder, requester, requestId, buildHash, dpsHash)
         LogEvent("RX","ignored legacy whole-state claim from %s for owner-only safety",
             tostring(responder))
     end
+    return true
 end
 
 local function HandleBucketClaim(responder, requester, requestId, kind, bucket, bucketHash)
-    if responder==MyName() then return end
+    if responder==MyName() then return true end
     local key=tostring(requester)..":"..tostring(requestId)
-    local entry=pendingResponses[key]; if not entry then return end
+    local entry=pendingResponses[key]; if not entry then return true end
     local id=tostring(kind)..tostring(tonumber(bucket) or 0)
     local b=entry.buckets and entry.buckets[id]
     if b and b.claimable ~= false
@@ -1289,40 +1574,63 @@ local function HandleBucketClaim(responder, requester, requestId, kind, bucket, 
         LogEvent("RX","mesh bucket %s claimed by %s for %s",id,tostring(responder),tostring(requester))
         if not next(entry.buckets) then pendingResponses[key]=nil end
     end
+    return true
 end
 
 local function ProcessPendingResponses(elapsed)
     elapsed=tonumber(elapsed) or 0
     local sends={}
     for key,entry in pairs(pendingResponses) do
-        for id,b in pairs(entry.buckets or {}) do
-            b.remaining=(tonumber(b.remaining) or 0)-elapsed
-            if b.remaining<=0 then
-                if b.phase=="wait" and b.claimable ~= false then
-                    EnqueueControl(string.format("%s|%s|%s|%s|%s|%d|%s",CODE_BUCKET_CLAIM,MyName(),entry.requester,entry.requestId,b.kind,b.bucket,b.hash))
-                    b.phase="settle"; b.remaining=BUCKET_SETTLE
-                else
-                    entry.buckets[id]=nil
-                    sends[#sends+1]={entry=entry,kind=b.kind,bucket=b.bucket}
+        if Now() - (tonumber(entry.createdAt) or Now()) > PENDING_TTL then
+            pendingResponses[key] = nil
+        else
+            for id,b in pairs(entry.buckets or {}) do
+                b.remaining=(tonumber(b.remaining) or 0)-elapsed
+                if b.remaining<=0 then
+                    if b.phase=="wait" and b.claimable ~= false then
+                        local queued = EnqueueControl(string.format(
+                            "%s|%s|%s|%s|%s|%d|%s",CODE_BUCKET_CLAIM,
+                            MyName(),entry.requester,entry.requestId,b.kind,
+                            b.bucket,b.hash))
+                        if queued then
+                            b.phase="settle"; b.remaining=BUCKET_SETTLE
+                        else
+                            b.remaining=1
+                        end
+                    else
+                        entry.buckets[id]=nil
+                        sends[#sends+1]={entry=entry,kind=b.kind,bucket=b.bucket}
+                    end
                 end
             end
+            if not next(entry.buckets or {}) then pendingResponses[key]=nil end
         end
-        if not next(entry.buckets or {}) then pendingResponses[key]=nil end
     end
     table.sort(sends,function(a,b) return (a.kind..a.bucket)<(b.kind..b.bucket) end)
     for _,x in ipairs(sends) do SendBucketResponse(x.entry,x.kind,x.bucket) end
     local loadoutReady={}
     for key,entry in pairs(pendingLoadouts) do
-        entry.remaining=(tonumber(entry.remaining) or 0)-elapsed
-        if entry.remaining<=0 then pendingLoadouts[key]=nil; loadoutReady[#loadoutReady+1]=entry end
+        if Now() - (tonumber(entry.createdAt) or Now()) > PENDING_TTL then
+            pendingLoadouts[key] = nil
+        else
+            entry.remaining=(tonumber(entry.remaining) or 0)-elapsed
+            if entry.remaining<=0 then pendingLoadouts[key]=nil; loadoutReady[#loadoutReady+1]=entry end
+        end
     end
     table.sort(loadoutReady,function(a,b)return tostring(a.key)<tostring(b.key) end)
     for _,entry in ipairs(loadoutReady) do
         local b=NexusDB and NexusDB.communityBuilds and NexusDB.communityBuilds[entry.buildId]
         if b and type(b.echoes)=="table" and #b.echoes>0 then
-            EnqueueControl(string.format("%s|%s|%s|%s",CODE_LOADOUT_CLAIM,MyName(),entry.requester,entry.buildId))
-            Sync.BroadcastBuild(b)
-            LogEvent("TX","answered on-demand loadout '%s' for %s",tostring(entry.buildId),tostring(entry.requester))
+            local claimed = EnqueueControl(string.format("%s|%s|%s|%s",
+                CODE_LOADOUT_CLAIM,MyName(),entry.requester,entry.buildId))
+            if claimed then
+                Sync.BroadcastBuild(b)
+                LogEvent("TX","answered on-demand loadout '%s' for %s",
+                    tostring(entry.buildId),tostring(entry.requester))
+            else
+                entry.remaining = 1
+                pendingLoadouts[entry.key] = entry
+            end
         end
     end
 end
@@ -1332,27 +1640,30 @@ local function HandleDelete(sender, buildId, stamp, originAuthor)
     local db = NexusDB and NexusDB.communityBuilds
     local existing = db and db[buildId]
     -- originAuthor is an optional 5th field; treat empty string same as nil
-    local author = tostring((originAuthor and originAuthor ~= "") and originAuthor or sender or "")
+    local author = tostring((originAuthor and originAuthor ~= "")
+        and originAuthor or sender or "")
     if not SamePeer(sender, author) then
         LogEvent("RX", "REJECT relayed delete for '%s' from %s",
             tostring(buildId), tostring(sender))
-        return
+        return false
     end
     local tomb = { stamp=tonumber(stamp) or 0, author=author }
     local prior = tombstones[buildId]
-    if prior and TombStamp(prior) >= tomb.stamp then return end
+    if prior and TombStamp(prior) >= tomb.stamp then return true end
     if not existing then
         LogEvent("RX", "REJECT unprovable tombstone for unknown build '%s'",
             tostring(buildId))
-        return
+        return false
     end
     if existing.isMine then
         LogEvent("RX","ignoring delete for MY build '%s' relayed by %s",
-            tostring(existing.title), tostring(sender)); return
+            tostring(existing.title), tostring(sender))
+        return false
     end
     if not SamePeer(existing.author, sender) then
         LogEvent("RX","REJECT delete of '%s': origin %s is not the author (%s)",
-            tostring(existing.title), author, tostring(existing.author)); return
+            tostring(existing.title), author, tostring(existing.author))
+        return false
     end
     db[buildId] = nil
     tombstones[buildId] = tomb
@@ -1362,155 +1673,260 @@ local function HandleDelete(sender, buildId, stamp, originAuthor)
     if Nexus.CommunityBuilds and Nexus.CommunityBuilds.Refresh then
         pcall(Nexus.CommunityBuilds.Refresh)
     end
+    return true
 end
 
 -- CHAT_MSG_CHANNEL handler. The wire has | escaped to || on send;
 -- since none of our fields ever contain a literal |, collapsing ||→|
 -- is unambiguous.
-function Sync.HandleIncoming(text, sender)
-    if type(text) ~= "string" then return end
-    text = text:gsub("||", "|")
-    local parts = {}
-    for part in text:gmatch("([^|]*)|?") do
-        parts[#parts+1] = part
-        if #parts > 20 then break end
+local function SplitWire(text)
+    local parts, start = {}, 1
+    while true do
+        if #parts >= 8 then return nil end
+        local pos = text:find("|", start, true)
+        if not pos then
+            parts[#parts + 1] = text:sub(start)
+            return parts
+        end
+        parts[#parts + 1] = text:sub(start, pos - 1)
+        start = pos + 1
     end
-    local code = parts[1]
-    local protocolSender = parts[2] or sender
-    local actualSender = sender or protocolSender
-    if protocolSender and actualSender
-        and not SamePeer(protocolSender, actualSender) then
-        LogEvent("RX", "DROP sender mismatch: wire=%s transport=%s",
-            tostring(protocolSender), tostring(actualSender))
-        return
-    end
-    if actualSender and parts[2] then parts[2] = actualSender end
-    protocolSender = actualSender
-    if PEER_PROTOCOL_CODES[code] and protocolSender and protocolSender ~= "" then
-        MarkPeer(protocolSender, code == CODE_REQUEST and parts[6] or nil)
-    end
+end
 
-    if code == CODE_PRESENCE then
-        MarkPeer(protocolSender, parts[3])
-        return
-    end
-    if code == CODE_REQUEST then
-        HandleRequest(parts[2] or sender, parts[3], parts[4], parts[5])
-        return
-    end
-    if code == CODE_CLAIM then
-        HandleClaim(parts[2] or sender, parts[3], parts[4], parts[5], parts[6])
-        return
-    end
-    if code == CODE_BUCKET_CLAIM then
-        HandleBucketClaim(parts[2] or sender, parts[3], parts[4], parts[5], parts[6], parts[7])
-        return
-    end
-    if code == CODE_DELETE then
-        HandleDelete(parts[2] or sender, parts[3], parts[4], parts[5])
-        return
-    end
-    if code == CODE_INDEX then
-        autoConverge.lastInbound = Now()
-        local raw = parts[3] and Codec.Base64Decode(parts[3])
-        local data = raw and Codec.JSONDecode(raw)
-        if StoreSummary(data, protocolSender)
-            and Nexus.CommunityBuilds and Nexus.CommunityBuilds.Refresh then
-            pcall(Nexus.CommunityBuilds.Refresh)
-        end
-        return
-    end
-    if code == CODE_LOADOUT_REQ then
-        local requester, buildId = parts[2] or sender, parts[3]
-        if requester ~= MyName() and buildId then
-            local b = NexusDB and NexusDB.communityBuilds and NexusDB.communityBuilds[buildId]
-            if b and type(b.echoes)=="table" and #b.echoes>0 then
-                local key = tostring(requester)..":"..tostring(buildId)
-                pendingLoadouts[key] = { key=key, requester=requester, buildId=buildId,
-                    remaining=StableDelay(key..":"..MyName()) }
-            end
-        end
-        return
-    end
-    if code == CODE_LOADOUT_CLAIM then
-        local requester, buildId = parts[3], parts[4]
-        local key = tostring(requester)..":"..tostring(buildId)
-        if parts[2] ~= MyName() and pendingLoadouts[key] then
-            pendingLoadouts[key] = nil
-            LogEvent("RX","suppressed duplicate loadout response; %s claimed %s", tostring(parts[2]), tostring(buildId))
-        end
-        return
-    end
-    if code == CODE_DPS then
-        HandleDps(parts)
-        return
-    end
-    if code == CODE_DPS2 then
-        HandleDps2(parts)
-        return
-    end
-    if code ~= CODE_BUILD then
+local function RejectIncoming(reason)
+    stats.malformedRejected = (stats.malformedRejected or 0) + 1
+    LogEvent("RX", "REJECT envelope: %s", tostring(reason or "malformed"))
+    return false
+end
+
+local function AcceptPeer(sender, version)
+    MarkPeer(sender, version)
+    return true
+end
+
+function Sync.HandleIncoming(text, sender)
+    if type(text) ~= "string" or #text > MAX_WIRE_BYTES
+        or text:find("[%c]") then return RejectIncoming("invalid wire length") end
+    text = text:gsub("||", "|")
+    local parts = SplitWire(text)
+    if not parts then return RejectIncoming("too many fields") end
+    local code = parts[1]
+    if not PEER_PROTOCOL_CODES[code] then
         if code and code ~= "" then
             LogEvent("RX","unknown code '%s'", tostring(code))
         end
-        return
+        return false
     end
 
+    local protocolSender = parts[2]
+    local actualSender = sender or protocolSender
+    if not ValidPeerName(protocolSender) or not ValidPeerName(actualSender)
+        or not SameTransportSender(protocolSender, actualSender) then
+        LogEvent("RX", "DROP sender mismatch: wire=%s transport=%s",
+            tostring(protocolSender), tostring(actualSender))
+        return RejectIncoming("sender mismatch")
+    end
+    parts[2] = actualSender
+    protocolSender = actualSender
+
+    if code == CODE_PRESENCE then
+        if #parts ~= 3 or not ValidVersion(parts[3]) then
+            return RejectIncoming("invalid presence")
+        end
+        return AcceptPeer(protocolSender, parts[3])
+    end
+
+    if code == CODE_REQUEST then
+        if #parts < 2 or #parts > 6
+            or (parts[3] ~= nil and parts[3] ~= "" and not ValidHash(parts[3]))
+            or (parts[4] ~= nil and parts[4] ~= "" and not ValidHash(parts[4]))
+            or (parts[5] ~= nil and parts[5] ~= ""
+                and not ValidIdentifier(parts[5], MAX_REQUEST_ID_BYTES))
+            or (parts[6] ~= nil and not ValidVersion(parts[6])) then
+            return RejectIncoming("invalid request")
+        end
+        local accepted = HandleRequest(protocolSender,
+            (parts[3] and parts[3] ~= "") and parts[3] or "0",
+            (parts[4] and parts[4] ~= "") and parts[4] or "0",
+            (parts[5] and parts[5] ~= "") and parts[5] or nil)
+        if accepted then return AcceptPeer(protocolSender, parts[6]) end
+        return false
+    end
+
+    if code == CODE_CLAIM then
+        if #parts ~= 6 or not ValidPeerName(parts[3])
+            or not ValidIdentifier(parts[4], MAX_REQUEST_ID_BYTES)
+            or not ValidField(parts[5], MAX_HASH_BYTES, false)
+            or not ValidField(parts[6], MAX_HASH_BYTES, false) then
+            return RejectIncoming("invalid legacy claim")
+        end
+        HandleClaim(protocolSender, parts[3], parts[4], parts[5], parts[6])
+        return AcceptPeer(protocolSender)
+    end
+
+    if code == CODE_BUCKET_CLAIM then
+        local bucket = tonumber(parts[6])
+        if #parts ~= 7 or not ValidPeerName(parts[3])
+            or not ValidIdentifier(parts[4], MAX_REQUEST_ID_BYTES)
+            or (parts[5] ~= "B" and parts[5] ~= "D")
+            or not bucket or bucket ~= math.floor(bucket)
+            or bucket < 1 or bucket > BUILD_BUCKETS
+            or not ValidHash(parts[7]) then
+            return RejectIncoming("invalid bucket claim")
+        end
+        HandleBucketClaim(protocolSender, parts[3], parts[4], parts[5],
+            bucket, parts[7])
+        return AcceptPeer(protocolSender)
+    end
+
+    if code == CODE_DELETE then
+        if (#parts ~= 4 and #parts ~= 5)
+            or not ValidIdentifier(parts[3], MAX_BUILD_ID_BYTES)
+            or not ValidIntegerText(parts[4], 1)
+            or (parts[5] ~= nil and parts[5] ~= ""
+                and not ValidPeerName(parts[5])) then
+            return RejectIncoming("invalid delete")
+        end
+        if HandleDelete(protocolSender, parts[3], parts[4], parts[5]) then
+            return AcceptPeer(protocolSender)
+        end
+        return false
+    end
+
+    if code == CODE_INDEX then
+        if #parts ~= 3 or not ValidField(parts[3], MAX_CHUNK_BYTES, false) then
+            return RejectIncoming("invalid build summary")
+        end
+        local raw = Codec.Base64Decode(parts[3])
+        local data = raw and Codec.JSONDecode(raw)
+        local accepted, changed = StoreSummary(data, protocolSender)
+        if not accepted then return RejectIncoming("rejected build summary") end
+        autoConverge.lastInbound = Now()
+        if changed and Nexus.CommunityBuilds
+            and Nexus.CommunityBuilds.Refresh then
+            pcall(Nexus.CommunityBuilds.Refresh)
+        end
+        return AcceptPeer(protocolSender)
+    end
+
+    if code == CODE_LOADOUT_REQ then
+        if #parts ~= 3
+            or not ValidIdentifier(parts[3], MAX_BUILD_ID_BYTES) then
+            return RejectIncoming("invalid loadout request")
+        end
+        local requester, buildId = protocolSender, parts[3]
+        if requester ~= MyName() then
+            local b = NexusDB and NexusDB.communityBuilds
+                and NexusDB.communityBuilds[buildId]
+            if b and type(b.echoes)=="table" and #b.echoes>0 then
+                local key = tostring(requester)..":"..tostring(buildId)
+                if not pendingLoadouts[key] then
+                    if TableCount(pendingLoadouts) >= MAX_PENDING_LOADOUTS then
+                        stats.pendingOverflowRejected =
+                            (stats.pendingOverflowRejected or 0) + 1
+                        return false
+                    end
+                    pendingLoadouts[key] = { key=key, requester=requester,
+                        buildId=buildId, createdAt=Now(),
+                        remaining=StableDelay(key..":"..MyName()) }
+                end
+            end
+        end
+        return AcceptPeer(protocolSender)
+    end
+
+    if code == CODE_LOADOUT_CLAIM then
+        if #parts ~= 4 or not ValidPeerName(parts[3])
+            or not ValidIdentifier(parts[4], MAX_BUILD_ID_BYTES) then
+            return RejectIncoming("invalid loadout claim")
+        end
+        local requester, buildId = parts[3], parts[4]
+        local key = tostring(requester)..":"..tostring(buildId)
+        if protocolSender ~= MyName() and pendingLoadouts[key] then
+            pendingLoadouts[key] = nil
+            LogEvent("RX","suppressed duplicate loadout response; %s claimed %s",
+                tostring(protocolSender), tostring(buildId))
+        end
+        return AcceptPeer(protocolSender)
+    end
+
+    if code == CODE_DPS then
+        if #parts ~= 7 then return RejectIncoming("invalid legacy DPS") end
+        HandleDps(parts)
+        return false
+    end
+
+    if code == CODE_DPS2 then
+        if #parts ~= 5 then return RejectIncoming("invalid DPS transfer") end
+        if HandleDps2(parts) then return AcceptPeer(protocolSender) end
+        return false
+    end
+
+    if code ~= CODE_BUILD or #parts ~= 6 then
+        return RejectIncoming("invalid build transfer")
+    end
     local msgSender, buildId, lastMod, chunkSpec, data =
-        parts[2], parts[3], parts[4], parts[5], parts[6]
-    if not (msgSender and buildId and lastMod and chunkSpec and data) then return end
+        protocolSender, parts[3], parts[4], parts[5], parts[6]
+    if not ValidIdentifier(buildId, MAX_BUILD_ID_BYTES)
+        or not ValidIntegerText(lastMod, 0)
+        or not ValidField(chunkSpec, 16, false)
+        or not ValidField(data, MAX_CHUNK_BYTES, false) then
+        return RejectIncoming("invalid build fields")
+    end
     local idx, total = chunkSpec:match("^(%d+)/(%d+)$")
     idx, total = tonumber(idx), tonumber(total)
     if not (idx and total and idx >= 1 and total >= 1 and idx <= total
-        and total <= MAX_CHUNKS and #data <= MAX_CHUNK_BYTES) then return end
+        and total <= MAX_CHUNKS) then
+        return RejectIncoming("invalid build chunk geometry")
+    end
 
     autoConverge.lastInbound = Now()
-    local key   = msgSender..":"..buildId
+    local key = msgSender..":"..buildId
     local entry = inflight[key]
-
     if not entry then
-        -- Valid build updates are always accepted. The old receive-window gate
-        -- caused permanently incomplete rows and menu-triggered request spam.
-        autoConverge.lastInbound = Now()
         if total == 1 then
-            if #data > MAX_ENCODED_BYTES then return end
-            LogEvent("RX","single-chunk build '%s' from %s", tostring(buildId), tostring(msgSender))
-            HandleComplete(buildId, lastMod, data, msgSender)
-            return
+            local accepted = HandleComplete(buildId, lastMod, data, msgSender)
+            if accepted then return AcceptPeer(protocolSender) end
+            return false
         end
         CleanExpiredInflight()
-        if not CanStartTransfer(inflight, msgSender) then return end
+        if not CanStartTransfer(inflight, msgSender) then return false end
         LogEvent("RX","starting %d-chunk build '%s' from %s",
             total, tostring(buildId), tostring(msgSender))
         entry = { chunks={}, total=total, t0=Now(), lastSeen=Now(),
-            lastMod=lastMod, sender=msgSender, bytes=0, received=0 }
+            buildId=buildId, lastMod=lastMod, sender=msgSender,
+            bytes=0, received=0 }
         inflight[key] = entry
     end
 
-    if total ~= entry.total or tostring(lastMod) ~= tostring(entry.lastMod) then
+    if total ~= entry.total or buildId ~= entry.buildId
+        or msgSender ~= entry.sender
+        or tostring(lastMod) ~= tostring(entry.lastMod) then
         inflight[key] = nil
-        return
+        return false
     end
     entry.lastSeen = Now()
     local prior = entry.chunks[idx]
     if prior ~= nil then
         if prior ~= data then inflight[key] = nil end
-        return
+        return false
     end
     if entry.bytes + #data > MAX_ENCODED_BYTES then
         inflight[key] = nil
-        return
+        return false
     end
     entry.chunks[idx] = data
     entry.bytes = entry.bytes + #data
     entry.received = entry.received + 1
-    if entry.received == entry.total then
-        local full = table.concat(entry.chunks, "", 1, entry.total)
-        inflight[key] = nil
-        LogEvent("RX","transfer '%s' complete (%d/%d chunks, %d bytes)",
-            tostring(buildId), entry.received, entry.total, #full)
-        HandleComplete(buildId, entry.lastMod, full, msgSender)
+    if entry.received ~= entry.total then return false end
+    local full = table.concat(entry.chunks, "", 1, entry.total)
+    inflight[key] = nil
+    LogEvent("RX","transfer '%s' complete (%d/%d chunks, %d bytes)",
+        tostring(buildId), entry.received, entry.total, #full)
+    if HandleComplete(buildId, entry.lastMod, full, msgSender) then
+        return AcceptPeer(protocolSender)
     end
+    return false
 end
 
 local function PumpLegacyRecovery(elapsed)
@@ -1518,21 +1934,25 @@ local function PumpLegacyRecovery(elapsed)
     if legacyRecoveryTicker < 1.5 then return end
     legacyRecoveryTicker = 0
     -- Do not pile recovery traffic on top of a large response burst.
-    local pending = #sendQueue - sendQueueHead + 1
+    local pending = QueueDepth(sendQueueHead, sendQueueTail)
     if pending > 8 then return end
     local buildId = legacyRecoveryQueue[legacyRecoveryHead]
     if not buildId then
-        if legacyRecoveryHead > 1 then legacyRecoveryQueue = {}; legacyRecoveryHead = 1 end
+        if legacyRecoveryHead > legacyRecoveryTail then
+            legacyRecoveryQueue, legacyRecoveryHead, legacyRecoveryTail = {}, 1, 0
+        end
         return
     end
-    legacyRecoveryQueue[legacyRecoveryHead] = nil
-    legacyRecoveryHead = legacyRecoveryHead + 1
     local build = NexusDB and NexusDB.communityBuilds and NexusDB.communityBuilds[buildId]
     if not (build and type(build.echoes) == "table" and #build.echoes > 0) then
-        Enqueue(string.format("%s|%s|%s", CODE_LOADOUT_REQ, MyName(), tostring(buildId)))
+        local queued = Enqueue(string.format("%s|%s|%s",
+            CODE_LOADOUT_REQ, MyName(), tostring(buildId)))
+        if not queued then return end
         receiveWindowUntil = math.max(receiveWindowUntil, Now() + INFLIGHT_GRACE)
         LogEvent("SYNC", "background recovery requested legacy loadout '%s'", tostring(buildId))
     end
+    legacyRecoveryQueue[legacyRecoveryHead] = nil
+    legacyRecoveryHead = legacyRecoveryHead + 1
 end
 
 local function QueueBusy()
@@ -1540,7 +1960,8 @@ local function QueueBusy()
     if sendQueue[sendQueueHead] then return true end
     if next(inflight) or next(dpsInflight) then return true end
     if next(pendingResponses) or next(pendingLoadouts) then return true end
-    if legacyRecoveryQueue[legacyRecoveryHead] then return true end
+    if legacyRecoveryHead <= legacyRecoveryTail
+        and legacyRecoveryQueue[legacyRecoveryHead] then return true end
     return false
 end
 
@@ -1584,18 +2005,19 @@ local function SyncWorkCounts()
         recovery = 0,
         pass = tonumber(autoConverge.pass) or 0,
     }
-    for i = controlQueueHead, #controlQueue do
+    for i = controlQueueHead, controlQueueTail do
         if controlQueue[i] then work.control = work.control + 1 end
     end
-    for i = sendQueueHead, #sendQueue do
+    for i = sendQueueHead, sendQueueTail do
         if sendQueue[i] then work.sending = work.sending + 1 end
     end
     for _ in pairs(inflight) do work.receivingBuilds = work.receivingBuilds + 1 end
     for _ in pairs(dpsInflight) do work.receivingRecords = work.receivingRecords + 1 end
     for _ in pairs(pendingResponses) do work.preparing = work.preparing + 1 end
     for _ in pairs(pendingLoadouts) do work.preparing = work.preparing + 1 end
-    if legacyRecoveryQueue[legacyRecoveryHead] then
-        for i = legacyRecoveryHead, #legacyRecoveryQueue do
+    if legacyRecoveryHead <= legacyRecoveryTail
+        and legacyRecoveryQueue[legacyRecoveryHead] then
+        for i = legacyRecoveryHead, legacyRecoveryTail do
             if legacyRecoveryQueue[i] then work.recovery = work.recovery + 1 end
         end
     end
@@ -1756,8 +2178,8 @@ end
 
 function Sync.Init(codec, adapter)
     Codec, Adapter = codec, adapter
-    sendQueue, sendQueueHead = {}, 1
-    controlQueue, controlQueueHead = {}, 1
+    sendQueue, sendQueueHead, sendQueueTail = {}, 1, 0
+    controlQueue, controlQueueHead, controlQueueTail = {}, 1, 0
     inflight, dpsInflight = {}, {}
     ticker = 0
     throttlePauseUntil, throttleSlowUntil = 0, 0
@@ -1770,12 +2192,14 @@ function Sync.Init(codec, adapter)
     stats.sent, stats.received, stats.duplicatesSkipped = 0, 0, 0
     stats.malformedRejected, stats.ignoredOutsideWindow = 0, 0
     stats.oversizeDropped, stats.updated, stats.skippedUpToDate = 0, 0, 0
+    stats.queueOverflowRejected, stats.pendingOverflowRejected = 0, 0
     hotBuilds    = {}  -- clear on init
     pendingResponses = {}
     pendingLoadouts = {}
     requestedLoadouts = {}
     legacyRecoveryQueue = {}
     legacyRecoveryHead = 1
+    legacyRecoveryTail = 0
     legacyRecoveryTicker = 0
     autoConverge = { active=false, pass=0, stable=0, started=0, lastInbound=0, buildHash=nil, dpsHash=nil }
     -- Keep login initialization constant-time. Existing build timestamps are

--- a/core/Sync.lua
+++ b/core/Sync.lua
@@ -93,7 +93,8 @@ local AUTO_SYNC_DELAY      = 6
 local AUTO_SYNC_MIN_PASS    = 60  -- allow throttled peers time to begin/drain large responses
 local AUTO_SYNC_QUIET       = 15  -- require a real quiet period before judging a pass stable
 local AUTO_SYNC_MAX_PASSES  = 0   -- retained for diagnostics; convergence now ends only when stable
-local PENDING_TTL           = 30
+local PENDING_TTL           = 30  -- inactivity cap for pending response work
+local PENDING_MAX_AGE       = 300 -- absolute cap even while backpressured
 
 ------------------------------------------------------------------------
 -- Module state
@@ -857,12 +858,19 @@ end
 
 local function BroadcastSummary(build)
     local payload = SummaryEncode(build)
-    if not ValidIdentifier(payload.id, MAX_BUILD_ID_BYTES)
-        or not ValidHash(tostring(payload.h or "")) then return false end
+    if not ValidIdentifier(payload.id, MAX_BUILD_ID_BYTES) then
+        return false, "invalid build id"
+    end
+    if not ValidHash(tostring(payload.h or "")) then
+        return false, "invalid build hash"
+    end
     local data = Codec.Base64Encode(Codec.JSONEncode(payload))
     local msg = string.format("%s|%s|%s", CODE_INDEX, MyName(), data)
-    if EscapedLen(msg) > CHAT_LIMIT - CHAT_SAFETY then return false end
-    if not Enqueue(msg) then return false end
+    if EscapedLen(msg) > CHAT_LIMIT - CHAT_SAFETY then
+        return false, "summary too large"
+    end
+    local queued, queueWhy = Enqueue(msg)
+    if not queued then return false, queueWhy end
     LogEvent("TX","queuing summary '%s' (%d chars, no Echo list)", tostring(build.title), EscapedLen(msg))
     return true
 end
@@ -1078,96 +1086,95 @@ end
 -- Only send builds the requester doesn't already have.
 -- peerHash: djb2 hash of peer's library (from their WLRQ).
 -- If hash matches ours, peer is fully up to date → send nothing.
-local function BroadcastMineFiltered(peerHash, onlyBucket)
+local function BroadcastMineFiltered(peerHash, onlyBucket, progress)
     local myDB = NexusDB and NexusDB.communityBuilds or {}
     local myMine = {}
+    progress = type(progress) == "table" and progress or {}
     for id, b in pairs(myDB) do myMine[id] = b end
     for id, h in pairs(hotBuilds) do
         if not myMine[id] and (Now()-h.t) <= HOT_WINDOW then myMine[id] = h.build end
     end
     if not next(myMine) and not next(tombstones or {}) then
         LogEvent("TX","nothing to share")
-        return 0, true
+        return 0, true, true
     end
     local myHash = LibraryHash(myMine)
     if peerHash and tostring(peerHash) == tostring(myHash) then
         LogEvent("TX","peer build buckets match -- sending nothing")
         stats.skippedUpToDate = (stats.skippedUpToDate or 0) + 1
-        return 0, true
+        return 0, true, true
     end
     local peerBuckets = SplitHashes(peerHash)
     local myBuckets = SplitHashes(myHash)
     local legacyPeer = #peerBuckets ~= BUILD_BUCKETS
-    local n = 0
-    local queueTailBefore = sendQueueTail
-    local recentBefore, hotBefore = {}, {}
-    local function SnapshotBuildState(build)
-        local buildKey = tostring(build.id or build.fingerprintHash
-            or build.fingerprint or "")
-        if buildKey ~= "" and recentBefore[buildKey] == nil then
-            recentBefore[buildKey] = {
-                present = recentBuildBroadcast[buildKey] ~= nil,
-                value = recentBuildBroadcast[buildKey],
-            }
-        end
-        local id = build.id
-        if id ~= nil and hotBefore[id] == nil then
-            hotBefore[id] = {
-                present = hotBuilds[id] ~= nil,
-                value = hotBuilds[id],
-            }
-        end
-    end
-    local function RollBackBucketQueue()
-        for i = queueTailBefore + 1, sendQueueTail do sendQueue[i] = nil end
-        sendQueueTail = queueTailBefore
-        for key, prior in pairs(recentBefore) do
-            recentBuildBroadcast[key] = prior.present and prior.value or nil
-        end
-        for id, prior in pairs(hotBefore) do
-            hotBuilds[id] = prior.present and prior.value or nil
-        end
-    end
-    local complete = true
+    local n, claimSafe = 0, true
+    local candidates = {}
     for id, b in pairs(myMine) do
         local bucket = BuildBucket(id)
         if (not onlyBucket or bucket == onlyBucket)
             and (legacyPeer or tostring(peerBuckets[bucket] or "") ~= tostring(myBuckets[bucket] or "")) then
-            -- Send the complete build during reconciliation so receivers never
-            -- need to click a menu item to fetch its Echo list. Summary is only
-            -- a compatibility fallback for legacy/incomplete local rows.
-            local ok, why = false, nil
-            if type(b.echoes) == "table" and #b.echoes > 0 then
-                SnapshotBuildState(b)
-                ok, why = Sync.BroadcastBuild(b)
-            else
-                ok = BroadcastSummary(b)
-            end
-            if not ok or why == "duplicate suppressed" then
-                complete = false
-                break
-            end
-            n=n+1
+            local complete = (type(b.echoes) == "table" and #b.echoes > 0)
+                and "F" or "S"
+            local token = table.concat({ "B", tostring(id),
+                tostring(b.lastModified or b.postedAt or 0), complete,
+                tostring(b.fingerprintHash or b.fingerprint or "0") }, ":")
+            candidates[#candidates + 1] = {
+                kind="build", id=id, build=b, token=token,
+            }
         end
     end
-    for id, tomb in pairs(complete and (tombstones or {}) or {}) do
+    for id, tomb in pairs(tombstones or {}) do
         local bucket = BuildBucket(id)
         if SamePeer(TombAuthor(tomb), MyName())
             and (not onlyBucket or bucket == onlyBucket)
             and (legacyPeer or tostring(peerBuckets[bucket] or "") ~= tostring(myBuckets[bucket] or "")) then
-            if not Enqueue(string.format("%s|%s|%s|%s|%s", CODE_DELETE,
-                MyName(), id, tostring(TombStamp(tomb)), TombAuthor(tomb))) then
-                complete = false
-                break
-            end
-            n=n+1
+            candidates[#candidates + 1] = {
+                kind="tomb", id=id, tomb=tomb,
+                token=table.concat({ "T", tostring(id),
+                    tostring(TombStamp(tomb)), TombAuthor(tomb) }, ":"),
+            }
         end
     end
-    if not complete then
-        RollBackBucketQueue()
-        return 0, false
+    table.sort(candidates, function(a, b)
+        return tostring(a.token) < tostring(b.token)
+    end)
+    for _, item in ipairs(candidates) do
+        if not progress[item.token] then
+            local ok, why
+            if item.kind == "build" then
+                -- Full builds are preferred; summaries are compatibility
+                -- fallbacks for incomplete legacy rows.
+                if type(item.build.echoes) == "table"
+                    and #item.build.echoes > 0 then
+                    ok, why = Sync.BroadcastBuild(item.build)
+                else
+                    ok, why = BroadcastSummary(item.build)
+                end
+            else
+                ok, why = Enqueue(string.format("%s|%s|%s|%s|%s",
+                    CODE_DELETE, MyName(), item.id,
+                    tostring(TombStamp(item.tomb)), TombAuthor(item.tomb)))
+            end
+            if ok and why ~= "duplicate suppressed" then
+                progress[item.token] = "admitted"
+                n = n + 1
+            elseif why == "sync queue full"
+                or why == "duplicate suppressed" then
+                -- Preserve admitted progress. The next attempt resumes with
+                -- this item instead of re-enqueueing earlier payloads.
+                return n, false, claimSafe
+            else
+                -- Permanent serialization/validation failures must not block
+                -- unrelated valid rows. Do not claim the bucket, so another
+                -- peer with a sendable copy remains free to answer.
+                progress[item.token] = "skipped"
+                claimSafe = false
+                LogEvent("TX", "skipping unsendable %s '%s': %s",
+                    item.kind, tostring(item.id), tostring(why or "invalid"))
+            end
+        end
     end
-    return n, true
+    return n, true, claimSafe
 end
 
 local function BucketDelay(key, kind, bucket)
@@ -1538,22 +1545,26 @@ local function HandleComplete(buildId, lastMod, fullData, transportSender)
     return true
 end
 
-local function SendBucketResponse(entry, kind, bucket)
-    local n, dpsN, complete = 0, 0, true
+local function SendBucketResponse(entry, kind, bucket, bucketState)
+    local n, dpsN, complete, claimSafe = 0, 0, true, true
+    bucketState.progress = bucketState.progress or {}
     if kind == "B" then
-        n, complete = BroadcastMineFiltered(entry.peerBuildHash, bucket)
+        n, complete, claimSafe = BroadcastMineFiltered(
+            entry.peerBuildHash, bucket, bucketState.progress)
+        if claimSafe == false then bucketState.claimSafe = false end
     else
         local D = Nexus.DpsCapture
         if D and D.BroadcastAllBuildBests then
             local ok, result, allAdmitted = pcall(
-                D.BroadcastAllBuildBests, entry.peerDpsHash, bucket)
+                D.BroadcastAllBuildBests, entry.peerDpsHash, bucket,
+                bucketState.progress)
             if ok then dpsN = tonumber(result) or 0 end
             complete = ok and allAdmitted == true
         end
     end
     LogEvent("RX", "mesh bucket %s%d for %s: %d build(s), %d record(s)",
         kind, bucket, tostring(entry.requester), n, dpsN)
-    return complete
+    return complete, bucketState.claimSafe ~= false
 end
 
 local function HandleRequest(requester, peerBuildHash, peerDpsHash, requestId)
@@ -1589,7 +1600,7 @@ local function HandleRequest(requester, peerBuildHash, peerDpsHash, requestId)
     local peerBuildBuckets = #peerB == BUILD_BUCKETS
     local entry={key=key,requester=requester,requestId=requestId,
         peerBuildHash=peerBuildHash,peerDpsHash=peerDpsHash,buckets={},
-        createdAt=Now()}
+        createdAt=Now(),lastActiveAt=Now()}
     for i=1,BUILD_BUCKETS do
         if tostring(peerB[i] or "") ~= tostring(myB[i] or "") then
             entry.buckets["B"..i]={kind="B",bucket=i,hash=tostring(myB[i] or "0"),
@@ -1637,11 +1648,19 @@ local function HandleBucketClaim(responder, requester, requestId, kind, bucket, 
     return true
 end
 
+local function PendingExpired(entry)
+    local now = Now()
+    local createdAt = tonumber(entry and entry.createdAt) or now
+    local lastActiveAt = tonumber(entry and entry.lastActiveAt) or createdAt
+    return now - createdAt > PENDING_MAX_AGE
+        or now - lastActiveAt > PENDING_TTL
+end
+
 local function ProcessPendingResponses(elapsed)
     elapsed=tonumber(elapsed) or 0
     local sends={}
     for key,entry in pairs(pendingResponses) do
-        if Now() - (tonumber(entry.createdAt) or Now()) > PENDING_TTL then
+        if PendingExpired(entry) then
             pendingResponses[key] = nil
         else
             for id,b in pairs(entry.buckets or {}) do
@@ -1655,8 +1674,10 @@ local function ProcessPendingResponses(elapsed)
     end
     table.sort(sends,function(a,b) return (a.kind..a.bucket)<(b.kind..b.bucket) end)
     for _,x in ipairs(sends) do
-        if SendBucketResponse(x.entry,x.kind,x.bucket) then
-            if x.bucketState.claimable ~= false then
+        local complete, claimSafe = SendBucketResponse(
+            x.entry,x.kind,x.bucket,x.bucketState)
+        if complete then
+            if claimSafe and x.bucketState.claimable ~= false then
                 local claimed, claimWhy = EnqueueControl(string.format(
                     "%s|%s|%s|%s|%s|%d|%s",CODE_BUCKET_CLAIM,
                     MyName(),x.entry.requester,x.entry.requestId,x.kind,
@@ -1672,11 +1693,12 @@ local function ProcessPendingResponses(elapsed)
             if not next(x.entry.buckets) then pendingResponses[x.key]=nil end
         else
             x.bucketState.remaining=1
+            x.entry.lastActiveAt=Now()
         end
     end
     local loadoutReady={}
     for key,entry in pairs(pendingLoadouts) do
-        if Now() - (tonumber(entry.createdAt) or Now()) > PENDING_TTL then
+        if PendingExpired(entry) then
             pendingLoadouts[key] = nil
         else
             entry.remaining=(tonumber(entry.remaining) or 0)-elapsed
@@ -1704,8 +1726,16 @@ local function ProcessPendingResponses(elapsed)
                 LogEvent("TX","answered on-demand loadout '%s' for %s",
                     tostring(entry.buildId),tostring(entry.requester))
             else
-                entry.remaining = 1
-                pendingLoadouts[entry.key] = entry
+                if sendWhy == "sync queue full"
+                    or sendWhy == "duplicate suppressed" then
+                    entry.remaining = 1
+                    entry.lastActiveAt = Now()
+                    pendingLoadouts[entry.key] = entry
+                else
+                    LogEvent("TX", "dropping unsendable loadout '%s': %s",
+                        tostring(entry.buildId),
+                        tostring(sendWhy or "invalid build"))
+                end
             end
         end
     end
@@ -1903,7 +1933,7 @@ function Sync.HandleIncoming(text, sender)
                         return false
                     end
                     pendingLoadouts[key] = { key=key, requester=requester,
-                        buildId=buildId, createdAt=Now(),
+                        buildId=buildId, createdAt=Now(), lastActiveAt=Now(),
                         remaining=StableDelay(key..":"..MyName()) }
                 end
             end

--- a/tests/run_private_sync_compat.lua
+++ b/tests/run_private_sync_compat.lua
@@ -4,7 +4,7 @@ local H=dofile('tests/harness.lua')
 dofile('core/Codec.lua'); dofile('core/Sync.lua'); dofile('core/DpsCapture.lua')
 local Codec,Sync,DPS=Nexus.Codec,Nexus.Sync,Nexus.DpsCapture
 local clock=1000; GetTime=function() return clock end; time=function() return 50000 end
-UnitName=function() return 'Localhero' end
+local currentName='Localhero'; UnitName=function() return currentName end
 UnitClass=function() return 'Mage','MAGE' end
 UnitLevel=function() return 80 end
 GetNormalizedRealmName=function() return 'Ebonhold' end
@@ -45,6 +45,32 @@ assert(payload.v==7 and payload.f==fp and payload.h==hash and type(payload.e)=='
 assert(payload.p=='Localhero' and payload.k=='MAGE' and payload.o=='localhero@ebonhold',
     'current wire lost sender identity evidence')
 
+-- Localized player names are valid in both the WLD2 envelope and its transfer
+-- ID. Exercise outbound generation and inbound reassembly with UTF-8 bytes.
+currentName='Duká'
+local localizedRecord={protocolVersion=7,fingerprint=fp,loadoutHash=hash,echoes=echoes,
+    category='dummy',dps=26000000,duration=66,ts=49001,player='Duká',class='MAGE',
+    ownerKey='duká@ebonhold',realm='ebonhold',level=80,buildId='dps-localized'}
+H.sentChatMessages={}
+assert(Sync.BroadcastDpsRecord(localizedRecord),
+    'localized player name was rejected from DPS transfer ID')
+Pump(8)
+local localizedMessages=H.sentChatMessages
+local localizedPayload=DecodeDps(localizedMessages)
+assert(localizedPayload.p=='Duká','localized DPS identity changed on the wire')
+
+currentName='Receiver'
+NexusDB={communityBuilds={},syncTombstones={},dpsCapture={}}
+Sync.Init(Codec,{}); DPS.Init({},Sync)
+for _,message in ipairs(localizedMessages) do
+    Sync.HandleIncoming(message.text,'Duká')
+end
+local receivedLocalized=false
+for _,row in pairs(NexusDB.dpsCapture.characterBest.dummy or {}) do
+    if row.player=='Duká' then receivedLocalized=true end
+end
+assert(receivedLocalized,'localized DPS transfer was rejected during reassembly')
+
 -- A v6 peer remains acceptable only when it supplies the same complete proof.
 assert(DPS.ReceiveRecord({v=6,f=fp,h=hash,e=echoes,c='dummy',d=18000000,u=61,t=40000,
     p='Legacy',k='MAGE',o='legacy@ebonhold',r='ebonhold',l=80,b='legacy-build'},'Legacy'),
@@ -60,4 +86,4 @@ assert(not DPS.ReceiveRecord({v=7,f=fp,h=hash,e=echoes,c='dummy',d=19000000,u=61
 local before=#DPS.GetDpsBoard('dummy')
 Sync.HandleIncoming('WLDS|Attacker|victim|dummy|999999999999|80|Attacker','Attacker')
 assert(#DPS.GetDpsBoard('dummy')==before,'legacy enormous/no-duration DPS was accepted')
-print('safe v6 evidence compatibility, protocol 7 wire, and legacy rejection -- OK')
+print('safe v6 compatibility, localized protocol 7 wire, and legacy rejection -- OK')

--- a/tests/run_release_mesh_stress.lua
+++ b/tests/run_release_mesh_stress.lua
@@ -31,4 +31,13 @@ local parts={}; for p in fullHash:gmatch("([^,]+)") do parts[#parts+1]=p end; pa
 broadcasts={}
 local n=DPS.BroadcastAllBuildBests(table.concat(parts,","))
 assert(n>0 and n<40,"one changed bucket should send a bounded subset, got "..tostring(n))
+local attempts=0
+DPS.Init({}, {BroadcastDpsRecord=function()
+ attempts=attempts+1
+ if attempts==1 then return true end
+ return false,"sync queue full"
+end})
+local admitted,complete=DPS.BroadcastAllBuildBests("0")
+assert(admitted==1 and complete==false and attempts>1,
+ "partial DPS bucket admission was incorrectly reported as complete")
 print("100-entry leaderboard and bucket-delta sync stress -- OK")

--- a/tests/run_release_mesh_stress.lua
+++ b/tests/run_release_mesh_stress.lua
@@ -31,13 +31,22 @@ local parts={}; for p in fullHash:gmatch("([^,]+)") do parts[#parts+1]=p end; pa
 broadcasts={}
 local n=DPS.BroadcastAllBuildBests(table.concat(parts,","))
 assert(n>0 and n<40,"one changed bucket should send a bounded subset, got "..tostring(n))
-local attempts=0
-DPS.Init({}, {BroadcastDpsRecord=function()
- attempts=attempts+1
- if attempts==1 then return true end
- return false,"sync queue full"
+local attempts,room,firstAdmitted={},1,nil
+DPS.Init({}, {BroadcastDpsRecord=function(record)
+ local key=tostring(record.category)..":"..tostring(record.player)
+ attempts[key]=(attempts[key] or 0)+1
+ if room<=0 then return false,"sync queue full" end
+ room=room-1; firstAdmitted=firstAdmitted or key
+ return true
 end})
-local admitted,complete=DPS.BroadcastAllBuildBests("0")
-assert(admitted==1 and complete==false and attempts>1,
+local progress={}
+local admitted,complete=DPS.BroadcastAllBuildBests("0",nil,progress)
+assert(admitted==1 and complete==false and firstAdmitted,
  "partial DPS bucket admission was incorrectly reported as complete")
+room=200
+local resumed,resumeComplete=DPS.BroadcastAllBuildBests("0",nil,progress)
+assert(resumed==99 and resumeComplete==true,
+ "DPS bucket retry did not resume after the admitted record")
+assert(attempts[firstAdmitted]==1,
+ "DPS bucket retry re-enqueued an already admitted record")
 print("100-entry leaderboard and bucket-delta sync stress -- OK")

--- a/tests/run_security_hardening.lua
+++ b/tests/run_security_hardening.lua
@@ -149,10 +149,21 @@ local record = {
     k="MAGE", o="alice@ebonhold", r="ebonhold",
 }
 local dpsData = Codec.Base64Encode(Codec.JSONEncode(record))
-Sync.HandleIncoming("WLD2|Mallory|spoof|1/1|" .. dpsData, "Mallory")
+local function DeliverDps(sender, transferId, encoded)
+    local chunkSize = 160
+    local total = math.ceil(#encoded / chunkSize)
+    for i = 1, total do
+        local chunk = encoded:sub((i - 1) * chunkSize + 1, i * chunkSize)
+        local packet = "WLD2|" .. sender .. "|" .. transferId .. "|"
+            .. i .. "/" .. total .. "|" .. chunk
+        assert(#packet <= 255, "DPS test fixture exceeded the real wire limit")
+        Sync.HandleIncoming(packet, sender)
+    end
+end
+DeliverDps("Mallory", "spoof", dpsData)
 assert(#DPS.GetDpsBoard("dummy") == 0,
     "DPS player spoof entered the verified board")
-Sync.HandleIncoming("WLD2|Alice|valid|1/1|" .. dpsData, "Alice")
+DeliverDps("Alice", "valid", dpsData)
 assert(#DPS.GetDpsBoard("dummy") == 1,
     "valid owner-bound DPS record was rejected")
 Sync.HandleIncoming("WLDS|Mallory|x|Mallory|999999999999|80|dummy",

--- a/tests/run_sync_hostile_fuzz.lua
+++ b/tests/run_sync_hostile_fuzz.lua
@@ -1,0 +1,170 @@
+-- Deterministic hostile-input coverage. This is an independent Nexus test:
+-- fixed LCG input generation, bounded-state assertions, and no source shared
+-- with the unlicensed architectural reference archive.
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua")
+dofile("core/Sync.lua")
+
+local Sync = Nexus.Sync
+local clock = 4000
+GetTime = function() return clock end
+UnitName = function() return "Defender" end
+time = function() return 50000 end
+
+local protectedBuild = {
+    id="protected", title="Protected", author="Defender",
+    ownerKey="defender@ebonhold", class="MAGE", isMine=true,
+    postedAt=1, lastModified=1,
+    echoes={{spellId=200100, quality=3, stacks=1}},
+}
+NexusDB = {
+    communityBuilds={ protected=protectedBuild },
+    syncTombstones={},
+    settings={ hostileFuzzSentinel="unchanged" },
+    characterState={ selectedSlot=3, ownedGeneration=77 },
+}
+Sync.Init(Nexus.Codec, {})
+
+local seed = 24681357
+local function Next()
+    seed = (seed * 48271) % 2147483647
+    return seed
+end
+
+local function SafeHandle(payload, actualSender)
+    local ok, err = pcall(Sync.HandleIncoming, payload, actualSender)
+    assert(ok, "hostile payload raised an error: " .. tostring(err))
+end
+
+local hostileNames = {}
+for i = 1, 4000 do
+    local n = Next()
+    local sender = "Fuzzer" .. tostring((n % 50) + 1)
+    hostileNames[sender] = true
+    local case = n % 12
+    local payload
+    local actual = sender
+    if case == 0 then
+        payload = string.rep("X", 256 + (n % 512))
+    elseif case == 1 then
+        payload = "UNKNOWN|" .. sender .. "|" .. tostring(n)
+    elseif case == 2 then
+        payload = "WLRQ|Forged|0|0|mismatch-" .. tostring(n)
+    elseif case == 3 then
+        payload = "WLRB|" .. sender .. "|" .. string.rep("i", 140)
+            .. "|1|1/2|AAAA"
+    elseif case == 4 then
+        payload = "WLRB|" .. sender .. "|bad-" .. tostring(n)
+            .. "|1|0/1|AAAA"
+    elseif case == 5 then
+        payload = "WLD2|" .. sender .. "|bad-" .. tostring(n)
+            .. "|1/1000|AAAA"
+    elseif case == 6 then
+        payload = "WLRD|" .. sender .. "|unknown-" .. tostring(n)
+            .. "|-1|" .. sender
+    elseif case == 7 then
+        payload = "WLNP|" .. sender .. "|" .. string.rep("9", 80)
+    elseif case == 8 then
+        payload = "WLRQ|" .. sender .. "|0|0|" .. string.rep("r", 140)
+    elseif case == 9 then
+        -- Valid geometry but incomplete/out of order: bounded transfer state
+        -- may be retained, but it must not prove that this is a Nexus peer.
+        payload = "WLRB|" .. sender .. "|partial-" .. tostring(n)
+            .. "|1|2/3|AAAA"
+    elseif case == 10 then
+        payload = "WLD2|" .. sender .. "|partial-" .. tostring(n)
+            .. "|2/3|AAAA"
+    else
+        payload = "WLRQ|" .. sender .. "|not a hash|0|bad-" .. tostring(n)
+    end
+    if case == 2 then actual = sender end
+    SafeHandle(payload, actual)
+end
+
+-- Deterministic duplicate/out-of-order and immutable-metadata conflicts.
+SafeHandle("WLRB|ConflictPeer|same|1|2/3|AAAA", "ConflictPeer")
+SafeHandle("WLRB|ConflictPeer|same|1|2/3|AAAA", "ConflictPeer")
+SafeHandle("WLRB|ConflictPeer|same|2|1/3|BBBB", "ConflictPeer")
+SafeHandle("WLD2|ConflictDps|same|2/3|AAAA", "ConflictDps")
+SafeHandle("WLD2|ConflictDps|same|1/4|BBBB", "ConflictDps")
+assert(not Sync.IsKnownPeer("ConflictPeer")
+    and not Sync.IsKnownPeer("ConflictDps"),
+    "incomplete/conflicting transfers created false peers")
+
+local state = Sync.WorkState()
+assert(state.buildInflight + state.dpsInflight <= state.maxGlobal,
+    "hostile fuzz escaped the global inflight cap")
+assert(state.buildBytes + state.dpsBytes
+        <= state.maxGlobal * state.maxEncodedBytes,
+    "hostile fuzz escaped the cumulative transfer-byte cap")
+assert(state.pendingResponses <= state.maxPendingResponses
+    and state.pendingLoadouts <= state.maxPendingLoadouts,
+    "hostile fuzz escaped pending-response bounds")
+for sender in pairs(hostileNames) do
+    assert(not Sync.IsKnownPeer(sender),
+        "rejected/incomplete hostile traffic created a false Nexus peer")
+end
+SafeHandle("WLNP|RealmTwin-One|1.19.4", "RealmTwin-Two")
+assert(not Sync.IsKnownPeer("RealmTwin"),
+    "realm-qualified sender mismatch created a false peer")
+
+-- Accepted protocol traffic still creates a peer after validation.
+SafeHandle("WLNP|KnownPeer|1.19.4", "KnownPeer")
+assert(Sync.IsKnownPeer("KnownPeer"),
+    "accepted presence did not create a Nexus peer")
+
+-- Exercise pending/control and bulk overflow boundaries with accepted local
+-- work. Both queues remain bounded and report rejected-newest backpressure.
+for i = 1, state.maxPendingResponses + 32 do
+    SafeHandle("WLRQ|QueuePeer" .. i .. "|0|0|req-" .. i,
+        "QueuePeer" .. i)
+end
+Sync.OnUpdate(10)
+state = Sync.WorkState()
+assert(state.pendingResponses <= state.maxPendingResponses,
+    "request flood exceeded the pending-response cap")
+assert(state.control <= state.maxControlQueue,
+    "request flood exceeded the control-queue cap")
+
+for i = 1, state.maxOutboundQueue + 32 do
+    Sync.BroadcastDps("fuzz-queue-" .. i, "Defender", 1000 + i, 80, "dummy")
+end
+state = Sync.WorkState()
+assert(state.sending <= state.maxOutboundQueue,
+    "bulk queue exceeded its explicit cap")
+assert((Sync.Stats().queueOverflowRejected or 0) > 0,
+    "queue pressure did not report rejected-newest overflow")
+
+-- Abandoned chunk and pending-response state expires deterministically.
+clock = clock + 61
+Sync.OnUpdate(0)
+state = Sync.WorkState()
+assert(state.buildInflight == 0 and state.dpsInflight == 0,
+    "abandoned hostile transfers survived their TTL")
+assert(state.pendingResponses == 0 and state.pendingLoadouts == 0,
+    "abandoned hostile response state survived its TTL")
+
+-- Replaying one duplicate chunk may refresh idle activity, but cannot retain
+-- an incomplete transfer beyond the absolute lifetime cap.
+Sync.Init(Nexus.Codec, {})
+SafeHandle("WLRB|DripPeer|drip|1|1/2|AAAA", "DripPeer")
+for _ = 1, 16 do
+    clock = clock + 20
+    SafeHandle("WLRB|DripPeer|drip|1|1/2|AAAA", "DripPeer")
+    Sync.OnUpdate(0)
+end
+assert(Sync.WorkState().buildInflight == 0,
+    "duplicate drip traffic retained an incomplete transfer indefinitely")
+
+-- Protected player/configuration state must remain byte-for-byte equivalent
+-- at the fields hostile traffic could otherwise target.
+assert(NexusDB.communityBuilds.protected == protectedBuild
+    and NexusDB.communityBuilds.protected.title == "Protected"
+    and NexusDB.communityBuilds.protected.isMine == true,
+    "hostile fuzz mutated the protected local build")
+assert(NexusDB.settings.hostileFuzzSentinel == "unchanged"
+    and NexusDB.characterState.selectedSlot == 3
+    and NexusDB.characterState.ownedGeneration == 77,
+    "hostile fuzz mutated protected character or automation state")
+
+print("4000 deterministic hostile Sync payloads remained bounded and fail-closed -- OK")

--- a/tests/run_sync_index_on_demand.lua
+++ b/tests/run_sync_index_on_demand.lua
@@ -43,4 +43,28 @@ assert(placeholder and not placeholder.loadoutAvailable and not placeholder.echo
     'legacy summary was incorrectly treated as exact evidence')
 local immediate,why=Sync.RequestLoadout('build-79')
 assert(not immediate and why,'legacy recovery request did not remain background-only')
-print('complete current sync and safe legacy-summary compatibility -- OK')
+
+-- A recovery rejected at the queue cap must remain immediately eligible once
+-- a slot opens; rejected work must not receive the 120-second cooldown.
+Sync.Init(Nexus.Codec,{})
+local recoveryLimit=Sync.WorkState().maxRecoveryQueue
+for i=1,recoveryLimit do
+    local sent,reason=Sync.RequestLoadout('recovery-'..i)
+    assert(not sent and reason=='queued for background recovery',
+        'recovery queue rejected work before its documented cap')
+end
+assert(Sync.WorkState().recovery==recoveryLimit,
+    'recovery queue did not reach its documented cap')
+local sentOverflow,overflowReason=Sync.RequestLoadout('recovery-overflow')
+assert(not sentOverflow and overflowReason=='awaiting sync',
+    'overflow recovery request was not rejected explicitly')
+Sync.OnUpdate(1.6)
+assert(Sync.WorkState().recovery==recoveryLimit-1,
+    'recovery pump did not release one queue slot')
+local sentRetry,retryReason=Sync.RequestLoadout('recovery-overflow')
+assert(not sentRetry and retryReason=='queued for background recovery',
+    'rejected recovery request was incorrectly left on cooldown')
+assert(Sync.WorkState().recovery==recoveryLimit,
+    'immediate recovery retry did not enter the released slot')
+
+print('complete current sync, legacy recovery, and cooldown admission -- OK')

--- a/tests/run_sync_index_on_demand.lua
+++ b/tests/run_sync_index_on_demand.lua
@@ -7,7 +7,7 @@ local clock=1000; GetTime=function() return clock end; time=function() return 50
 local function Pump(steps) for _=1,steps do clock=clock+0.2; Sync.OnUpdate(0.2) end end
 local who='Source'; UnitName=function() return who end
 local echoes={}; for i=1,79 do echoes[i]={spellId=200000+i,stacks=(i%3)+1,quality=3} end
-local build={id='build-79',title='Full Record Build',description=string.rep('description ',50),
+local build={id='build-79',title='AoE | ST',description=string.rep('description ',50),
     author='Source',ownerKey='source@ebonhold',class='MAGE',echoes=echoes,
     postedAt=10,lastModified=10,isMine=true}
 NexusDB={communityBuilds={[build.id]=build},syncTombstones={},dpsCapture={}}
@@ -41,6 +41,8 @@ for _,m in ipairs(summaries) do Sync.HandleIncoming(m.text,'Source') end
 local placeholder=NexusDB.communityBuilds['build-79']
 assert(placeholder and not placeholder.loadoutAvailable and not placeholder.echoes,
     'legacy summary was incorrectly treated as exact evidence')
+assert(placeholder.title=='AoE | ST',
+    'Base64-encoded summary title containing a wire delimiter was rejected')
 local immediate,why=Sync.RequestLoadout('build-79')
 assert(not immediate and why,'legacy recovery request did not remain background-only')
 

--- a/tests/run_sync_mesh_optimized.lua
+++ b/tests/run_sync_mesh_optimized.lua
@@ -25,6 +25,7 @@ local function buildHash(builds)
 end
 local bh=buildHash(NexusDB.communityBuilds)
 local dh=DPS.GetSyncHash()
+local emptyBuckets="0,0,0,0,0,0,0,0"
 -- Fully current requester receives nothing.
 H.sentChatMessages={}
 Sync.HandleIncoming("WLRQ|Current|"..bh.."|"..dh.."|req-current","Current")
@@ -33,7 +34,7 @@ assert(#H.sentChatMessages==0,"current requester should receive no duplicate tra
 -- A matching per-build bucket claim suppresses only that safely relayable
 -- build bucket. Legacy whole-state claims cannot suppress owner-only state.
 H.sentChatMessages={}
-Sync.HandleIncoming("WLRQ|NewPeer|0|0|req-claim","NewPeer")
+Sync.HandleIncoming("WLRQ|NewPeer|"..emptyBuckets.."|"..emptyBuckets.."|req-claim","NewPeer")
 local buildParts={}; for p in bh:gmatch("([^,]+)") do buildParts[#buildParts+1]=p end
 local buildBucket,buildBucketHash
 for i,value in ipairs(buildParts) do if value~="0" then buildBucket,buildBucketHash=i,value break end end
@@ -47,7 +48,7 @@ end
 assert(not duplicateBuild,"matching build-bucket claim did not suppress duplicate build reply")
 -- A claim advertising different state must not suppress our useful contribution.
 H.sentChatMessages={}
-Sync.HandleIncoming("WLRQ|OtherPeer|0|0|req-different","OtherPeer")
+Sync.HandleIncoming("WLRQ|OtherPeer|"..emptyBuckets.."|"..emptyBuckets.."|req-different","OtherPeer")
 Sync.HandleIncoming("WLRC|PartialPeer|OtherPeer|req-different|different|different","PartialPeer")
 Pump(100)
 local claim,buildMsg,dpsMsg=false,false,false

--- a/tests/run_sync_transport_safety.lua
+++ b/tests/run_sync_transport_safety.lua
@@ -93,4 +93,34 @@ assert(H.sentChatMessages[1]
     and H.sentChatMessages[1].text:find("queued%-1", 1, false),
     "queue overflow overwrote the oldest retained packet")
 
-print("sync channel validation, retry retention, and queue overflow policy -- OK")
+-- A responder must never publish a WLLC claim when the corresponding WLRB
+-- payload was rejected by bulk backpressure. Keep the response pending until
+-- capacity is available instead of suppressing every other responder.
+Sync.Init(Nexus.Codec, {})
+NexusDB.communityBuilds["claim-build"] = {
+    id="claim-build", title="Claim Build", author="Alice", class="MAGE",
+    lastModified=10, postedAt=10,
+    echoes={{spellId=200100, quality=3, stacks=1}},
+}
+limits = Sync.WorkState()
+for i = 1, limits.maxOutboundQueue do
+    assert(Sync.BroadcastDps("claim-fill-" .. i, "Alice", 3000 + i,
+        80, "dummy"), "failed to fill claim backpressure queue")
+end
+assert(Sync.HandleIncoming("WLLQ|Requester|claim-build", "Requester"),
+    "valid on-demand loadout request was rejected")
+assert(Sync.WorkState().pendingLoadouts == 1,
+    "on-demand loadout response was not scheduled")
+local oldTemporary2, oldNamed2 = JoinTemporaryChannel, JoinChannelByName
+H.joinedChannels = {}
+JoinTemporaryChannel = function() end
+JoinChannelByName = function() end
+Sync.OnUpdate(2)
+local rejectedResponse = Sync.WorkState()
+assert(rejectedResponse.control == 0,
+    "loadout claim was queued without an admitted build payload")
+assert(rejectedResponse.pendingLoadouts == 1,
+    "backpressured loadout response was not retained for retry")
+JoinTemporaryChannel, JoinChannelByName = oldTemporary2, oldNamed2
+
+print("sync channel validation, retry retention, overflow, and claim safety -- OK")

--- a/tests/run_sync_transport_safety.lua
+++ b/tests/run_sync_transport_safety.lua
@@ -1,0 +1,96 @@
+-- Outbound Sync must revalidate the named channel immediately before every
+-- send, retain packets while disconnected, and reject newest packets when a
+-- bounded queue is full without overwriting older queued traffic.
+local H = dofile("tests/harness.lua")
+dofile("core/Codec.lua")
+dofile("core/Sync.lua")
+
+local Sync = Nexus.Sync
+local clock = 1000
+GetTime = function() return clock end
+UnitName = function() return "Alice" end
+NexusDB = { communityBuilds={}, syncTombstones={} }
+Sync.Init(Nexus.Codec, {})
+
+local function Pump(steps)
+    for _ = 1, steps do
+        clock = clock + 0.2
+        Sync.OnUpdate(0.2)
+    end
+end
+
+-- The cached slot began as 1. Before the queued packet is sent, the sync
+-- channel moves to 7 and General takes slot 1. Raw Sync traffic must follow
+-- wrbuildssync, never the stale numeric slot.
+H.sentChatMessages = {}
+assert(Sync.BroadcastDps("renumbered", "Alice", 1000, 80, "dummy"))
+H.joinedChannels[Sync.ChannelName()] = 7
+H.joinedChannels.general = 1
+Pump(6)
+assert(#H.sentChatMessages == 1, "renumbered packet was not sent")
+assert(H.sentChatMessages[1].target == 7,
+    "cached Sync slot sent raw traffic to a different channel")
+
+-- If the named channel cannot be found or rejoined, the packet stays queued.
+assert(Sync.BroadcastDps("retained", "Alice", 1001, 80, "dummy"))
+H.joinedChannels = {}
+local oldTemporary, oldNamed = JoinTemporaryChannel, JoinChannelByName
+JoinTemporaryChannel = function() end
+JoinChannelByName = function() end
+local sentBefore = #H.sentChatMessages
+Pump(6)
+local waiting = Sync.WorkState()
+assert(#H.sentChatMessages == sentBefore,
+    "packet was sent without a validated wrbuildssync channel")
+assert(waiting.outbound == 1,
+    "packet was discarded when channel validation/reconnect failed")
+
+-- Discovery of the channel at a new slot releases the retained packet.
+H.joinedChannels[Sync.ChannelName()] = 9
+JoinTemporaryChannel, JoinChannelByName = oldTemporary, oldNamed
+Pump(6)
+assert(#H.sentChatMessages == sentBefore + 1
+    and H.sentChatMessages[#H.sentChatMessages].target == 9,
+    "retained packet did not use the newly validated channel slot")
+assert(Sync.WorkState().outbound == 0,
+    "retained packet remained queued after a successful send")
+
+-- Saturate the documented bulk queue. The explicit policy is to preserve
+-- already queued packets and reject the newest packet/batch with a visible
+-- counter and false return value.
+Sync.Init(Nexus.Codec, {})
+H.sentChatMessages = {}
+local limits = Sync.WorkState()
+assert(type(limits.maxOutboundQueue) == "number"
+    and limits.maxOutboundQueue > 0,
+    "Sync does not expose an explicit outbound queue bound")
+for i = 1, limits.maxOutboundQueue - 1 do
+    assert(Sync.BroadcastDps("queued-" .. i, "Alice", 2000 + i, 80, "dummy"),
+        "outbound queue rejected a packet before its documented limit")
+end
+local batchEchoes = {}
+for i = 1, 24 do
+    batchEchoes[i] = { spellId=200000 + i, quality=3, stacks=2 }
+end
+assert(not Sync.BroadcastBuild({ id="atomic-batch", title="Atomic Batch",
+    author="Alice", class="MAGE", lastModified=1, postedAt=1,
+    description=string.rep("bounded ", 20), echoes=batchEchoes }),
+    "multi-chunk batch partially entered a nearly full queue")
+assert(Sync.WorkState().sending == limits.maxOutboundQueue - 1,
+    "rejected multi-chunk batch partially mutated the queue")
+assert(Sync.BroadcastDps("queued-final", "Alice", 999998, 80, "dummy"),
+    "final available queue slot was not usable after atomic batch rejection")
+assert(not Sync.BroadcastDps("rejected-newest", "Alice", 999999, 80, "dummy"),
+    "outbound queue silently exceeded its documented limit")
+local full = Sync.WorkState()
+assert(full.sending == limits.maxOutboundQueue,
+    "outbound overflow changed or overwrote the bounded queue")
+assert((Sync.Stats().queueOverflowRejected or 0) >= 1,
+    "outbound overflow was not recorded explicitly")
+
+Pump(6)
+assert(H.sentChatMessages[1]
+    and H.sentChatMessages[1].text:find("queued%-1", 1, false),
+    "queue overflow overwrote the oldest retained packet")
+
+print("sync channel validation, retry retention, and queue overflow policy -- OK")

--- a/tests/run_sync_transport_safety.lua
+++ b/tests/run_sync_transport_safety.lua
@@ -179,4 +179,26 @@ assert(rejectedBucket.sending == limits.maxOutboundQueue - 1,
     "failed bucket admission partially mutated the bulk queue")
 JoinTemporaryChannel, JoinChannelByName = oldTemporary3, oldNamed3
 
+-- DPS bucket broadcasters report partial queue admission separately from the
+-- number of records queued. A partial result must retain the pending bucket
+-- for retry instead of treating it as complete.
+Sync.Init(Nexus.Codec, {})
+NexusDB.communityBuilds = {}
+local partialCalls = 0
+Nexus.DpsCapture = {
+    GetSyncHash = function() return "abc,0,0,0,0,0,0,0" end,
+    BroadcastAllBuildBests = function()
+        partialCalls = partialCalls + 1
+        return 1, false
+    end,
+}
+local localBuildHash = Sync.GetCompatibilityHashes()
+assert(Sync.HandleIncoming("WLRQ|Requester|" .. localBuildHash .. "|"
+    .. emptyBuckets .. "|req-dps-partial", "Requester"),
+    "valid DPS reconciliation request was rejected")
+Sync.OnUpdate(6)
+assert(partialCalls >= 1, "DPS bucket broadcaster was not invoked")
+assert(Sync.WorkState().pendingResponses == 1,
+    "partially admitted DPS bucket was not retained for retry")
+
 print("sync validation, retry retention, overflow, and claim safety -- OK")

--- a/tests/run_sync_transport_safety.lua
+++ b/tests/run_sync_transport_safety.lua
@@ -123,4 +123,60 @@ assert(rejectedResponse.pendingLoadouts == 1,
     "backpressured loadout response was not retained for retry")
 JoinTemporaryChannel, JoinChannelByName = oldTemporary2, oldNamed2
 
-print("sync channel validation, retry retention, overflow, and claim safety -- OK")
+-- Bucket election has the same invariant: WLBC may only be published after
+-- every WLRB packet in that bucket has been admitted atomically. Leave room
+-- for one packet while scheduling two one-packet builds in the same bucket;
+-- the partial admission must be rolled back along with the claim.
+Sync.Init(Nexus.Codec, {})
+local function TestBuildBucket(id)
+    local hash = 5381
+    for i = 1, #id do hash = ((hash * 33) + id:byte(i)) % 2147483648 end
+    return (hash % 8) + 1
+end
+local firstBucketId = "bucket-build-a"
+local secondBucketId
+for i = 1, 100 do
+    local candidate = "bucket-build-" .. i
+    if TestBuildBucket(candidate) == TestBuildBucket(firstBucketId) then
+        secondBucketId = candidate
+        break
+    end
+end
+assert(secondBucketId, "test setup could not find two ids in one build bucket")
+NexusDB.communityBuilds = {
+    [firstBucketId] = {
+        id=firstBucketId, title="Bucket Build A", author="Alice", class="MAGE",
+        lastModified=11, postedAt=11,
+        echoes={{spellId=200101, quality=3, stacks=1}},
+    },
+    [secondBucketId] = {
+        id=secondBucketId, title="Bucket Build B", author="Alice", class="MAGE",
+        lastModified=12, postedAt=12,
+        echoes={{spellId=200102, quality=3, stacks=1}},
+    },
+}
+limits = Sync.WorkState()
+for i = 1, limits.maxOutboundQueue - 1 do
+    assert(Sync.BroadcastDps("bucket-fill-" .. i, "Alice", 4000 + i,
+        80, "dummy"), "failed to fill bucket backpressure queue")
+end
+local emptyBuckets = "0,0,0,0,0,0,0,0"
+assert(Sync.HandleIncoming("WLRQ|Requester|" .. emptyBuckets .. "|0|req-bucket",
+    "Requester"), "valid bucket reconciliation request was rejected")
+assert(Sync.WorkState().pendingResponses == 1,
+    "bucket reconciliation response was not scheduled")
+local oldTemporary3, oldNamed3 = JoinTemporaryChannel, JoinChannelByName
+H.joinedChannels = {}
+JoinTemporaryChannel = function() end
+JoinChannelByName = function() end
+Sync.OnUpdate(6)
+local rejectedBucket = Sync.WorkState()
+assert(rejectedBucket.control == 0,
+    "bucket claim was queued without a complete admitted payload")
+assert(rejectedBucket.pendingResponses == 1,
+    "backpressured bucket response was not retained for retry")
+assert(rejectedBucket.sending == limits.maxOutboundQueue - 1,
+    "failed bucket admission partially mutated the bulk queue")
+JoinTemporaryChannel, JoinChannelByName = oldTemporary3, oldNamed3
+
+print("sync validation, retry retention, overflow, and claim safety -- OK")

--- a/tests/run_sync_transport_safety.lua
+++ b/tests/run_sync_transport_safety.lua
@@ -121,12 +121,26 @@ assert(rejectedResponse.control == 0,
     "loadout claim was queued without an admitted build payload")
 assert(rejectedResponse.pendingLoadouts == 1,
     "backpressured loadout response was not retained for retry")
+for _ = 1, 40 do
+    clock = clock + 1
+    Sync.OnUpdate(1)
+end
+assert(Sync.WorkState().pendingLoadouts == 1,
+    "active backpressured loadout response expired at the inactivity TTL")
 JoinTemporaryChannel, JoinChannelByName = oldTemporary2, oldNamed2
+H.joinedChannels[Sync.ChannelName()] = 5
+for _ = 1, 10 do
+    clock = clock + 1.2
+    Sync.OnUpdate(1.2)
+    if Sync.WorkState().pendingLoadouts == 0 then break end
+end
+assert(Sync.WorkState().pendingLoadouts == 0,
+    "retained loadout response did not complete after backpressure cleared")
 
 -- Bucket election has the same invariant: WLBC may only be published after
--- every WLRB packet in that bucket has been admitted atomically. Leave room
--- for one packet while scheduling two one-packet builds in the same bucket;
--- the partial admission must be rolled back along with the claim.
+-- every WLRB packet in that bucket has been admitted. Leave room for one
+-- packet while scheduling two one-packet builds in the same bucket: retain
+-- the admitted first payload, then resume with the second without duplication.
 Sync.Init(Nexus.Codec, {})
 local function TestBuildBucket(id)
     local hash = 5381
@@ -175,9 +189,60 @@ assert(rejectedBucket.control == 0,
     "bucket claim was queued without a complete admitted payload")
 assert(rejectedBucket.pendingResponses == 1,
     "backpressured bucket response was not retained for retry")
-assert(rejectedBucket.sending == limits.maxOutboundQueue - 1,
-    "failed bucket admission partially mutated the bulk queue")
+assert(rejectedBucket.sending == limits.maxOutboundQueue,
+    "successfully admitted bucket progress was rolled back")
 JoinTemporaryChannel, JoinChannelByName = oldTemporary3, oldNamed3
+H.joinedChannels[Sync.ChannelName()] = 6
+for _ = 1, 10 do
+    clock = clock + 1.2
+    Sync.OnUpdate(1.2)
+    if Sync.WorkState().pendingResponses == 0 then break end
+end
+assert(Sync.WorkState().pendingResponses == 0,
+    "bucket retry did not resume after its admitted build")
+assert(Sync.WorkState().sending == limits.maxOutboundQueue,
+    "bucket retry duplicated prior work or failed to use the released slot")
+
+-- A permanently invalid legacy row must not roll back or indefinitely block
+-- a valid build in the same bucket. Because the row was skipped, do not claim
+-- the bucket; another peer may still hold a sendable copy.
+Sync.Init(Nexus.Codec, {})
+local validId = "sendable-bucket-build"
+local invalidKey
+for i = 1, 100 do
+    local candidate = "unsendable-bucket-" .. i
+    if TestBuildBucket(candidate) == TestBuildBucket(validId) then
+        invalidKey = candidate
+        break
+    end
+end
+assert(invalidKey, "test setup could not colocate an unsendable row")
+NexusDB.communityBuilds = {
+    [validId] = {
+        id=validId, title="Sendable", author="Alice", class="MAGE",
+        lastModified=21, postedAt=21,
+        echoes={{spellId=200201, quality=3, stacks=1}},
+    },
+    [invalidKey] = {
+        id="invalid|wire-id", title="Unsendable", author="Alice",
+        class="MAGE", lastModified=22, postedAt=22,
+        fingerprintHash="1",
+    },
+}
+local oldTemporary4, oldNamed4 = JoinTemporaryChannel, JoinChannelByName
+H.joinedChannels = {}
+JoinTemporaryChannel = function() end
+JoinChannelByName = function() end
+assert(Sync.HandleIncoming("WLRQ|Requester|" .. emptyBuckets
+    .. "|0|req-unsendable", "Requester"),
+    "mixed sendable/unsendable bucket request was rejected")
+Sync.OnUpdate(6)
+local mixedBucket = Sync.WorkState()
+assert(mixedBucket.pendingResponses == 0 and mixedBucket.sending == 1,
+    "unsendable row blocked the valid build sharing its bucket")
+assert(mixedBucket.control == 0,
+    "responder claimed a bucket after skipping an unsendable row")
+JoinTemporaryChannel, JoinChannelByName = oldTemporary4, oldNamed4
 
 -- DPS bucket broadcasters report partial queue admission separately from the
 -- number of records queued. A partial result must retain the pending bucket

--- a/tests/run_sync_transport_safety.lua
+++ b/tests/run_sync_transport_safety.lua
@@ -244,6 +244,41 @@ assert(mixedBucket.control == 0,
     "responder claimed a bucket after skipping an unsendable row")
 JoinTemporaryChannel, JoinChannelByName = oldTemporary4, oldNamed4
 
+-- A locally authored delete rejected at the outbound queue limit must remain
+-- pending and use the first capacity that becomes available. Otherwise the
+-- local row is gone before online peers receive its tombstone.
+NexusDB.communityBuilds = {}
+NexusDB.syncTombstones = {}
+Sync.Init(Nexus.Codec, {})
+limits = Sync.WorkState()
+for i = 1, limits.maxOutboundQueue do
+    assert(Sync.BroadcastDps("delete-fill-" .. i, "Alice", 5000 + i,
+        80, "dummy"), "failed to fill delete backpressure queue")
+end
+local immediateDelete, deleteWhy = Sync.BroadcastDelete({
+    id="delete-backpressure", title="Delete Backpressure", author="Alice",
+    lastModified=30, postedAt=30,
+    echoes={{spellId=200301, quality=3, stacks=1}},
+})
+assert(not immediateDelete and deleteWhy == "queued for retry",
+    "full-queue delete was not retained for retry")
+assert(Sync.WorkState().pendingDeletes == 1,
+    "retained delete was not exposed as pending work")
+assert(NexusDB.syncTombstones["delete-backpressure"].pending == true,
+    "retained delete was not persisted across reloads")
+H.joinedChannels[Sync.ChannelName()] = 7
+clock = clock + 1.2
+Sync.OnUpdate(1.2) -- observe the full queue, then drain one packet
+clock = clock + 1.2
+Sync.OnUpdate(1.2) -- admit the pending delete, then drain one packet
+local retriedDelete = Sync.WorkState()
+assert(retriedDelete.pendingDeletes == 0,
+    "retained delete did not clear after queue admission")
+assert(retriedDelete.sending == limits.maxOutboundQueue - 1,
+    "retained delete did not use the first freed queue slot")
+assert(NexusDB.syncTombstones["delete-backpressure"].pending == nil,
+    "admitted delete left stale persisted retry state")
+
 -- DPS bucket broadcasters report partial queue admission separately from the
 -- number of records queued. A partial result must retain the pending bucket
 -- for retry instead of treating it as complete.

--- a/tests/run_wishlist_editor.lua
+++ b/tests/run_wishlist_editor.lua
@@ -44,4 +44,25 @@ for i = 1, 5 do
     assert(ok2, "Refresh() threw on iteration " .. i)
 end
 
-print("wishlist editor: lifecycle + seeding OK (checks=5)")
+-- Regression: opening Wishlists with an active Saved Build that has no
+-- association used to initialize the new-wishlist draft without showing the
+-- editor. The Panel had already suppressed its HUD, leaving both windows
+-- invisible and causing the HUD to flash closed on every subsequent render.
+frame:Hide()
+Adapter.Slots = function()
+    return {
+        activeSlot = 2,
+        maxSlots = 5,
+        bySlot = {
+            [2] = { slot = 2, name = "best2", echoes = {
+                { spellId = 200100, quality = 3, stacks = 1 },
+            } },
+        },
+    }
+end
+Adapter.GetLoadoutWishlist = function() return nil end
+local ok3 = pcall(EW.Show)
+assert(ok3, "Show() threw for an unassociated active loadout")
+assert(frame:IsShown(), "editor stayed hidden for an unassociated active loadout")
+
+print("wishlist editor: lifecycle + seeding + unassociated loadout open OK (checks=7)")

--- a/tests/run_wishlist_editor.lua
+++ b/tests/run_wishlist_editor.lua
@@ -48,6 +48,20 @@ end
 -- association used to initialize the new-wishlist draft without showing the
 -- editor. The Panel had already suppressed its HUD, leaving both windows
 -- invisible and causing the HUD to flash closed on every subsequent render.
+-- Seed a prior unsaved draft with a queued lock design and a fulfilled lock
+-- target. Neither may carry into the new active-loadout draft.
+local staleEchoes = {}
+for i = 1, 80 do
+    staleEchoes[i] = { spellId = 310000 + i, quality = 3, stacks = 1 }
+end
+staleEchoes[80].locked = true
+local seededOk = pcall(EW.OpenForCandidate,
+    { title="Stale draft", echoes=staleEchoes })
+assert(seededOk, "failed to seed the prior unsaved lock-design draft")
+local staleDraft = EW.DebugDraftState()
+assert(staleDraft.pendingLock == 1,
+    "test setup did not create a queued stale lock design")
+EW._fulfilledDraftTargets[399999] = true
 frame:Hide()
 Adapter.Slots = function()
     return {
@@ -64,5 +78,12 @@ Adapter.GetLoadoutWishlist = function() return nil end
 local ok3 = pcall(EW.Show)
 assert(ok3, "Show() threw for an unassociated active loadout")
 assert(frame:IsShown(), "editor stayed hidden for an unassociated active loadout")
+local freshDraft = EW.DebugDraftState()
+assert(freshDraft.pending == 0 and freshDraft.pendingLock == 0
+    and freshDraft.fulfilled == 0,
+    "unassociated active loadout inherited stale draft or lock state")
+assert(freshDraft.scrollOffset == 0 and freshDraft.pickOffset == 0
+    and freshDraft.pendingLoadoutOpen == nil,
+    "unassociated active loadout did not reset complete editor draft state")
 
-print("wishlist editor: lifecycle + seeding + unassociated loadout open OK (checks=7)")
+print("wishlist editor: lifecycle + clean unassociated loadout open OK (checks=11)")

--- a/ui/WishlistEditor.lua
+++ b/ui/WishlistEditor.lua
@@ -1421,6 +1421,18 @@ local function HideLoadoutSwitchMenu()
     if loadoutSwitchMenu then loadoutSwitchMenu:Hide() end
 end
 
+local function ResetNewWishlistDraft()
+    editingContext = nil
+    createTargetContext = nil
+    pending = {}
+    pendingLock = {}
+    M._fulfilledDraftTargets = {}
+    scrollOffset, pickOffset = 0, 0
+    pendingLoadoutOpen = nil
+    pendingSeeded = true
+    currentLockKey = 0
+end
+
 local function LoadEditorForLoadout(slot)
     slot = tonumber(slot)
     if not slot then return end
@@ -1436,11 +1448,8 @@ local function LoadEditorForLoadout(slot)
         return
     end
 
-    editingContext = nil
+    ResetNewWishlistDraft()
     createTargetContext = { loadoutSlot = slot, loadoutName = name }
-    pending = {}
-    currentLockKey = 0
-    pendingSeeded = true
     if wishlistNameBox then wishlistNameBox:SetText("") end
     -- M.Show delegates here whenever a real Saved Build is active. An
     -- unassociated build is a valid new-wishlist destination, so this branch
@@ -2926,6 +2935,23 @@ function M.DebugPendingCount()
     return n
 end
 
+function M.DebugDraftState()
+    local pendingCount, pendingLockCount, fulfilledCount = 0, 0, 0
+    for _ in pairs(pending) do pendingCount = pendingCount + 1 end
+    for _ in pairs(pendingLock) do pendingLockCount = pendingLockCount + 1 end
+    for _ in pairs(M._fulfilledDraftTargets or {}) do
+        fulfilledCount = fulfilledCount + 1
+    end
+    return {
+        pending = pendingCount,
+        pendingLock = pendingLockCount,
+        fulfilled = fulfilledCount,
+        scrollOffset = scrollOffset,
+        pickOffset = pickOffset,
+        pendingLoadoutOpen = pendingLoadoutOpen,
+    }
+end
+
 
 function M.OpenForCandidate(candidate)
     editingContext = nil
@@ -2976,8 +3002,7 @@ end
 
 function M.NewWishlist()
     HideServerEchoUI()
-    editingContext = nil
-    createTargetContext = nil
+    ResetNewWishlistDraft()
     local slots = Adapter and Adapter.Slots and Adapter.Slots()
     local active = slots and tonumber(slots.activeSlot) or 0
     local maxSlots = slots and (tonumber(slots.maxSlots) or 5) or 5
@@ -2988,16 +3013,9 @@ function M.NewWishlist()
         if loadoutName == "" then loadoutName = "Saved Build " .. tostring(active) end
         createTargetContext = { loadoutSlot = active, loadoutName = loadoutName }
     end
-    pending = {}
-    pendingLock = {}
-    M._fulfilledDraftTargets = {}
-    scrollOffset, pickOffset = 0, 0
-    pendingLoadoutOpen = nil
-    pendingSeeded = true
     -- Doesn't call LoadPendingEchoes (nothing to load yet), so reset the
     -- lock-design key directly -- a brand new, still-empty wishlist has no
     -- content yet, so no fingerprint (bucket 0), matching WishlistKey(nil).
-    currentLockKey = 0
     EnsureFrame()
     if Nexus.Panel and Nexus.Panel.AttachMenuFrame then Nexus.Panel.AttachMenuFrame(frame) end
     if Nexus.Theme and Nexus.Theme.StyleWindow then Nexus.Theme.StyleWindow(frame, 0.96) end
@@ -3035,13 +3053,7 @@ function M.Show()
         M.OpenForWishlist(firstRun, nil)
         return
     end
-    editingContext = nil
-    createTargetContext = nil
-    pending = {}
-    pendingLock = {}
-    M._fulfilledDraftTargets = {}
-    currentLockKey = 0
-    pendingSeeded = true
+    ResetNewWishlistDraft()
     frame:Show()
     M.Refresh()
 end

--- a/ui/WishlistEditor.lua
+++ b/ui/WishlistEditor.lua
@@ -1442,6 +1442,11 @@ local function LoadEditorForLoadout(slot)
     currentLockKey = 0
     pendingSeeded = true
     if wishlistNameBox then wishlistNameBox:SetText("") end
+    -- M.Show delegates here whenever a real Saved Build is active. An
+    -- unassociated build is a valid new-wishlist destination, so this branch
+    -- must show the editor just like OpenForWishlist does for linked builds.
+    -- Without this, the Panel remains menu-suppressed while no editor appears.
+    frame:Show()
     M.Refresh()
 end
 


### PR DESCRIPTION
## Summary

- revalidate the named Sync channel immediately before queued delivery
- use bounded FIFO queues with explicit backpressure and retry retention
- tighten transfer-envelope invariants and record peers only after accepted protocol handling
- add deterministic internal transport and bounded-state regression coverage
- show the Wishlist Editor when an active Saved Build has no wishlist association
- cover the unassociated-loadout editor path with a regression test

## Why

Sync previously trusted a cached numeric channel slot and used array length on partially drained queues. Channel renumbering could misroute queued traffic, while sustained work had no explicit queue policy. Peer state was also recorded before the message-specific acceptance path completed.

The Wishlist hotfix addresses a separate user-visible control-flow bug in 1.19.4. Opening Wishlists first suppresses the Nexus HUD. For an active Saved Build without an association, the editor initialized a new-wishlist draft and refreshed it but never showed its frame. The HUD therefore remained suppressed, and subsequent attempts to reopen it flashed closed on the next render.

## Impact

Queued traffic now follows `wrbuildssync` by name, waits safely through reconnect failures, preserves older queued packets when capacity is reached, and keeps incomplete work within explicit limits. Supported legacy/current wire behavior remains covered.

Players with an unassociated active Saved Build now get the persistent Create New Wishlist editor instead of losing both the editor and the Nexus HUD. No release-note, changelog, or version bump is included.

## Validation

- Lua 5.1 parse: all production and test sources passed
- all `tests/run_*.lua`: 74 passed, 0 failed
- focused Sync/DPS/compatibility programs: 27 passed, 0 failed
- focused Wishlist/Panel/editor/full-boot programs: 8 passed, 0 failed
- `git diff --check`: clean