### PR TITLE
Align public policy and upstream provenance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Viscerals is the human authority for policy and release-critical files.
+* @Viscerals
+
+# Keep policy and release-controlled surfaces under the same human review.
+/.github/ @Viscerals
+/LICENSE.md @Viscerals
+/AI_POLICY.md @Viscerals
+/RELEASE_SECURITY.md @Viscerals
+/SECURITY.md @Viscerals
+/UPSTREAM.md @Viscerals
+/Nexus.toc @Viscerals
+/data/Release.lua @Viscerals
+/ui/Changelog.lua @Viscerals

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,62 @@
+# AI and Automated Systems Policy
+
+## Scope
+
+This policy defines acceptable AI-assisted development and release behavior for this repository.
+
+## Allowed AI-assisted activities
+
+AI systems and automated assistants may be used by authorized contributors and maintainers for:
+
+- source-code analysis and refactoring;
+- code generation and drafting;
+- debugging and test generation;
+- review and quality checks;
+- documentation writing and updates;
+- translation and localization support;
+- issue/log analysis and release planning;
+- performance and security analysis;
+- project maintenance and repository hygiene.
+
+## Human responsibility
+
+AI-assisted tooling does not remove human accountability. For every change:
+
+- a contributor must understand the change and run required checks;
+- correctness, regression, and compatibility must be validated;
+- security and privacy impact must be reviewed;
+- license and attribution impact must be reviewed;
+- ownership and provenance obligations must be preserved;
+- the contributor remains responsible for final merge/release decisions.
+
+AI output is treated as draft input and must receive the same review and validation standards as a human draft. Prompts, chat logs, transcripts, chain-of-thought, scratch files, and private model output are not required repository artifacts.
+
+## Prohibited use
+
+The following are not allowed:
+
+- using AI to copy or transform proprietary/incompatible third-party code and present it as original Better-Nexus work;
+- laundering upstream, third-party, or confidential code through translation/refactoring to evade notices or legal constraints;
+- removing or obscuring provenance, copyright notices, or license requirements;
+- using AI output to bypass security, release, or branch controls;
+- implying ownership of transformed upstream/third-party work where ownership cannot be shown;
+- uploading credentials, private tokens, private player data, private SavedVariables, private logs, or confidential material to AI systems without explicit authorization;
+- committing prompts, chats, transcripts, chain-of-thought, scratch outputs, or private temporary data as source artifacts.
+
+Permission to use AI is not a separate copyright or redistribution license. It does not authorize copying, modifying, repackaging, sublicensing, selling, rebranding, unauthorized redistribution, or model training/use.
+
+## Third-party and upstream respect
+
+Contributors must preserve known upstream provenance, notices, and license files, including:
+
+- Boganic attribution;
+- `UPSTREAM.md`;
+- other third-party notices and required license terms.
+
+AI-assisted changes derived from upstream/third-party material remain governed by the actual applicable rights.
+
+## Security and privacy
+
+AI tooling must never be used to disclose secrets, credentials, private player data, SavedVariables, exploitable details, or private vulnerability data.
+
+Do not use model output to bypass required reviews, policy checks, or release approvals.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,40 @@
+# Better Nexus Source-Available License
+
+## Copyright and scope
+
+Copyright (c) 2026 Viscerals for original Better Nexus contributions whose rights are owned by Viscerals or another identifiable Better Nexus contributor.
+
+This license applies only to material for which the project rightsholder can grant rights. It does not relicense or claim ownership of:
+
+- upstream Nexus material attributed to Boganic;
+- upstream dependencies and third-party libraries with their own terms;
+- World of Warcraft, Project Ebonhold, or their trademarks, data, and marks.
+
+See `UPSTREAM.md` for the known provenance boundaries and unresolved licensing status.
+
+## Limited permitted use
+
+Subject to all third-party terms:
+
+1. A player may download and use an official Better Nexus release published on the project release channel;
+2. A player may make reasonable personal backups;
+3. A player may install and run an unmodified official release for personal, non-commercial gameplay on Project Ebonhold.
+
+This limited permission does not grant source redistribution or modification rights.
+
+## Reserved rights
+
+Unless another right applies and is granted by the relevant rightsholder:
+
+- copy, modify, adapt, translate, reverse engineer, distribute, sublicense, sell, rent, or commercially exploit any Better Nexus material;
+- create or publish derivative works, forks, or competing releases built from Better Nexus materials;
+- remove, hide, alter, or misrepresent provenance, copyright, or licensing notices;
+- claim rights that are not actually held by the contributor.
+
+## AI and data-mining
+
+AI-assisted development is permitted for authorized project work under `AI_POLICY.md`. AI assistance does not create new ownership rights, does not override attribution or license obligations, and does not authorize ML training or model reuse without separate legal rights.
+
+## Disclaimers
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, THIS SOFTWARE IS PROVIDED "AS IS" WITH NO WARRANTIES OR CONDITIONS OF ANY KIND.

