### PR TITLE
Add structured Test 18 issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,18 +1,18 @@
 name: Bug Report
-description: Report a reproducible Nexus Test 18 bug that is not primarily performance or multiplayer Sync related.
+description: Report a reproducible Better Nexus public prerelease bug that is not primarily performance or multiplayer Sync related.
 title: "[Bug]: "
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for testing Nexus Test 18. Back up your Nexus SavedVariables before testing and search existing issues before submitting a new report.
+        Thanks for testing a Better Nexus public prerelease. Back up your Nexus SavedVariables before testing and search existing issues before submitting a new report.
 
   - type: input
     id: nexus-build
     attributes:
       label: Exact Nexus build
       description: Copy the exact build shown by `/nexus status` or the release filename. Do not enter only "latest."
-      placeholder: "Example: test.18-d9b48c5 / v1.20.0-beta.1-test.18"
+      placeholder: "Example: test.18-d9b48c5"
     validations:
       required: true
 
@@ -29,7 +29,7 @@ body:
     id: database-upgrade
     attributes:
       label: Existing or older Nexus database
-      description: Did this Test 18 installation upgrade Nexus SavedVariables that already contained data?
+      description: Did this prerelease installation upgrade Nexus SavedVariables that already contained data?
       options:
         - Yes - upgraded an existing or older Nexus database
         - No - tested with a new or empty Nexus database
@@ -97,7 +97,7 @@ body:
     attributes:
       label: Reporting acknowledgements
       options:
-        - label: I understand that Test 18 is an unfinished prerelease build.
+        - label: I understand that I am testing an unfinished Better Nexus prerelease.
           required: true
         - label: I searched existing issues and did not find a duplicate report.
           required: true

--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,0 +1,107 @@
+name: Bug Report
+description: Report a reproducible Nexus Test 18 bug that is not primarily performance or multiplayer Sync related.
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for testing Nexus Test 18. Back up your Nexus SavedVariables before testing and search existing issues before submitting a new report.
+
+  - type: input
+    id: nexus-build
+    attributes:
+      label: Exact Nexus build
+      description: Copy the exact build shown by `/nexus status` or the release filename. Do not enter only "latest."
+      placeholder: "Example: test.18-d9b48c5 / v1.20.0-beta.1-test.18"
+    validations:
+      required: true
+
+  - type: input
+    id: character-context
+    attributes:
+      label: Class and character context
+      description: Include the class and any relevant character, level, loadout, or realm context. Do not include private account information.
+      placeholder: "Example: Death Knight, level 80, existing character with several saved loadouts"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: database-upgrade
+    attributes:
+      label: Existing or older Nexus database
+      description: Did this Test 18 installation upgrade Nexus SavedVariables that already contained data?
+      options:
+        - Yes - upgraded an existing or older Nexus database
+        - No - tested with a new or empty Nexus database
+        - Unsure
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: List the smallest repeatable sequence that triggers the problem, including commands, UI actions, reloads, relogs, or zoning.
+      placeholder: |
+        1. Open ...
+        2. Select ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: Describe what you expected Nexus to do.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      description: Describe exactly what happened instead, including whether it recurs after `/reload`.
+    validations:
+      required: true
+
+  - type: textarea
+    id: lua-errors
+    attributes:
+      label: Lua errors
+      description: Paste the complete Lua error and stack trace. If no Lua error appeared, enter "None observed."
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots-diagnostics
+    attributes:
+      label: Screenshots and diagnostics
+      description: Drag in relevant screenshots and paste useful Nexus diagnostics such as `/nexus status` or `/nexus log`. If evidence is unavailable, explain why.
+      placeholder: Attach screenshots or paste diagnostics here.
+    validations:
+      required: true
+
+  - type: textarea
+    id: relevant-addons
+    attributes:
+      label: Other relevant addons
+      description: List addons that affect the same UI, data, automation, or gameplay path. Enter "None" if no other addon appears relevant.
+      placeholder: "Example: Details!, StutterAlert, or None"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Reporting acknowledgements
+      options:
+        - label: I understand that Test 18 is an unfinished prerelease build.
+          required: true
+        - label: I searched existing issues and did not find a duplicate report.
+          required: true
+        - label: I included the exact Nexus build rather than only saying "latest."
+          required: true
+        - label: I included enough reproduction information for someone else to investigate the problem.
+          required: true

