### PR TITLE
Prepare Better Nexus 1.19.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Nexus 1.19.5
+
+- Fixed the Wishlist button for active Saved Builds without an association; it now opens a persistent Create New Wishlist editor instead of hiding the Nexus menu.
+- Reset all draft selections and locked-slot designs when opening an unassociated build, preventing stale editor state from carrying into the new wishlist.
+- Made queued Sync traffic follow the named channel across reconnects and channel renumbering, with explicit queue limits and retained retries under backpressure.
+- Hardened build, loadout, deletion, and DPS synchronization against malformed or spoofed traffic while preserving supported legacy/current peers.
+- Prevented incomplete loadout, bucket, DPS, and deletion responses from being claimed or discarded before their payloads are safely queued.
+
 # Nexus 1.19.4
 
 - Forward-ported the proven queue-aware Echo policy, exact-quality targets, final-search handling, refusal recovery, equal-progress wishlist rotation, and truthful horizon/final diagnostics while preserving the current UI architecture.

--- a/Nexus.toc
+++ b/Nexus.toc
@@ -2,7 +2,7 @@
 ## Title: Nexus
 ## Notes: Nexus — Echo build automation, community builds, DPS leaderboards, and auto-snapshot convergence.
 ## Author: Boganic
-## Version: 1.19.4
+## Version: 1.19.5
 ## OptionalDeps: ProjectEbonhold
 ## SavedVariables: NexusDB WishlistRealizerDB
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ compatibility with existing installations and user data.
 ## Project status
 
 - Repository visibility: private during development.
-- Current release: Nexus 1.19.4.
+- Current release: Nexus 1.19.5.
 - Client target: World of Warcraft 3.3.5a / Project Ebonhold.
 - Language target: Lua 5.1.
 - Upstream author attribution is preserved in `Nexus.toc` and

--- a/ui/Changelog.lua
+++ b/ui/Changelog.lua
@@ -4,8 +4,8 @@ Nexus = Nexus or {}
 local M = {}
 Nexus.Changelog = M
 
-local VERSION = "1.19.4"
-local RELEASE_KEY = "1.19.4"
+local VERSION = "1.19.5"
+local RELEASE_KEY = "1.19.5"
 local frame
 local shownThisSession = false
 
@@ -43,22 +43,22 @@ local function Create()
 
     local title = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
     title:SetPoint("TOP", 0, -20)
-    title:SetText("Nexus 1.19.4")
+    title:SetText("Nexus 1.19.5")
 
     local body = frame:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
     body:SetPoint("TOPLEFT", 28, -52)
     body:SetPoint("RIGHT", -28, 0)
     body:SetJustifyH("LEFT")
     body:SetJustifyV("TOP")
-    body:SetText([[|cffffd200Progress accuracy|r
+    body:SetText([[|cffffd200Wishlist editor|r
 
-• Wishlist progress is now counted per exact Echo/quality everywhere. A forced Uncommon copy no longer counts as one of the Rare copies your wishlist asked for.
-• Fixes STILL NEEDED and save messages contradicting each other on the same run.
+- Wishlist now opens reliably for active Saved Builds that do not yet have an associated wishlist.
+- The Create New Wishlist editor starts clean and automatically targets the active Saved Build.
 
-|cffffd200Wrong-quality cleanup|r
+|cffffd200Sync reliability|r
 
-• Clearing a wrong-quality copy now counts as cleanup instead of scoring nothing.
-• Save messages now say how many wrong-quality copies were cleared, so a family's count dropping is explained.]])
+- Community builds, loadouts, deletions, and DPS records now survive full queues, reconnects, and delayed retries without losing pending work.
+- Stricter ownership and packet validation reject malformed or spoofed sync traffic.]])
 
     local close = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
     close:SetSize(92, 24)


### PR DESCRIPTION
## Summary

- bump the addon, repository, and in-game changelog version to 1.19.5
- document the merged Wishlist Editor fix for unassociated active Saved Builds
- document the merged Sync transport, validation, backpressure, and retry hardening
- refresh the one-time in-game release popup with concise player-facing notes

## Why

Better Nexus 1.19.4 was tagged before PR #2 merged. The current `main` branch now contains the Wishlist Editor hotfix and Sync hardening, so it needs a distinct 1.19.5 release rather than replacing the existing 1.19.4 tag and asset.

## Player impact

Wishlist now opens a persistent Create New Wishlist editor when the active Saved Build has no association. Community builds, loadouts, deletions, and DPS records also retain pending work more safely across queue pressure, reconnects, and delayed retries while malformed or spoofed traffic is rejected.

## Validation

- Lua 5.1 parse: 100 passed, 0 failed
- all `tests/run_*.lua`: 74 passed, 0 failed
- focused release UI, Wishlist Editor, Sync transport, tombstone relay, and security suites passed
- installable archive audit: 26 expected files, no development artifacts
- packaged Lua parse: 25 passed, 0 failed
- packaged Lua matched validated source byte-for-byte
- `git diff --check`: clean
- prepared ZIP SHA-256: `FF2C32A82C4FFA89A0795F2546E5B95931D367D19BCD0FC9C2FCE5358D2C8485`

## Release handoff

After this PR is merged, publish `v1.19.5` from `main` and upload `Better-Nexus-1.19.5.zip`.