--- a/RELEASE_SECURITY.md
+++ b/RELEASE_SECURITY.md
@@ -1,0 +1,42 @@
+# Release Security
+
+## Core principles
+
+Release authority remains a human and repository control function; AI assistance does not replace review, merge, or branch protections.
+
+## Required local controls
+
+Checked-in policy files should be validated together with GitHub branch protections and review controls:
+
+- `.github/CODEOWNERS` for policy/release-critical ownership;
+- `tools/Test-ReleasePolicy.ps1` for archive and source policy checks;
+- branch and PR review rules configured in GitHub settings.
+
+## Required release archive contents
+
+Release archives must include, in the top-level `Nexus` folder:
+
+- `Nexus.toc`
+- `LICENSE.md`
+- `AI_POLICY.md`
+- `UPSTREAM.md`
+
+`RELEASE_SECURITY.md`, `SECURITY.md`, and `README.md` are required in source but are not substitutes for the three mandatory archive files.
+
+## Offline checks
+
+Before release:
+
+1. verify the source commit is reviewed and clean;
+2. run `tools/Test-ReleasePolicy.ps1 -Archive <artifact>`;
+3. record commit, artifact SHA-256, and validation outcome in release notes.
+
+## Incident response
+
+On suspected takeover, unauthorized release, or credential compromise:
+
+- stop publish actions;
+- preserve evidence and logs;
+- rotate affected credentials;
+- remove compromised collaborators/apps;
+- notify the maintainer via the private security path and recover safely.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting
+
+Report suspected vulnerabilities, compromises, or release integrity issues privately through the Better Nexus security reporting path.
+
+Do not publish credentials, access tokens, private data, exploit detail, private SavedVariables, or active incident details in public channels.
+
+## Required report content
+
+Include:
+
+- affected version/tag;
+- observed time and timezone;
+- affected URL(s);
+- archive checksums when available;
+- concise reproducible context.
+
+## Contact
+
+If private reporting is unavailable, use the repository maintainer’s verified contact path.
+
+See `RELEASE_SECURITY.md` for incident and release controls.

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -4,15 +4,10 @@ Better Nexus begins from a locally installed Nexus 1.19.3 snapshot.
 
 - Upstream addon name: Nexus
 - Upstream author recorded by the addon: Boganic
-- Historical repository referenced by the earlier source documentation:
-  `Solkex/Nexus`
+- Current TOC maintainer metadata: Valentine
+- Historical repository referenced by the earlier source documentation: `Solkex/Nexus`
 - Imported base version: 1.19.3
 
-The upstream project was reported as deprecated, so this repository provides a
-private development home for maintenance and compatibility fixes. Runtime
-identifiers and author attribution are intentionally preserved.
+The initial snapshot did not include an upstream license file. Better-Nexus preserves upstream provenance and attribution records but does not claim rights to upstream materials beyond what the upstream rightsholders can grant.
 
-No license file accompanied either local source snapshot inspected during the
-initial import. Keep this repository private and clarify the upstream
-redistribution and licensing terms before making source or binary releases
-public.
+Any redistribution or derivative use of upstream materials requires rights compatible with the relevant upstream or third-party terms.


### PR DESCRIPTION
## Summary

- replace stale private-repository language in `UPSTREAM.md` with the already-reviewed public provenance boundary from PR #10
- add the already-reviewed source-available license, security, release-security, AI-use, and CODEOWNERS policy files from PR #10
- preserve upstream attribution and avoid granting rights the project does not own

## Scope

Policy, legal/provenance, and ownership files only. This does not modify product Lua, runtime tests, `Nexus.toc`, SavedVariables, PR #10, Test 18, tags, releases, packages, installation, or live state.

## Validation

- exact normalized content match against the corresponding reviewed files at PR #10 head `d9b48c5d1cbc0dd4a1d2ffa60e737cc0e27cd16f`
- `git diff --check`
- focused required-text checks for all six files
- reviewed `tools/Test-ReleasePolicy.ps1` at exact PR #10 head: passed
- exact changed-path allowlist: six policy/provenance files