### PR TITLE
Update public testing status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Better Nexus
 
-Better Nexus is a private, community-maintained continuation of the deprecated
+Better Nexus is a public, community-maintained continuation of the deprecated
 Nexus addon for Project Ebonhold.
 
 The repository begins from the installed Nexus 1.19.3 player build. The in-game
@@ -9,8 +9,10 @@ compatibility with existing installations and user data.
 
 ## Project status
 
-- Repository visibility: private during development.
-- Current release: Nexus 1.19.5.
+- Stable production release: Nexus 1.19.5.
+- Experimental public prereleases are available through
+  [GitHub Releases](https://github.com/Viscerals/Better-Nexus/releases). These
+  builds are for testing and are not stable releases.
 - Client target: World of Warcraft 3.3.5a / Project Ebonhold.
 - Language target: Lua 5.1.
 - Upstream author attribution is preserved in `Nexus.toc` and
@@ -35,6 +37,17 @@ DPS records, and Snapshot convergence for Project Ebonhold.
 
 Do not rename the installed addon folder to `Better-Nexus`; the repository name
 is different from the runtime addon identity by design.
+
+Back up `NexusDB` and `WishlistRealizerDB` before testing a prerelease. Better
+Nexus preserves compatibility with these SavedVariables because existing user
+data must survive upgrades and rollback testing.
+
+## Reporting problems
+
+Use the [structured issue
+forms](https://github.com/Viscerals/Better-Nexus/issues/new/choose) to report a
+bug, performance or stutter problem, or multiplayer Sync problem. Include the
+exact prerelease build and the diagnostics requested by the selected form.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

- describe Better Nexus as a public, community-maintained continuation
- distinguish stable Nexus 1.19.5 from experimental public prereleases
- link GitHub Releases and the structured issue chooser
- reinforce the `Nexus` runtime folder and SavedVariables compatibility boundaries

## Scope

README-only repository housekeeping. This does not change product Lua, `Nexus.toc`, PR #10, Test 18, releases, tags, packaging, installation, or live state.

## Validation

- `git diff --check origin/main...HEAD`
- exact diff contains only `README.md`
- required durable status and links present
- no permanent Test 18 wording
- `CHANGELOG.md` unchanged