--- a/.github/ISSUE_TEMPLATE/02-performance-stutter-report.yml
+++ b/.github/ISSUE_TEMPLATE/02-performance-stutter-report.yml
@@ -1,5 +1,5 @@
 name: Performance / Stutter Report
-description: Report Nexus Test 18 frame cost, hitches, stuttering, or long-session performance with required diagnostics.
+description: Report Better Nexus public prerelease frame cost, hitches, stuttering, or long-session performance with required diagnostics.
 title: "[Performance]: "
 body:
   - type: markdown
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Exact Nexus build
       description: Copy the exact build shown by `/nexus status` or the release filename. Do not enter only "latest."
-      placeholder: "Example: test.18-d9b48c5 / v1.20.0-beta.1-test.18"
+      placeholder: "Example: test.18-d9b48c5"
     validations:
       required: true
 
@@ -116,7 +116,7 @@ body:
     attributes:
       label: Reporting acknowledgements
       options:
-        - label: I understand that Test 18 is an unfinished prerelease build.
+        - label: I understand that I am testing an unfinished Better Nexus prerelease.
           required: true
         - label: I searched existing issues and did not find a duplicate report.
           required: true

--- a/.github/ISSUE_TEMPLATE/02-performance-stutter-report.yml
+++ b/.github/ISSUE_TEMPLATE/02-performance-stutter-report.yml
@@ -1,0 +1,124 @@
+name: Performance / Stutter Report
+description: Report Nexus Test 18 frame cost, hitches, stuttering, or long-session performance with required diagnostics.
+title: "[Performance]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Performance reports require StutterAlert evidence and `/nexus perf` output. Capture both near the reported event before submitting this form.
+
+  - type: input
+    id: nexus-build
+    attributes:
+      label: Exact Nexus build
+      description: Copy the exact build shown by `/nexus status` or the release filename. Do not enter only "latest."
+      placeholder: "Example: test.18-d9b48c5 / v1.20.0-beta.1-test.18"
+    validations:
+      required: true
+
+  - type: input
+    id: activity-location
+    attributes:
+      label: Activity and location
+      description: State what you were doing and where the hitch or sustained cost occurred.
+      placeholder: "Example: two-player Sync while standing in Dalaran"
+    validations:
+      required: true
+
+  - type: input
+    id: session-duration
+    attributes:
+      label: Session duration
+      description: How long had the client been running when the problem occurred?
+      placeholder: "Example: 2 hours 35 minutes"
+    validations:
+      required: true
+
+  - type: textarea
+    id: stutteralert-output
+    attributes:
+      label: StutterAlert output
+      description: Paste the relevant StutterAlert trace and `/sa report` output, including the event time and attribution.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: nexus-perf-output
+    attributes:
+      label: /nexus perf output
+      description: Paste the complete `/nexus perf` output captured near the reported event.
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: nexus-ms-frame
+    attributes:
+      label: Nexus ms/frame
+      description: Enter the Nexus steady frame cost reported by your diagnostics.
+      placeholder: "Example: 0.80 ms/frame"
+    validations:
+      required: true
+
+  - type: input
+    id: all-addon-ms-frame
+    attributes:
+      label: All-addon ms/frame
+      description: Enter the combined addon steady frame cost reported by your diagnostics.
+      placeholder: "Example: 1.75 ms/frame"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: hitch-attribution
+    attributes:
+      label: Hitch attribution
+      description: Choose the attribution shown by StutterAlert for the reported event.
+      options:
+        - Nexus or addon-attributed
+        - Game-side attributed
+        - Mixed or unclear
+    validations:
+      required: true
+
+  - type: textarea
+    id: other-major-addons
+    attributes:
+      label: Other major addons
+      description: List other enabled addons with meaningful frame cost or overlapping behavior. Enter "None" if there are none.
+      placeholder: "Example: Details!, WeakAuras, or None"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction-details
+    attributes:
+      label: Reproduction details
+      description: Explain the exact action sequence, frequency, and whether `/reload`, relogging, zoning, or disabling Nexus changes the result.
+      placeholder: |
+        1. Start StutterAlert capture ...
+        2. Perform ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed-impact
+    attributes:
+      label: Observed impact
+      description: Describe the visible hitch, stutter pattern, or sustained performance change and its frequency.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Reporting acknowledgements
+      options:
+        - label: I understand that Test 18 is an unfinished prerelease build.
+          required: true
+        - label: I searched existing issues and did not find a duplicate report.
+          required: true
+        - label: I captured both StutterAlert evidence and `/nexus perf` output for this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/03-sync-multiplayer-report.yml
+++ b/.github/ISSUE_TEMPLATE/03-sync-multiplayer-report.yml
@@ -1,0 +1,124 @@
+name: Sync / Multiplayer Report
+description: Report a two-player Nexus Test 18 synchronization, recovery, or convergence problem with evidence from both clients.
+title: "[Sync]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Sync reports are most useful when both players run the same exact build and provide Peer Test / Sync diagnostics from both clients.
+
+  - type: input
+    id: player-a-build
+    attributes:
+      label: Player A exact Nexus build
+      description: Copy Player A's exact build from `/nexus status`. Do not enter only "latest."
+      placeholder: "Example: test.18-d9b48c5 / v1.20.0-beta.1-test.18"
+    validations:
+      required: true
+
+  - type: input
+    id: player-b-build
+    attributes:
+      label: Player B exact Nexus build
+      description: Copy Player B's exact build from `/nexus status`. If unavailable, state why and provide every known version detail.
+      placeholder: "Example: test.18-d9b48c5 / v1.20.0-beta.1-test.18"
+    validations:
+      required: true
+
+  - type: textarea
+    id: player-a-steps
+    attributes:
+      label: Player A steps
+      description: Describe Player A's actions in order, including requests, shares, UI actions, reloads, relogs, zoning, and timing.
+      placeholder: |
+        1. Player A ...
+        2. Player A ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: player-b-steps
+    attributes:
+      label: Player B steps
+      description: Describe Player B's actions in order and how they corresponded to Player A's actions.
+      placeholder: |
+        1. Player B ...
+        2. Player B ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: failed-to-sync
+    attributes:
+      label: What failed to synchronize
+      description: Identify the exact build, loadout, deletion, DPS record, request, status count, or recovery state that did not converge.
+    validations:
+      required: true
+
+  - type: textarea
+    id: peer-sync-diagnostics
+    attributes:
+      label: Peer Test / Sync diagnostics from both players
+      description: Paste the complete Peer Test and Sync diagnostics from Player A and Player B. If one side is unavailable, explain why and identify which side is missing.
+      placeholder: |
+        Player A:
+        ...
+
+        Player B:
+        ...
+      render: shell
+    validations:
+      required: true
+
+  - type: dropdown
+    id: transition-context
+    attributes:
+      label: Reload, zoning, or Sync Now context
+      description: Select every transition or manual action involved. Choose "None of these" only when none occurred.
+      multiple: true
+      options:
+        - /reload
+        - Zoning or loading screen
+        - Sync Now
+        - Relog or reconnect
+        - None of these
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: Describe the state both players should have reached.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      description: Describe each player's final state, including counts, visible rows, errors, or repeated no-progress results.
+    validations:
+      required: true
+
+  - type: textarea
+    id: relevant-addons
+    attributes:
+      label: Other relevant addons
+      description: List addons enabled on either client that affect networking, builds, loadouts, UI, or diagnostics. Enter "None" if none appear relevant.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Reporting acknowledgements
+      options:
+        - label: I understand that Test 18 is an unfinished prerelease build.
+          required: true
+        - label: I searched existing issues and did not find a duplicate report.
+          required: true
+        - label: I provided exact build information for both clients or explained why one side is unavailable.
+          required: true
+        - label: I included Peer Test / Sync diagnostics from both players where possible.
+          required: true

