### PR TITLE
Add contributor and support guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+Describe the problem and the smallest coherent change.
+
+## Scope
+
+List the behavior and exact paths in scope. Note anything intentionally excluded.
+
+## Validation
+
+List focused checks and their exact outcomes. Do not count skipped, unavailable, or failing checks as passing.
+
+## Risk
+
+Describe compatibility, migration, SavedVariables, performance, security, provenance, and rollback risk as applicable.
+
+## Native testing
+
+State whether the exact proposed head was tested in WoW 3.3.5a / Project Ebonhold. If not, state the remaining live-unproven boundary.
+
+## Confirmation
+
+- [ ] The PR contains no unrelated changes.
+- [ ] Lua changes remain compatible with Lua 5.1.
+- [ ] `NexusDB` and `WishlistRealizerDB` compatibility is preserved or the migration is explained and tested.
+- [ ] No packages, SavedVariables, private logs, AI transcripts, or transient artifacts are included.
+- [ ] Published or exact-SHA-reviewed history was not rewritten.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to Better Nexus
+
+Better Nexus is in public prerelease stabilization. Keep contributions focused, evidence-based, and compatible with the existing addon and player data.
+
+## Compatibility
+
+- Target Lua 5.1.
+- Target World of Warcraft 3.3.5a on Project Ebonhold.
+- Preserve the runtime addon name and folder name `Nexus`.
+- Preserve `NexusDB` and `WishlistRealizerDB`, including migration behavior, unknown fields, and rollback safety.
+
+## Before opening a pull request
+
+1. Start from the current `main` branch.
+2. Keep the change narrowly scoped. Separate unrelated product, policy, and infrastructure work.
+3. Run the relevant focused and repository validation checks.
+4. Record what was tested offline and what was tested in the native game client. Do not claim live behavior from offline checks.
+5. Review the final diff for unrelated files, generated output, secrets, private data, and provenance concerns.
+
+Do not include:
+
+- AI chat transcripts, prompts, scratch notes, or transient automation artifacts;
+- release packages or locally built archives;
+- SavedVariables, account or character data, private diagnostics, or logs;
+- editor, backup, cache, or temporary files.
+
+Do not force-push, rebase, or otherwise rewrite a head that is already under exact-SHA review or native testing. Open a successor commit or coordinate with the maintainer when reviewed history must be preserved.
+
+## Reports and requests
+
+- Use the repository's GitHub Issue Forms for bugs, performance or stutter reports, and Sync or multiplayer reports.
+- Feature requests are deferred while public prerelease stabilization is active.
+- Report vulnerabilities through [private vulnerability reporting](https://github.com/Viscerals/Better-Nexus/security/advisories/new), not a public issue.
+
+## Pull-request evidence
+
+Every pull request should state:
+
+- the problem and proposed change;
+- the exact paths and behavior in scope;
+- focused validation results;
+- regression and migration risks;
+- native testing status and any unproven boundary;
+- confirmation that unrelated changes are excluded.
+
+Maintainers may ask for a smaller PR or additional evidence when review, provenance, compatibility, or player-data safety is unclear.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,12 @@
+# Better Nexus support
+
+Use the route that matches the problem so the report requests the right evidence.
+
+- **Bug:** [Bug Report](https://github.com/Viscerals/Better-Nexus/issues/new?template=01-bug-report.yml)
+- **Performance or stutter:** [Performance / Stutter Report](https://github.com/Viscerals/Better-Nexus/issues/new?template=02-performance-stutter-report.yml)
+- **Sync or multiplayer:** [Sync / Multiplayer Report](https://github.com/Viscerals/Better-Nexus/issues/new?template=03-sync-multiplayer-report.yml)
+- **Security:** [Report a vulnerability privately](https://github.com/Viscerals/Better-Nexus/security/advisories/new). Do not disclose vulnerability details in a public issue.
+
+Feature requests are deferred while public prerelease stabilization is active. Existing feature discussions may remain open, but new feature work is not currently the support priority.
+
+Before submitting a report, search existing issues, confirm the exact Better Nexus build, preserve SavedVariables, and capture the diagnostics requested by the selected form.


### PR DESCRIPTION
## Summary

- add concise contribution guidance for Lua 5.1, WoW 3.3.5a / Project Ebonhold, SavedVariables safety, focused PRs, and exact validation evidence
- add a pull-request template covering summary, scope, validation, risk, native testing, and unrelated-change confirmation
- add support routing for Bug, Performance, Sync, and private vulnerability reports while deferring feature requests during prerelease stabilization

## Scope

Community and contributor documentation only. This does not modify product Lua, runtime tests, `Nexus.toc`, SavedVariables, PR #10, Test 18, tags, releases, packages, installation, or live state.

## Validation

- exact changed-path allowlist: `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `SUPPORT.md`
- required compatibility, data-safety, report-routing, and evidence language present
- no Vibe/AGENTS/internal workflow instructions copied into public docs
- `git diff --check`: passed