### PR TITLE
Apply prerelease labels to Issue Forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,6 +1,9 @@
 name: Bug Report
 description: Report a reproducible Better Nexus public prerelease bug that is not primarily performance or multiplayer Sync related.
 title: "[Bug]: "
+labels:
+  - bug
+  - prerelease
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/02-performance-stutter-report.yml
+++ b/.github/ISSUE_TEMPLATE/02-performance-stutter-report.yml
@@ -1,6 +1,9 @@
 name: Performance / Stutter Report
 description: Report Better Nexus public prerelease frame cost, hitches, stuttering, or long-session performance with required diagnostics.
 title: "[Performance]: "
+labels:
+  - performance
+  - prerelease
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/03-sync-multiplayer-report.yml
+++ b/.github/ISSUE_TEMPLATE/03-sync-multiplayer-report.yml
@@ -1,6 +1,9 @@
 name: Sync / Multiplayer Report
 description: Report a two-player Better Nexus public prerelease synchronization, recovery, or convergence problem with evidence from both clients.
 title: "[Sync]: "
+labels:
+  - sync
+  - prerelease
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary

- apply `bug` and `prerelease` to Bug Reports
- apply `performance` and `prerelease` to Performance / Stutter Reports
- apply `sync` and `prerelease` to Sync / Multiplayer Reports
- keep `needs-diagnostics` manual for reports that still lack evidence

## Scope

Nine configuration lines across the three existing Issue Forms only. `blank_issues_enabled: false` is unchanged. This does not modify product Lua, runtime tests, `Nexus.toc`, SavedVariables, PR #10, Test 18, tags, releases, packages, installation, or live state.

## Validation

- PyYAML 6.0.2 parsed all four files under `.github/ISSUE_TEMPLATE`
- exactly three supported forms, valid body types, unique field IDs, expected labels, and no tab indentation
- `blank_issues_enabled: false` verified
- `git diff --check`: passed