--- a/.github/ISSUE_TEMPLATE/03-sync-multiplayer-report.yml
+++ b/.github/ISSUE_TEMPLATE/03-sync-multiplayer-report.yml
@@ -1,5 +1,5 @@
 name: Sync / Multiplayer Report
-description: Report a two-player Nexus Test 18 synchronization, recovery, or convergence problem with evidence from both clients.
+description: Report a two-player Better Nexus public prerelease synchronization, recovery, or convergence problem with evidence from both clients.
 title: "[Sync]: "
 body:
   - type: markdown
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Player A exact Nexus build
       description: Copy Player A's exact build from `/nexus status`. Do not enter only "latest."
-      placeholder: "Example: test.18-d9b48c5 / v1.20.0-beta.1-test.18"
+      placeholder: "Example: test.18-d9b48c5"
     validations:
       required: true
 
@@ -21,7 +21,7 @@ body:
     attributes:
       label: Player B exact Nexus build
       description: Copy Player B's exact build from `/nexus status`. If unavailable, state why and provide every known version detail.
-      placeholder: "Example: test.18-d9b48c5 / v1.20.0-beta.1-test.18"
+      placeholder: "Example: test.18-d9b48c5"
     validations:
       required: true
 
@@ -114,7 +114,7 @@ body:
     attributes:
       label: Reporting acknowledgements
       options:
-        - label: I understand that Test 18 is an unfinished prerelease build.
+        - label: I understand that I am testing an unfinished Better Nexus prerelease.
           required: true
         - label: I searched existing issues and did not find a duplicate report.
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,6 @@ contact_links:
   - name: Check existing reports first
     url: https://github.com/Viscerals/Better-Nexus/issues?q=is%3Aissue
     about: Search for an existing Bug, Performance, or Sync report before opening a duplicate.
-  - name: Test 18 download and notes
-    url: https://github.com/Viscerals/Better-Nexus/releases/tag/v1.20.0-beta.1-test.18
-    about: Confirm that you are testing the current public Test 18 prerelease.
+  - name: Public prereleases and release notes
+    url: https://github.com/Viscerals/Better-Nexus/releases
+    about: Check the available Better Nexus prereleases and confirm the exact build you are testing.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Check existing reports first
+    url: https://github.com/Viscerals/Better-Nexus/issues?q=is%3Aissue
+    about: Search for an existing Bug, Performance, or Sync report before opening a duplicate.
+  - name: Test 18 download and notes
+    url: https://github.com/Viscerals/Better-Nexus/releases/tag/v1.20.0-beta.1-test.18
+    about: Confirm that you are testing the current public Test 18 prerelease.


### PR DESCRIPTION
## Summary

- Disable blank contributor issues and add chooser links for existing reports and Test 18 notes.
- Add a structured Bug Report form with exact build, character/database context, reproduction, expected/actual behavior, Lua errors, diagnostics, relevant addons, and required acknowledgements.
- Add a structured Performance / Stutter Report requiring StutterAlert and `/nexus perf` evidence, frame-cost metrics, attribution, addon context, and reproduction details.
- Add a structured Sync / Multiplayer Report requiring both client builds, Player A/B steps, failed state, two-sided diagnostics where possible, transition context, and expected/actual behavior.
- Do not add a Feature Request form.

## Why

Public Test 18 reports need consistent reproduction and diagnostic evidence so bugs, performance reports, and two-player Sync failures can be triaged without repeated follow-up.

## Validation

- Parsed all four YAML files with PyYAML 6.0.2.
- Passed local GitHub Issue Form structure checks: exactly three forms, supported field types, valid unique IDs, required requested fields, required acknowledgements, and `blank_issues_enabled: false`.
- Confirmed no tab indentation and passed `git diff --cached --check` before commit.

## Isolation

- Based directly on current `main` at `d36a09f06be198dfb76cd1cc82bf437444f60cb2`.
- Contains one commit and only `.github/ISSUE_TEMPLATE/**` files.
- Does not modify Lua/runtime files or PR #10.