### PR TITLE
Fix realm-aware leaderboard duplicates and sync hitches

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Viscerals is the human authority for policy and release-critical files.
+* @Viscerals
+
+# Keep policy and release-controlled surfaces under the same human review.
+/.github/ @Viscerals
+/LICENSE.md @Viscerals
+/AI_POLICY.md @Viscerals
+/RELEASE_SECURITY.md @Viscerals
+/SECURITY.md @Viscerals
+/UPSTREAM.md @Viscerals
+/Nexus.toc @Viscerals
+/data/Release.lua @Viscerals
+/ui/Changelog.lua @Viscerals

--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,6 +1,9 @@
 name: Bug Report
 description: Report a reproducible Better Nexus public prerelease bug that is not primarily performance or multiplayer Sync related.
 title: "[Bug]: "
+labels:
+  - bug
+  - prerelease
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,18 +1,18 @@
 name: Bug Report
-description: Report a reproducible Nexus Test 18 bug that is not primarily performance or multiplayer Sync related.
+description: Report a reproducible Better Nexus public prerelease bug that is not primarily performance or multiplayer Sync related.
 title: "[Bug]: "
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for testing Nexus Test 18. Back up your Nexus SavedVariables before testing and search existing issues before submitting a new report.
+        Thanks for testing a Better Nexus public prerelease. Back up your Nexus SavedVariables before testing and search existing issues before submitting a new report.
 
   - type: input
     id: nexus-build
     attributes:
       label: Exact Nexus build
       description: Copy the exact build shown by `/nexus status` or the release filename. Do not enter only "latest."
-      placeholder: "Example: test.18-d9b48c5 / v1.20.0-beta.1-test.18"
+      placeholder: "Example: test.18-d9b48c5"
     validations:
       required: true
 
@@ -29,7 +29,7 @@ body:
     id: database-upgrade
     attributes:
       label: Existing or older Nexus database
-      description: Did this Test 18 installation upgrade Nexus SavedVariables that already contained data?
+      description: Did this prerelease installation upgrade Nexus SavedVariables that already contained data?
       options:
         - Yes - upgraded an existing or older Nexus database
         - No - tested with a new or empty Nexus database
@@ -97,7 +97,7 @@ body:
     attributes:
       label: Reporting acknowledgements
       options:
-        - label: I understand that Test 18 is an unfinished prerelease build.
+        - label: I understand that I am testing an unfinished Better Nexus prerelease.
           required: true
         - label: I searched existing issues and did not find a duplicate report.
           required: true

--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,0 +1,107 @@
+name: Bug Report
+description: Report a reproducible Nexus Test 18 bug that is not primarily performance or multiplayer Sync related.
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for testing Nexus Test 18. Back up your Nexus SavedVariables before testing and search existing issues before submitting a new report.
+
+  - type: input
+    id: nexus-build
+    attributes:
+      label: Exact Nexus build
+      description: Copy the exact build shown by `/nexus status` or the release filename. Do not enter only "latest."
+      placeholder: "Example: test.18-d9b48c5 / v1.20.0-beta.1-test.18"
+    validations:
+      required: true
+
+  - type: input
+    id: character-context
+    attributes:
+      label: Class and character context
+      description: Include the class and any relevant character, level, loadout, or realm context. Do not include private account information.
+      placeholder: "Example: Death Knight, level 80, existing character with several saved loadouts"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: database-upgrade
+    attributes:
+      label: Existing or older Nexus database
+      description: Did this Test 18 installation upgrade Nexus SavedVariables that already contained data?
+      options:
+        - Yes - upgraded an existing or older Nexus database
+        - No - tested with a new or empty Nexus database
+        - Unsure
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: List the smallest repeatable sequence that triggers the problem, including commands, UI actions, reloads, relogs, or zoning.
+      placeholder: |
+        1. Open ...
+        2. Select ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: Describe what you expected Nexus to do.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      description: Describe exactly what happened instead, including whether it recurs after `/reload`.
+    validations:
+      required: true
+
+  - type: textarea
+    id: lua-errors
+    attributes:
+      label: Lua errors
+      description: Paste the complete Lua error and stack trace. If no Lua error appeared, enter "None observed."
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots-diagnostics
+    attributes:
+      label: Screenshots and diagnostics
+      description: Drag in relevant screenshots and paste useful Nexus diagnostics such as `/nexus status` or `/nexus log`. If evidence is unavailable, explain why.
+      placeholder: Attach screenshots or paste diagnostics here.
+    validations:
+      required: true
+
+  - type: textarea
+    id: relevant-addons
+    attributes:
+      label: Other relevant addons
+      description: List addons that affect the same UI, data, automation, or gameplay path. Enter "None" if no other addon appears relevant.
+      placeholder: "Example: Details!, StutterAlert, or None"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Reporting acknowledgements
+      options:
+        - label: I understand that Test 18 is an unfinished prerelease build.
+          required: true
+        - label: I searched existing issues and did not find a duplicate report.
+          required: true
+        - label: I included the exact Nexus build rather than only saying "latest."
+          required: true
+        - label: I included enough reproduction information for someone else to investigate the problem.
+          required: true

--- a/.github/ISSUE_TEMPLATE/02-performance-stutter-report.yml
+++ b/.github/ISSUE_TEMPLATE/02-performance-stutter-report.yml
@@ -1,6 +1,9 @@
 name: Performance / Stutter Report
 description: Report Better Nexus public prerelease frame cost, hitches, stuttering, or long-session performance with required diagnostics.
 title: "[Performance]: "
+labels:
+  - performance
+  - prerelease
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/02-performance-stutter-report.yml
+++ b/.github/ISSUE_TEMPLATE/02-performance-stutter-report.yml
@@ -1,5 +1,5 @@
 name: Performance / Stutter Report
-description: Report Nexus Test 18 frame cost, hitches, stuttering, or long-session performance with required diagnostics.
+description: Report Better Nexus public prerelease frame cost, hitches, stuttering, or long-session performance with required diagnostics.
 title: "[Performance]: "
 body:
   - type: markdown
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Exact Nexus build
       description: Copy the exact build shown by `/nexus status` or the release filename. Do not enter only "latest."
-      placeholder: "Example: test.18-d9b48c5 / v1.20.0-beta.1-test.18"
+      placeholder: "Example: test.18-d9b48c5"
     validations:
       required: true
 
@@ -116,7 +116,7 @@ body:
     attributes:
       label: Reporting acknowledgements
       options:
-        - label: I understand that Test 18 is an unfinished prerelease build.
+        - label: I understand that I am testing an unfinished Better Nexus prerelease.
           required: true
         - label: I searched existing issues and did not find a duplicate report.
           required: true

--- a/.github/ISSUE_TEMPLATE/02-performance-stutter-report.yml
+++ b/.github/ISSUE_TEMPLATE/02-performance-stutter-report.yml
@@ -1,0 +1,124 @@
+name: Performance / Stutter Report
+description: Report Nexus Test 18 frame cost, hitches, stuttering, or long-session performance with required diagnostics.
+title: "[Performance]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Performance reports require StutterAlert evidence and `/nexus perf` output. Capture both near the reported event before submitting this form.
+
+  - type: input
+    id: nexus-build
+    attributes:
+      label: Exact Nexus build
+      description: Copy the exact build shown by `/nexus status` or the release filename. Do not enter only "latest."
+      placeholder: "Example: test.18-d9b48c5 / v1.20.0-beta.1-test.18"
+    validations:
+      required: true
+
+  - type: input
+    id: activity-location
+    attributes:
+      label: Activity and location
+      description: State what you were doing and where the hitch or sustained cost occurred.
+      placeholder: "Example: two-player Sync while standing in Dalaran"
+    validations:
+      required: true
+
+  - type: input
+    id: session-duration
+    attributes:
+      label: Session duration
+      description: How long had the client been running when the problem occurred?
+      placeholder: "Example: 2 hours 35 minutes"
+    validations:
+      required: true
+
+  - type: textarea
+    id: stutteralert-output
+    attributes:
+      label: StutterAlert output
+      description: Paste the relevant StutterAlert trace and `/sa report` output, including the event time and attribution.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: nexus-perf-output
+    attributes:
+      label: /nexus perf output
+      description: Paste the complete `/nexus perf` output captured near the reported event.
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: nexus-ms-frame
+    attributes:
+      label: Nexus ms/frame
+      description: Enter the Nexus steady frame cost reported by your diagnostics.
+      placeholder: "Example: 0.80 ms/frame"
+    validations:
+      required: true
+
+  - type: input
+    id: all-addon-ms-frame
+    attributes:
+      label: All-addon ms/frame
+      description: Enter the combined addon steady frame cost reported by your diagnostics.
+      placeholder: "Example: 1.75 ms/frame"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: hitch-attribution
+    attributes:
+      label: Hitch attribution
+      description: Choose the attribution shown by StutterAlert for the reported event.
+      options:
+        - Nexus or addon-attributed
+        - Game-side attributed
+        - Mixed or unclear
+    validations:
+      required: true
+
+  - type: textarea
+    id: other-major-addons
+    attributes:
+      label: Other major addons
+      description: List other enabled addons with meaningful frame cost or overlapping behavior. Enter "None" if there are none.
+      placeholder: "Example: Details!, WeakAuras, or None"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction-details
+    attributes:
+      label: Reproduction details
+      description: Explain the exact action sequence, frequency, and whether `/reload`, relogging, zoning, or disabling Nexus changes the result.
+      placeholder: |
+        1. Start StutterAlert capture ...
+        2. Perform ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed-impact
+    attributes:
+      label: Observed impact
+      description: Describe the visible hitch, stutter pattern, or sustained performance change and its frequency.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Reporting acknowledgements
+      options:
+        - label: I understand that Test 18 is an unfinished prerelease build.
+          required: true
+        - label: I searched existing issues and did not find a duplicate report.
+          required: true
+        - label: I captured both StutterAlert evidence and `/nexus perf` output for this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/03-sync-multiplayer-report.yml
+++ b/.github/ISSUE_TEMPLATE/03-sync-multiplayer-report.yml
@@ -1,6 +1,9 @@
 name: Sync / Multiplayer Report
 description: Report a two-player Better Nexus public prerelease synchronization, recovery, or convergence problem with evidence from both clients.
 title: "[Sync]: "
+labels:
+  - sync
+  - prerelease
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/03-sync-multiplayer-report.yml
+++ b/.github/ISSUE_TEMPLATE/03-sync-multiplayer-report.yml
@@ -1,0 +1,124 @@
+name: Sync / Multiplayer Report
+description: Report a two-player Nexus Test 18 synchronization, recovery, or convergence problem with evidence from both clients.
+title: "[Sync]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Sync reports are most useful when both players run the same exact build and provide Peer Test / Sync diagnostics from both clients.
+
+  - type: input
+    id: player-a-build
+    attributes:
+      label: Player A exact Nexus build
+      description: Copy Player A's exact build from `/nexus status`. Do not enter only "latest."
+      placeholder: "Example: test.18-d9b48c5 / v1.20.0-beta.1-test.18"
+    validations:
+      required: true
+
+  - type: input
+    id: player-b-build
+    attributes:
+      label: Player B exact Nexus build
+      description: Copy Player B's exact build from `/nexus status`. If unavailable, state why and provide every known version detail.
+      placeholder: "Example: test.18-d9b48c5 / v1.20.0-beta.1-test.18"
+    validations:
+      required: true
+
+  - type: textarea
+    id: player-a-steps
+    attributes:
+      label: Player A steps
+      description: Describe Player A's actions in order, including requests, shares, UI actions, reloads, relogs, zoning, and timing.
+      placeholder: |
+        1. Player A ...
+        2. Player A ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: player-b-steps
+    attributes:
+      label: Player B steps
+      description: Describe Player B's actions in order and how they corresponded to Player A's actions.
+      placeholder: |
+        1. Player B ...
+        2. Player B ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: failed-to-sync
+    attributes:
+      label: What failed to synchronize
+      description: Identify the exact build, loadout, deletion, DPS record, request, status count, or recovery state that did not converge.
+    validations:
+      required: true
+
+  - type: textarea
+    id: peer-sync-diagnostics
+    attributes:
+      label: Peer Test / Sync diagnostics from both players
+      description: Paste the complete Peer Test and Sync diagnostics from Player A and Player B. If one side is unavailable, explain why and identify which side is missing.
+      placeholder: |
+        Player A:
+        ...
+
+        Player B:
+        ...
+      render: shell
+    validations:
+      required: true
+
+  - type: dropdown
+    id: transition-context
+    attributes:
+      label: Reload, zoning, or Sync Now context
+      description: Select every transition or manual action involved. Choose "None of these" only when none occurred.
+      multiple: true
+      options:
+        - /reload
+        - Zoning or loading screen
+        - Sync Now
+        - Relog or reconnect
+        - None of these
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: Describe the state both players should have reached.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      description: Describe each player's final state, including counts, visible rows, errors, or repeated no-progress results.
+    validations:
+      required: true
+
+  - type: textarea
+    id: relevant-addons
+    attributes:
+      label: Other relevant addons
+      description: List addons enabled on either client that affect networking, builds, loadouts, UI, or diagnostics. Enter "None" if none appear relevant.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Reporting acknowledgements
+      options:
+        - label: I understand that Test 18 is an unfinished prerelease build.
+          required: true
+        - label: I searched existing issues and did not find a duplicate report.
+          required: true
+        - label: I provided exact build information for both clients or explained why one side is unavailable.
+          required: true
+        - label: I included Peer Test / Sync diagnostics from both players where possible.
+          required: true

--- a/.github/ISSUE_TEMPLATE/03-sync-multiplayer-report.yml
+++ b/.github/ISSUE_TEMPLATE/03-sync-multiplayer-report.yml
@@ -1,5 +1,5 @@
 name: Sync / Multiplayer Report
-description: Report a two-player Nexus Test 18 synchronization, recovery, or convergence problem with evidence from both clients.
+description: Report a two-player Better Nexus public prerelease synchronization, recovery, or convergence problem with evidence from both clients.
 title: "[Sync]: "
 body:
   - type: markdown
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Player A exact Nexus build
       description: Copy Player A's exact build from `/nexus status`. Do not enter only "latest."
-      placeholder: "Example: test.18-d9b48c5 / v1.20.0-beta.1-test.18"
+      placeholder: "Example: test.18-d9b48c5"
     validations:
       required: true
 
@@ -21,7 +21,7 @@ body:
     attributes:
       label: Player B exact Nexus build
       description: Copy Player B's exact build from `/nexus status`. If unavailable, state why and provide every known version detail.
-      placeholder: "Example: test.18-d9b48c5 / v1.20.0-beta.1-test.18"
+      placeholder: "Example: test.18-d9b48c5"
     validations:
       required: true
 
@@ -114,7 +114,7 @@ body:
     attributes:
       label: Reporting acknowledgements
       options:
-        - label: I understand that Test 18 is an unfinished prerelease build.
+        - label: I understand that I am testing an unfinished Better Nexus prerelease.
           required: true
         - label: I searched existing issues and did not find a duplicate report.
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,6 @@ contact_links:
   - name: Check existing reports first
     url: https://github.com/Viscerals/Better-Nexus/issues?q=is%3Aissue
     about: Search for an existing Bug, Performance, or Sync report before opening a duplicate.
-  - name: Test 18 download and notes
-    url: https://github.com/Viscerals/Better-Nexus/releases/tag/v1.20.0-beta.1-test.18
-    about: Confirm that you are testing the current public Test 18 prerelease.
+  - name: Public prereleases and release notes
+    url: https://github.com/Viscerals/Better-Nexus/releases
+    about: Check the available Better Nexus prereleases and confirm the exact build you are testing.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Check existing reports first
+    url: https://github.com/Viscerals/Better-Nexus/issues?q=is%3Aissue
+    about: Search for an existing Bug, Performance, or Sync report before opening a duplicate.
+  - name: Test 18 download and notes
+    url: https://github.com/Viscerals/Better-Nexus/releases/tag/v1.20.0-beta.1-test.18
+    about: Confirm that you are testing the current public Test 18 prerelease.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+Describe the problem and the smallest coherent change.
+
+## Scope
+
+List the behavior and exact paths in scope. Note anything intentionally excluded.
+
+## Validation
+
+List focused checks and their exact outcomes. Do not count skipped, unavailable, or failing checks as passing.
+
+## Risk
+
+Describe compatibility, migration, SavedVariables, performance, security, provenance, and rollback risk as applicable.
+
+## Native testing
+
+State whether the exact proposed head was tested in WoW 3.3.5a / Project Ebonhold. If not, state the remaining live-unproven boundary.
+
+## Confirmation
+
+- [ ] The PR contains no unrelated changes.
+- [ ] Lua changes remain compatible with Lua 5.1.
+- [ ] `NexusDB` and `WishlistRealizerDB` compatibility is preserved or the migration is explained and tested.
+- [ ] No packages, SavedVariables, private logs, AI transcripts, or transient artifacts are included.
+- [ ] Published or exact-SHA-reviewed history was not rewritten.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,62 @@
+# AI and Automated Systems Policy
+
+## Scope
+
+This policy defines acceptable AI-assisted development and release behavior for this repository.
+
+## Allowed AI-assisted activities
+
+AI systems and automated assistants may be used by authorized contributors and maintainers for:
+
+- source-code analysis and refactoring;
+- code generation and drafting;
+- debugging and test generation;
+- review and quality checks;
+- documentation writing and updates;
+- translation and localization support;
+- issue/log analysis and release planning;
+- performance and security analysis;
+- project maintenance and repository hygiene.
+
+## Human responsibility
+
+AI-assisted tooling does not remove human accountability. For every change:
+
+- a contributor must understand the change and run required checks;
+- correctness, regression, and compatibility must be validated;
+- security and privacy impact must be reviewed;
+- license and attribution impact must be reviewed;
+- ownership and provenance obligations must be preserved;
+- the contributor remains responsible for final merge/release decisions.
+
+AI output is treated as draft input and must receive the same review and validation standards as a human draft. Prompts, chat logs, transcripts, chain-of-thought, scratch files, and private model output are not required repository artifacts.
+
+## Prohibited use
+
+The following are not allowed:
+
+- using AI to copy or transform proprietary/incompatible third-party code and present it as original Better-Nexus work;
+- laundering upstream, third-party, or confidential code through translation/refactoring to evade notices or legal constraints;
+- removing or obscuring provenance, copyright notices, or license requirements;
+- using AI output to bypass security, release, or branch controls;
+- implying ownership of transformed upstream/third-party work where ownership cannot be shown;
+- uploading credentials, private tokens, private player data, private SavedVariables, private logs, or confidential material to AI systems without explicit authorization;
+- committing prompts, chats, transcripts, chain-of-thought, scratch outputs, or private temporary data as source artifacts.
+
+Permission to use AI is not a separate copyright or redistribution license. It does not authorize copying, modifying, repackaging, sublicensing, selling, rebranding, unauthorized redistribution, or model training/use.
+
+## Third-party and upstream respect
+
+Contributors must preserve known upstream provenance, notices, and license files, including:
+
+- Boganic attribution;
+- `UPSTREAM.md`;
+- other third-party notices and required license terms.
+
+AI-assisted changes derived from upstream/third-party material remain governed by the actual applicable rights.
+
+## Security and privacy
+
+AI tooling must never be used to disclose secrets, credentials, private player data, SavedVariables, exploitable details, or private vulnerability data.
+
+Do not use model output to bypass required reviews, policy checks, or release approvals.

--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -267,6 +267,16 @@ perform no catalog/DPS walk or ordering pass, and every caller receives a
 defensive copy. Status, timers, visibility, Sync queues, and diagnostic activity
 are not cache inputs.
 
+DPS character identity is stored and projected as a hidden normalized
+`name@realm` key. Realm-less legacy rows inherit the current realm because the
+current product has one realm. Realm whitespace and presentation punctuation
+are discarded so historical spellings such as `roguelite(live)` and
+`rogue-lite(live)` resolve identically; duplicate rows resolving to that same
+identity are reconciled by newest timestamp, then DPS, then fingerprint. Normal capture
+and Sync replacement remain best-DPS based. Short names remain the default UI
+label, but projections expose a realm-qualified display label whenever two
+explicitly different realms contain the same short character name.
+
 Construction is publish-after-success. If a represented revision changes while
 a projection is building, the module retries once against the new snapshot; an
 error or second unstable pass publishes nothing. The module owns no frames,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to Better Nexus
+
+Better Nexus is in public prerelease stabilization. Keep contributions focused, evidence-based, and compatible with the existing addon and player data.
+
+## Compatibility
+
+- Target Lua 5.1.
+- Target World of Warcraft 3.3.5a on Project Ebonhold.
+- Preserve the runtime addon name and folder name `Nexus`.
+- Preserve `NexusDB` and `WishlistRealizerDB`, including migration behavior, unknown fields, and rollback safety.
+
+## Before opening a pull request
+
+1. Start from the current `main` branch.
+2. Keep the change narrowly scoped. Separate unrelated product, policy, and infrastructure work.
+3. Run the relevant focused and repository validation checks.
+4. Record what was tested offline and what was tested in the native game client. Do not claim live behavior from offline checks.
+5. Review the final diff for unrelated files, generated output, secrets, private data, and provenance concerns.
+
+Do not include:
+
+- AI chat transcripts, prompts, scratch notes, or transient automation artifacts;
+- release packages or locally built archives;
+- SavedVariables, account or character data, private diagnostics, or logs;
+- editor, backup, cache, or temporary files.
+
+Do not force-push, rebase, or otherwise rewrite a head that is already under exact-SHA review or native testing. Open a successor commit or coordinate with the maintainer when reviewed history must be preserved.
+
+## Reports and requests
+
+- Use the repository's GitHub Issue Forms for bugs, performance or stutter reports, and Sync or multiplayer reports.
+- Feature requests are deferred while public prerelease stabilization is active.
+- Report vulnerabilities through [private vulnerability reporting](https://github.com/Viscerals/Better-Nexus/security/advisories/new), not a public issue.
+
+## Pull-request evidence
+
+Every pull request should state:
+
+- the problem and proposed change;
+- the exact paths and behavior in scope;
+- focused validation results;
+- regression and migration risks;
+- native testing status and any unproven boundary;
+- confirmation that unrelated changes are excluded.
+
+Maintainers may ask for a smaller PR or additional evidence when review, provenance, compatibility, or player-data safety is unclear.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,40 @@
+# Better Nexus Source-Available License
+
+## Copyright and scope
+
+Copyright (c) 2026 Viscerals for original Better Nexus contributions whose rights are owned by Viscerals or another identifiable Better Nexus contributor.
+
+This license applies only to material for which the project rightsholder can grant rights. It does not relicense or claim ownership of:
+
+- upstream Nexus material attributed to Boganic;
+- upstream dependencies and third-party libraries with their own terms;
+- World of Warcraft, Project Ebonhold, or their trademarks, data, and marks.
+
+See `UPSTREAM.md` for the known provenance boundaries and unresolved licensing status.
+
+## Limited permitted use
+
+Subject to all third-party terms:
+
+1. A player may download and use an official Better Nexus release published on the project release channel;
+2. A player may make reasonable personal backups;
+3. A player may install and run an unmodified official release for personal, non-commercial gameplay on Project Ebonhold.
+
+This limited permission does not grant source redistribution or modification rights.
+
+## Reserved rights
+
+Unless another right applies and is granted by the relevant rightsholder:
+
+- copy, modify, adapt, translate, reverse engineer, distribute, sublicense, sell, rent, or commercially exploit any Better Nexus material;
+- create or publish derivative works, forks, or competing releases built from Better Nexus materials;
+- remove, hide, alter, or misrepresent provenance, copyright, or licensing notices;
+- claim rights that are not actually held by the contributor.
+
+## AI and data-mining
+
+AI-assisted development is permitted for authorized project work under `AI_POLICY.md`. AI assistance does not create new ownership rights, does not override attribution or license obligations, and does not authorize ML training or model reuse without separate legal rights.
+
+## Disclaimers
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, THIS SOFTWARE IS PROVIDED "AS IS" WITH NO WARRANTIES OR CONDITIONS OF ANY KIND.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Better Nexus
 
-Better Nexus is a private, community-maintained continuation of the deprecated
+Better Nexus is a public, community-maintained continuation of the deprecated
 Nexus addon for Project Ebonhold.
 
 The repository begins from the installed Nexus 1.19.3 player build. The in-game
@@ -9,8 +9,10 @@ compatibility with existing installations and user data.
 
 ## Project status
 
-- Repository visibility: private during development.
-- Current release: Nexus 1.19.5.
+- Stable production release: Nexus 1.19.5.
+- Experimental public prereleases are available through
+  [GitHub Releases](https://github.com/Viscerals/Better-Nexus/releases). These
+  builds are for testing and are not stable releases.
 - Client target: World of Warcraft 3.3.5a / Project Ebonhold.
 - Language target: Lua 5.1.
 - Upstream author attribution is preserved in `Nexus.toc` and
@@ -35,6 +37,17 @@ DPS records, and Snapshot convergence for Project Ebonhold.
 
 Do not rename the installed addon folder to `Better-Nexus`; the repository name
 is different from the runtime addon identity by design.
+
+Back up `NexusDB` and `WishlistRealizerDB` before testing a prerelease. Better
+Nexus preserves compatibility with these SavedVariables because existing user
+data must survive upgrades and rollback testing.
+
+## Reporting problems
+
+Use the [structured issue
+forms](https://github.com/Viscerals/Better-Nexus/issues/new/choose) to report a
+bug, performance or stutter problem, or multiplayer Sync problem. Include the
+exact prerelease build and the diagnostics requested by the selected form.
 
 ## Commands
 

--- a/RELEASE_SECURITY.md
+++ b/RELEASE_SECURITY.md
@@ -1,0 +1,42 @@
+# Release Security
+
+## Core principles
+
+Release authority remains a human and repository control function; AI assistance does not replace review, merge, or branch protections.
+
+## Required local controls
+
+Checked-in policy files should be validated together with GitHub branch protections and review controls:
+
+- `.github/CODEOWNERS` for policy/release-critical ownership;
+- `tools/Test-ReleasePolicy.ps1` for archive and source policy checks;
+- branch and PR review rules configured in GitHub settings.
+
+## Required release archive contents
+
+Release archives must include, in the top-level `Nexus` folder:
+
+- `Nexus.toc`
+- `LICENSE.md`
+- `AI_POLICY.md`
+- `UPSTREAM.md`
+
+`RELEASE_SECURITY.md`, `SECURITY.md`, and `README.md` are required in source but are not substitutes for the three mandatory archive files.
+
+## Offline checks
+
+Before release:
+
+1. verify the source commit is reviewed and clean;
+2. run `tools/Test-ReleasePolicy.ps1 -Archive <artifact>`;
+3. record commit, artifact SHA-256, and validation outcome in release notes.
+
+## Incident response
+
+On suspected takeover, unauthorized release, or credential compromise:
+
+- stop publish actions;
+- preserve evidence and logs;
+- rotate affected credentials;
+- remove compromised collaborators/apps;
+- notify the maintainer via the private security path and recover safely.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting
+
+Report suspected vulnerabilities, compromises, or release integrity issues privately through the Better Nexus security reporting path.
+
+Do not publish credentials, access tokens, private data, exploit detail, private SavedVariables, or active incident details in public channels.
+
+## Required report content
+
+Include:
+
+- affected version/tag;
+- observed time and timezone;
+- affected URL(s);
+- archive checksums when available;
+- concise reproducible context.
+
+## Contact
+
+If private reporting is unavailable, use the repository maintainer’s verified contact path.
+
+See `RELEASE_SECURITY.md` for incident and release controls.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,12 @@
+# Better Nexus support
+
+Use the route that matches the problem so the report requests the right evidence.
+
+- **Bug:** [Bug Report](https://github.com/Viscerals/Better-Nexus/issues/new?template=01-bug-report.yml)
+- **Performance or stutter:** [Performance / Stutter Report](https://github.com/Viscerals/Better-Nexus/issues/new?template=02-performance-stutter-report.yml)
+- **Sync or multiplayer:** [Sync / Multiplayer Report](https://github.com/Viscerals/Better-Nexus/issues/new?template=03-sync-multiplayer-report.yml)
+- **Security:** [Report a vulnerability privately](https://github.com/Viscerals/Better-Nexus/security/advisories/new). Do not disclose vulnerability details in a public issue.
+
+Feature requests are deferred while public prerelease stabilization is active. Existing feature discussions may remain open, but new feature work is not currently the support priority.
+
+Before submitting a report, search existing issues, confirm the exact Better Nexus build, preserve SavedVariables, and capture the diagnostics requested by the selected form.

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -4,15 +4,10 @@ Better Nexus begins from a locally installed Nexus 1.19.3 snapshot.
 
 - Upstream addon name: Nexus
 - Upstream author recorded by the addon: Boganic
-- Historical repository referenced by the earlier source documentation:
-  `Solkex/Nexus`
+- Current TOC maintainer metadata: Valentine
+- Historical repository referenced by the earlier source documentation: `Solkex/Nexus`
 - Imported base version: 1.19.3
 
-The upstream project was reported as deprecated, so this repository provides a
-private development home for maintenance and compatibility fixes. Runtime
-identifiers and author attribution are intentionally preserved.
+The initial snapshot did not include an upstream license file. Better-Nexus preserves upstream provenance and attribution records but does not claim rights to upstream materials beyond what the upstream rightsholders can grant.
 
-No license file accompanied either local source snapshot inspected during the
-initial import. Keep this repository private and clarify the upstream
-redistribution and licensing terms before making source or binary releases
-public.
+Any redistribution or derivative use of upstream materials requires rights compatible with the relevant upstream or third-party terms.

--- a/core/DpsCapture.lua
+++ b/core/DpsCapture.lua
@@ -166,20 +166,85 @@ local function CharacterBestStore()
 end
 
 local function PlayerKey(name)
-    return tostring(name or "?"):lower()
+    local value = tostring(name or ""):gsub("^%s+", ""):gsub("%s+$", "")
+    local ownerName = value:match("^([^@]+)@[^@]+$")
+    local transportName = value:match("^([^%-]+)%-.+$")
+    value = ownerName or transportName or value
+    value = value:lower():gsub("%s+", "")
+    return value ~= "" and value or "?"
+end
+
+local function RealmKey(realm)
+    -- Historical clients have emitted both `roguelite(live)` and
+    -- `rogue-lite(live)` for the same server. Realm is hidden identity data,
+    -- so discard presentation punctuation as well as whitespace here.
+    realm = tostring(realm or ""):lower():gsub("[^%w]", "")
+    return realm ~= "" and realm or nil
 end
 
 local function CurrentRealm()
     local realm = GetNormalizedRealmName and GetNormalizedRealmName()
     if not realm or realm == "" then realm = GetRealmName and GetRealmName() end
-    return tostring(realm or "unknown"):lower():gsub("%s+", "")
+    return RealmKey(realm) or "unknown"
+end
+
+local function OwnerParts(ownerKey)
+    if type(ownerKey) ~= "string" then return nil, nil end
+    local name, realm = ownerKey:match("^([^@]+)@([^@]+)$")
+    name, realm = PlayerKey(name), RealmKey(realm)
+    if name == "?" or not realm then return nil, nil end
+    return name, realm
+end
+
+local function RealmFromPlayer(name)
+    if type(name) ~= "string" then return nil end
+    return RealmKey(name:match("^[^@]+@([^@]+)$")
+        or name:match("^[^%-]+%-(.+)$"))
+end
+
+-- Character identity remains realm-qualified internally even while the
+-- current product has one realm and normally renders only the short name.
+-- Realm-less legacy rows intentionally inherit the current realm; the hidden
+-- realm marker keeps the storage shape ready for future multi-realm data.
+local function CharacterKey(name, ownerKey, realm, sourceKey)
+    local player = PlayerKey(name or sourceKey)
+    local ownerName, ownerRealm = OwnerParts(ownerKey)
+    local sourceName, sourceRealm = OwnerParts(sourceKey)
+    local selectedRealm
+    if ownerName == player then selectedRealm = ownerRealm end
+    if not selectedRealm then selectedRealm = RealmKey(realm) end
+    if not selectedRealm then selectedRealm = RealmFromPlayer(name) end
+    if not selectedRealm and sourceName == player then selectedRealm = sourceRealm end
+    selectedRealm = selectedRealm or CurrentRealm()
+    return player .. "@" .. selectedRealm, selectedRealm
 end
 
 local function OwnerKey(name, realm)
-    name = tostring(name or ""):lower():gsub("^%s+", ""):gsub("%s+$", "")
-    if name == "" then return nil end
-    realm = tostring(realm or CurrentRealm()):lower():gsub("%s+", "")
-    return name .. "@" .. realm
+    local player = PlayerKey(name)
+    if player == "?" then return nil end
+    local key = CharacterKey(player, nil, realm or RealmFromPlayer(name))
+    return key
+end
+
+local function StampCharacterIdentity(row, fallbackPlayer, sourceKey)
+    if type(row) ~= "table" then return nil, false end
+    local changed = false
+    local player = row.player or fallbackPlayer or sourceKey or "?"
+    if row.player == nil then row.player = PlayerKey(player); changed = true end
+    local ownerName, ownerRealm = OwnerParts(row.ownerKey)
+    local explicitRealm = RealmKey(row.realm) or RealmFromPlayer(player)
+    local sourceName, sourceRealm = OwnerParts(sourceKey)
+    local playerKey = PlayerKey(player)
+    local hadRealmEvidence = ownerName == playerKey and ownerRealm ~= nil
+        or explicitRealm ~= nil
+        or sourceName == playerKey and sourceRealm ~= nil
+    local key, realm = CharacterKey(player, row.ownerKey, row.realm, sourceKey)
+    if row.ownerKey ~= key then row.ownerKey = key; changed = true end
+    if row.realm ~= realm then row.realm = realm; changed = true end
+    if row.characterKey ~= key then row.characterKey = key; changed = true end
+    local assumed = row.realmAssumed == true or not hadRealmEvidence
+    if row.realmAssumed ~= assumed then row.realmAssumed = assumed; changed = true end
+    return key, changed
 end
 
 -- Repair legacy class metadata only for the exact character currently logged
@@ -201,10 +266,9 @@ local function RepairCurrentCharacterClass()
 
     for _, category in ipairs({ "dummy", "lk" }) do
         for _, row in pairs(character[category] or {}) do
-            local rowOwner = tostring(row and row.ownerKey or ""):lower()
-            local derivedOwner = row and OwnerKey(row.player,
-                row.realm and row.realm ~= "" and row.realm or realm)
-            if row and (rowOwner == localOwner or derivedOwner == localOwner) then
+            local rowOwner = row and CharacterKey(
+                row.player, row.ownerKey, row.realm) or nil
+            if row and rowOwner == localOwner then
                 if row.class ~= class then row.class = class; changed = true end
                 local prow = row.fingerprint and personal[row.fingerprint]
                     and personal[row.fingerprint][category]
@@ -249,7 +313,7 @@ local function RepairCurrentCharacterClass()
     return changed
 end
 
-local legacyMigrated = false
+local legacyMigratedOwner
 local function BetterRow(candidate, existing)
     if not existing then return true end
     local nd = math.floor(tonumber(candidate and candidate.dps) or 0)
@@ -261,35 +325,57 @@ local function BetterRow(candidate, existing)
     return tostring(candidate and candidate.fingerprint or "") < tostring(existing and existing.fingerprint or "")
 end
 
+-- Duplicate identity repair is deliberately recency-based. Normal gameplay
+-- still uses BetterRow (best DPS); this ordering is only for reconciling two
+-- durable rows that resolve to the same hidden realm-qualified character.
+local function NewerDuplicate(candidate, existing)
+    if not existing then return true end
+    local nt = tonumber(candidate and candidate.ts) or 0
+    local ot = tonumber(existing and existing.ts) or 0
+    if nt ~= ot then return nt > ot end
+    local nd = math.floor(tonumber(candidate and candidate.dps) or 0)
+    local od = math.floor(tonumber(existing and existing.dps) or 0)
+    if nd ~= od then return nd > od end
+    return tostring(candidate and candidate.fingerprint or "")
+        < tostring(existing and existing.fingerprint or "")
+end
+
 local function MigrateLegacyLeaderboard()
-    if legacyMigrated then return false end
-    legacyMigrated = true
+    NexusDB = NexusDB or {}
+    local migrationOwner = NexusDB
+    if legacyMigratedOwner == migrationOwner then return false end
+    legacyMigratedOwner = migrationOwner
     local db = DB()
     local me = (UnitName and UnitName("player")) or "?"
+    local myKey = CharacterKey(me)
     local personal = PersonalBestStore()
     local character = CharacterBestStore()
     local changed = false
 
-    -- Normalize any existing CharacterBestStore keys that were stored
-    -- with original casing (pre-PlayerKey-lowercase era). Collect all
-    -- non-lowercase keys and merge them into the canonical lowercase key.
+    -- Re-key existing state by hidden name@realm identity. On today's single
+    -- realm, legacy name-only rows inherit CurrentRealm and therefore collide
+    -- with their qualified copy. The newest valid duplicate wins. Explicitly
+    -- different realms remain separate for a future multi-realm deployment.
     for _, category in ipairs({ "dummy", "lk" }) do
         local bucket = character[category]
         if type(bucket) == "table" then
-            local toMerge = {}
-            for k in pairs(bucket) do
-                if k ~= k:lower() then toMerge[#toMerge+1] = k end
-            end
-            for _, k in ipairs(toMerge) do
-                local lk = k:lower()
-                local row = bucket[k]
-                if BetterRow(row, bucket[lk]) then
-                    bucket[lk] = row
+            local normalized = {}
+            for sourceKey, row in pairs(bucket) do
+                if type(row) == "table" and tonumber(row.dps) then
+                    local targetKey, stamped = StampCharacterIdentity(
+                        row, sourceKey, sourceKey)
+                    if stamped or sourceKey ~= targetKey then changed = true end
+                    if NewerDuplicate(row, normalized[targetKey]) then
+                        if normalized[targetKey] then changed = true end
+                        normalized[targetKey] = row
+                    else
+                        changed = true
+                    end
+                else
                     changed = true
                 end
-                bucket[k] = nil
-                changed = true
             end
+            character[category] = normalized
         end
     end
 
@@ -303,8 +389,11 @@ local function MigrateLegacyLeaderboard()
             row.fingerprint = fingerprint
             changed = true
         end
+        local pk, stamped = StampCharacterIdentity(
+            row, fallbackPlayer, fallbackPlayer)
+        if stamped then changed = true end
         if ReferenceEvidence(row) then changed = true end
-        if PlayerKey(row.player) == PlayerKey(me) and fingerprint then
+        if pk == myKey and fingerprint then
             personal[fingerprint] = personal[fingerprint] or {}
             if BetterRow(row, personal[fingerprint][category]) then
                 personal[fingerprint][category] = row
@@ -313,8 +402,7 @@ local function MigrateLegacyLeaderboard()
         end
         local bucket = character[category]
         if bucket then
-            local pk = PlayerKey(row.player)
-            if BetterRow(row, bucket[pk]) then
+            if NewerDuplicate(row, bucket[pk]) then
                 bucket[pk] = row
                 changed = true
             end
@@ -498,11 +586,12 @@ local function BackfillLocalLockedRows()
     end)() or nil)
     if not snap then return false end
 
-    local me = PlayerKey((UnitName and UnitName("player")) or "?")
+    local me = (UnitName and UnitName("player")) or "?"
+    local meKey = CharacterKey(me)
     local changed = false
     local changedRows = {}
     for _, category in ipairs({ "dummy", "lk" }) do
-        local row = CharacterBestStore()[category][me]
+        local row = CharacterBestStore()[category][meKey]
         if row and LockedKey(StoredEchoes(row, true)) ~= LockedKey(snap) then
             row.lockedEchoes = snap
             ReferenceEvidence(row)
@@ -1076,8 +1165,9 @@ end
 -- record known for each exact loadout and encounter. Peers with the same
 -- digest do not resend any DPS payloads during Sync Now.
 local DPS_BUCKETS = 8
-local function DpsBucket(category, player)
-    local text = tostring(category or "") .. ":" .. PlayerKey(player)
+local function DpsBucket(category, player, ownerKey, realm)
+    local text = tostring(category or "") .. ":"
+        .. CharacterKey(player, ownerKey, realm)
     local h = 5381
     for i = 1, #text do h = ((h * 33) + text:byte(i)) % 2147483648 end
     return (h % DPS_BUCKETS) + 1
@@ -1172,13 +1262,13 @@ local function InvalidateAllDpsHashes()
     end
 end
 
-local function UpdateDpsHashRecord(category, player)
+local function UpdateDpsHashRecord(category, player, ownerKey, realm)
     if not dpsHashCache.initialized then return end
     if category ~= "dummy" and category ~= "lk" then
         InvalidateAllDpsHashes()
         return
     end
-    local playerKey = PlayerKey(player)
+    local playerKey = CharacterKey(player, ownerKey, realm)
     local bucket = DpsBucket(category, playerKey)
     local row = CharacterBestStore()[category][playerKey]
     dpsHashCache.entries[bucket][category .. "|" .. playerKey] =
@@ -1192,7 +1282,8 @@ local function OnDpsRevision(_, revision, detail)
     dpsHashCache.observedRevision = revision
     if type(detail) == "table" and detail.scope == "record"
         and detail.category and detail.player then
-        UpdateDpsHashRecord(detail.category, detail.player)
+        UpdateDpsHashRecord(detail.category, detail.player,
+            detail.ownerKey, detail.realm)
     elseif type(detail) ~= "table"
         or (detail.scope ~= "local" and detail.scope ~= "metadata") then
         InvalidateAllDpsHashes()
@@ -1401,15 +1492,15 @@ end
 function DPS.GetDpsBoard(category)
     if category ~= "dummy" and category ~= "lk" then return {} end
     MigrateLocalLockedBaseline()
-    MigrateLegacyLeaderboard()
-    if RepairCurrentCharacterClass() then
+    local migrated = MigrateLegacyLeaderboard()
+    if RepairCurrentCharacterClass() and not migrated then
         BumpDps("local class repaired", {scope="metadata"})
     end
     if BackfillLocalLockedRows() then
         BumpDps("locked metadata backfilled", {scope="metadata"})
     end
     local out = {}
-    local seenPlayer = {}   -- dedup by lowercase player name
+    local seenPlayer = {}   -- dedup by hidden realm-qualified identity
     for _, row in pairs(CharacterBestStore()[category] or {}) do
         if type(row) == "table" and (tonumber(row.dps) or 0) > 0 then
             local buildId = row.buildId
@@ -1431,17 +1522,19 @@ function DPS.GetDpsBoard(category)
                 buildId, build = FindMatchingBuild(rowEchoes)
             end
             if build or rowEchoes then
-                local pkey = PlayerKey(row.player or "?")
+                local pkey = CharacterKey(row.player or "?",
+                    row.ownerKey, row.realm)
                 local entry = {
                     player = row.player or "?", dps = math.floor(tonumber(row.dps) or 0),
                     class = row.class, ownerKey = row.ownerKey, realm = row.realm,
+                    characterKey = pkey, realmAssumed = row.realmAssumed == true,
                     level = tonumber(row.level) or 0, ts = tonumber(row.ts) or 0,
                     duration = tonumber(row.duration) or 0, category = category,
                     fingerprint = row.fingerprint, echoes = rowEchoes or BuildSnapshot(build),
                     lockedEchoes = StoredEchoes(row, true),
                     buildId = buildId, build = build,
                 }
-                -- Keep only the highest-DPS entry per player
+                -- Keep only the highest-DPS entry per canonical character.
                 local existing = seenPlayer[pkey]
                 if not existing then
                     out[#out + 1] = entry
@@ -1450,6 +1543,20 @@ function DPS.GetDpsBoard(category)
                     out[existing] = entry
                 end
             end
+        end
+    end
+    local shortNameCounts = {}
+    for _, entry in ipairs(out) do
+        local short = PlayerKey(entry.player)
+        shortNameCounts[short] = (shortNameCounts[short] or 0) + 1
+    end
+    for _, entry in ipairs(out) do
+        local short = PlayerKey(entry.player)
+        if shortNameCounts[short] > 1 then
+            entry.displayPlayer = tostring(entry.player or "?") .. "-"
+                .. tostring(entry.realm or "unknown")
+        else
+            entry.displayPlayer = entry.player
         end
     end
     table.sort(out, function(a, b)
@@ -1469,7 +1576,7 @@ function DPS.GetCharacterBest(category, playerName)
     MigrateLocalLockedBaseline()
     MigrateLegacyLeaderboard()
     local name = playerName or ((UnitName and UnitName("player")) or "?")
-    local row = CharacterBestStore()[category][PlayerKey(name)]
+    local row = CharacterBestStore()[category][CharacterKey(name)]
     if not row or (tonumber(row.dps) or 0) <= 0 then return nil end
     return DPS.MaterializeRecord(row)
 end
@@ -1478,7 +1585,7 @@ function DPS.GetPlayerInfo(playerName)
     if not playerName or playerName == "" then return nil end
     MigrateLocalLockedBaseline()
     MigrateLegacyLeaderboard()
-    local pk = PlayerKey(playerName)
+    local pk = CharacterKey(playerName)
     local best
     for _, category in ipairs({"dummy", "lk"}) do
         local row = CharacterBestStore()[category][pk]
@@ -1659,13 +1766,15 @@ local function CommitSession(category)
             ownerKey = OwnerKey(player), realm = CurrentRealm(),
             protocolVersion = PROTOCOL_VERSION,
         }
+        StampCharacterIdentity(personalRow, player)
         SetStoreRow(PersonalBestStore(), key, category, personalRow)
 
         -- Only this character's highest result for the encounter enters the
         -- public mesh. Exact-set personal bests remain local, so experimenting
         -- with weaker loadouts cannot create or sync leaderboard bloat.
         local characterBucket = CharacterBestStore()[category]
-        local pk = PlayerKey(player)
+        local pk = CharacterKey(player, personalRow.ownerKey,
+            personalRow.realm)
         local previousCharacterBest = characterBucket[pk]
         local becameCharacterBest = BetterRow(personalRow, previousCharacterBest)
         if becameCharacterBest then
@@ -1697,6 +1806,7 @@ local function CommitSession(category)
         end
         BumpDps("personal best committed", becameCharacterBest and {
             scope="record", category=category, player=player,
+            ownerKey=personalRow.ownerKey, realm=personalRow.realm,
         } or {scope="local"})
         local catLabel = category == "lk" and "Lich King" or "Training Dummy"
         local setLabel = build and build.title or "current Echo set"
@@ -1708,7 +1818,7 @@ local function CommitSession(category)
 
         -- Global comparison is only meaningful when the exact current Echo
         -- set is already a published community build.
-        local characterNow = CharacterBestStore()[category][PlayerKey(player)]
+        local characterNow = CharacterBestStore()[category][pk]
         if characterNow == personalRow and Sync and Sync.BroadcastDpsRecord then
             pcall(Sync.BroadcastDpsRecord, {
                 protocolVersion = PROTOCOL_VERSION, fingerprint = key,
@@ -1849,7 +1959,8 @@ function DPS.ReceiveRecord(record, transportSender)
 
     MigrateLegacyLeaderboard()
     local bucket = CharacterBestStore()[category]
-    local existing = bucket[PlayerKey(player)]
+    local characterKey = CharacterKey(player, ownerKey, realm or ownerRealm)
+    local existing = bucket[characterKey]
     local rawLocked = record.lk or record.lockedEchoes
     if rawLocked ~= nil and not ValidWireEchoList(rawLocked) then return false end
     local incomingLocked = NormalizeEchoes(rawLocked)
@@ -1864,6 +1975,7 @@ function DPS.ReceiveRecord(record, transportSender)
         lockedEchoes = incomingLocked,
         protocolVersion = PROTOCOL_VERSION,
     }
+    StampCharacterIdentity(row, player)
     ReferenceEvidence(row)
     if not IsBetterPublicRecord(row, existing) then
         -- Metadata enrichment: the same winning parse may have been received
@@ -1917,9 +2029,10 @@ function DPS.ReceiveRecord(record, transportSender)
             if safeOk and safeId then row.buildId = safeId end
         end
     end
-    bucket[PlayerKey(player)] = row
+    bucket[characterKey] = row
     BumpDps("public record received", {
         scope="record", category=category, player=player,
+        ownerKey=row.ownerKey, realm=row.realm,
     })
     RequestDataViewRefresh()
     return true
@@ -1931,17 +2044,20 @@ function DPS.ReceiveSubmission(buildId, player, dps, level, category, ts)
     local key = BuildKey(buildId)
     if not (key and player and dps and dps > 0) then return end
     local bucket = CharacterBestStore()[category]
-    local existing = bucket[PlayerKey(player)]
+    local characterKey = CharacterKey(player)
+    local existing = bucket[characterKey]
     local row = {
         dps = dps, level = level, ts = ts or 0, player = player, buildId = buildId,
         echoes = BuildSnapshot(CatalogGet(buildId)),
         fingerprint = key, protocolVersion = PROTOCOL_VERSION,
     }
+    StampCharacterIdentity(row, player)
     ReferenceEvidence(row)
     if not IsBetterPublicRecord(row, existing) then return end
-    bucket[PlayerKey(player)] = row
+    bucket[characterKey] = row
     BumpDps("legacy submission received", {
         scope="record", category=category, player=player,
+        ownerKey=row.ownerKey, realm=row.realm,
     })
     RequestDataViewRefresh()
 end
@@ -1980,8 +2096,8 @@ function DPS.Init(adapter, sync)
         Catalog().Init(NexusDB, Nexus.BundledBuilds)
     end
     MigrateLocalLockedBaseline()
-    MigrateLegacyLeaderboard()
-    if RepairCurrentCharacterClass() then
+    local migrated = MigrateLegacyLeaderboard()
+    if RepairCurrentCharacterClass() and not migrated then
         BumpDps("local class repaired", {scope="metadata"})
     end
     Debug("initialized; current tracked key=" .. tostring(DPS.GetCurrentEchoKey()))

--- a/core/GameAdapter.lua
+++ b/core/GameAdapter.lua
@@ -47,7 +47,11 @@ local tomeMutationPausedUntil = 0
 -- the session (per-action, like the client itself); never a whole-loop stall
 local latchSince, deadLatch = {}, {}
 local slotsRetryAt, slotsRetries = nil, 0
-local slotsRefreshAt = 0
+-- A slot refresh is scheduled only after a concrete local/server action.
+-- Periodically requesting the entire SS-540 payload made an unchanged account
+-- rebuild every saved and designed Echo slot every five seconds.
+local slotsRefreshAt = nil
+local slotWriteCalling = false
 local lastAutoAcceptState, lastRivalState = nil, nil
 
 local CORRECTED_CLASS_MASKS = {
@@ -666,9 +670,9 @@ function A.WishlistKey(echoes)
     return WishlistIdentity(echoes)
 end
 
-function A.GetWishlistCandidates()
-    local slots = A.Slots()
-    if not slots then return {} end
+function A.GetWishlistCandidates(slots)
+    if slots == nil then slots = A.Slots() end
+    if type(slots) ~= "table" then return {} end
     local maxSlots = slots.maxSlots or 5
     local out = {}
     for slotId, row in pairs(slots.bySlot or {}) do
@@ -718,7 +722,7 @@ function A.GetWishlistCandidates()
     return out
 end
 
-local function ResolveAssociation(loadoutSlot)
+local function ResolveAssociation(loadoutSlot, slots)
     loadoutSlot = tonumber(loadoutSlot)
     if not loadoutSlot then return nil end
     local state = Store and Store.State and Store.State()
@@ -731,7 +735,7 @@ local function ResolveAssociation(loadoutSlot)
     -- recycled server slot can never resurrect an unrelated historical name.
     if type(saved) == "number" or type(saved) == "string" then
         local wanted = tonumber(saved)
-        for _, c in ipairs(A.GetWishlistCandidates()) do
+        for _, c in ipairs(A.GetWishlistCandidates(slots)) do
             if tonumber(c.slot) == wanted then
                 links[loadoutSlot] = { slot = c.slot, key = c.key, name = c.name }
                 return c
@@ -745,7 +749,7 @@ local function ResolveAssociation(loadoutSlot)
         return nil
     end
 
-    local candidates = A.GetWishlistCandidates()
+    local candidates = A.GetWishlistCandidates(slots)
     local wantedKey = saved.key
     if wantedKey and wantedKey ~= "" then
         for _, c in ipairs(candidates) do
@@ -802,11 +806,11 @@ end
 -- wishlist target so Nexus can guide their very first 1-80 run. This is a
 -- temporary account-local association and is replaced naturally once the
 -- player has a real Saved Build selected.
-local function ResolveFirstRunWishlist()
+local function ResolveFirstRunWishlist(slots)
     local state = Store and Store.State and Store.State()
     local saved = state and state.firstRunWishlist
     if type(saved) ~= "table" then return nil end
-    local candidates = A.GetWishlistCandidates()
+    local candidates = A.GetWishlistCandidates(slots)
     local wantedKey, wantedName = tostring(saved.key or ""), tostring(saved.name or "")
     if wantedKey ~= "" then
         for _, c in ipairs(candidates) do
@@ -829,8 +833,8 @@ local function ResolveFirstRunWishlist()
     return nil
 end
 
-function A.GetFirstRunWishlist()
-    return ResolveFirstRunWishlist()
+function A.GetFirstRunWishlist(slots)
+    return ResolveFirstRunWishlist(slots)
 end
 
 function A.SetFirstRunWishlist(wishlistSlot)
@@ -865,16 +869,17 @@ end
 
 local function IsPopulatedLoadout(loadoutSlot, slots)
     loadoutSlot = tonumber(loadoutSlot)
-    slots = slots or A.Slots()
-    local row = slots and slots.bySlot and loadoutSlot and slots.bySlot[loadoutSlot]
+    if slots == nil then slots = A.Slots() end
+    local row = type(slots) == "table" and slots.bySlot
+        and loadoutSlot and slots.bySlot[loadoutSlot]
     return row and type(row.echoes) == "table" and #row.echoes > 0 and true or false
 end
 
-function A.GetLoadoutWishlist(loadoutSlot)
+function A.GetLoadoutWishlist(loadoutSlot, slots)
     -- An association on an empty numbered slot is stale metadata, not a usable
     -- build. Never expose it to the panel/UI as though the player can swap to it.
-    if not IsPopulatedLoadout(loadoutSlot) then return nil end
-    return ResolveAssociation(loadoutSlot)
+    if not IsPopulatedLoadout(loadoutSlot, slots) then return nil end
+    return ResolveAssociation(loadoutSlot, slots)
 end
 
 function A.GetLoadoutWishlistSlot(loadoutSlot)
@@ -989,13 +994,13 @@ function A.ClearLoadoutWishlist(loadoutSlot)
     return true
 end
 
-function A.Wishlist()
+function A.Wishlist(slots)
     A._wishlistNote = nil
-    local slots = A.Slots()
+    if slots == nil then slots = A.Slots() end
     local activeSlot = slots and tonumber(slots.activeSlot) or 0
     local maxSlots = slots and (tonumber(slots.maxSlots) or 5) or 5
     if activeSlot < 1 or activeSlot > maxSlots then
-        local starter = ResolveFirstRunWishlist()
+        local starter = ResolveFirstRunWishlist(slots)
         if starter then
             A._wishlistNote = "First-run wishlist target"
             return EchoesToWishlist(starter.echoes, starter.name,
@@ -1004,7 +1009,7 @@ function A.Wishlist()
         A._wishlistNote = "Choose or create a wishlist to begin your first run."
         return nil
     end
-    local linked = ResolveAssociation(activeSlot)
+    local linked = ResolveAssociation(activeSlot, slots)
     if linked then
         return EchoesToWishlist(linked.echoes, linked.name,
             "loadout-association", false, linked.slot)
@@ -1026,7 +1031,7 @@ function A.GetLoadoutCandidates()
         -- Only populated server loadouts are real switch targets. A stale
         -- association on an empty slot must never make Nexus present it as one.
         if IsPopulatedLoadout(slot, slots) then
-            local linked = ResolveAssociation(slot)
+            local linked = ResolveAssociation(slot, slots)
             out[#out + 1] = {
                 slot = slot,
                 name = row and tostring(row.name or "") or "",
@@ -1089,10 +1094,7 @@ end
 
 -- NOTE: this is a READ (asks the server to re-send slot data), so it has
 -- its own throttle and deliberately does NOT touch lastBuildOpAt.
--- Sharing that guard was a real bug (2026-07-24): the background loop
--- calls this every ~5s, and the write guard is 3s, so a manual Save /
--- Activate / UploadWishlist was refused with "spacing" roughly 60% of
--- the time. Reads must never block writes.
+-- Reads must never block Save / Activate / UploadWishlist writes.
 local lastSlotRequestAt = -10
 function A.RequestSlots()
     local svc = PS()
@@ -1102,6 +1104,11 @@ function A.RequestSlots()
         return true
     end
     return false
+end
+
+local function ScheduleSlotRefresh(delay)
+    local due = GetTime() + math.max(0, tonumber(delay) or 0)
+    if not slotsRefreshAt or due < slotsRefreshAt then slotsRefreshAt = due end
 end
 
 ------------------------------------------------------------------------
@@ -1475,7 +1482,9 @@ function A.Activate(slot)
     if level ~= 1 and level ~= 80 then return false, "not level 1/80" end
     if (GetTime() - lastBuildOpAt) < 3 then return false, "spacing" end
     local svc = PS()
+    slotWriteCalling = true
     local ok = svc and SafeCall(svc.ActivateServerBuildSlot, slot)
+    slotWriteCalling = false
     if ok then
         lastBuildOpAt = GetTime()
         A._pendingWishlistSlot = tonumber(slot) or slot
@@ -1491,7 +1500,9 @@ function A.Save(slot, name)
     if (UnitLevel("player") or 0) ~= 80 then return false, "not level 80" end
     if (GetTime() - lastBuildOpAt) < 3 then return false, "spacing" end
     local svc = PS()
+    slotWriteCalling = true
     local ok = svc and SafeCall(svc.SaveServerBuildSlot, slot, name)
+    slotWriteCalling = false
     if ok then lastBuildOpAt = GetTime(); return true end
     return false, "refused"
 end
@@ -1563,8 +1574,10 @@ function A.UploadWishlist(slot, name, echoes)
     for _, e in pairs(byFamily) do clean[#clean + 1] = e end
     table.sort(clean, function(a, b) return a.spellId < b.spellId end)
     if #clean == 0 then return false, "no valid echoes" end
+    slotWriteCalling = true
     local ok = svc and SafeCall(svc.UploadServerBuildSlot,
         tonumber(slot) or 0, tostring(name or "Nexus"), clean)
+    slotWriteCalling = false
     if ok then
         lastBuildOpAt = GetTime()
         -- the slot cache is now stale; re-request like Save/seed does
@@ -1800,6 +1813,19 @@ local function InstallHooks()
                 end)
             end
         end
+        -- Native Echo Journal writes do not pass through A.Activate/Save/
+        -- UploadWishlist. Follow those concrete actions with one settled slot
+        -- request instead of continuously polling an unchanged SS-540 payload.
+        for _, name in ipairs({ "ActivateServerBuildSlot", "SaveServerBuildSlot",
+            "UploadServerBuildSlot", "DeleteServerBuildSlot" }) do
+            if type(svc[name]) == "function" then
+                hooksecurefunc(svc, name, function()
+                    pcall(function()
+                        if not slotWriteCalling then ScheduleSlotRefresh(0.5) end
+                    end)
+                end)
+            end
+        end
         hooksInstalled = true
     end
 end
@@ -1867,13 +1893,12 @@ function A.Poll()
         and (GetTime() - ownedRequestAt) > 5 and ownedRetries < 5 then
         A.RequestGranted()
     end
-    -- Keep the active Echo Wishlist selection fresh. The player can switch
-    -- which designed build is active while the addon is already running, and
-    -- the old slot snapshot may otherwise leave us targeting a previous
-    -- wishlist. Refresh periodically; RequestSlots() itself is rate-limited.
-    if pewDone and GetTime() >= (slotsRefreshAt or 0) then
+    -- A native build write schedules exactly one settled refresh. Normal
+    -- server replies also flow through EchoJournal.OnDataChanged above, which
+    -- marks the represented state dirty without any polling loop.
+    if pewDone and slotsRefreshAt and GetTime() >= slotsRefreshAt then
         if A.RequestSlots() then
-            slotsRefreshAt = GetTime() + 5
+            slotsRefreshAt = nil
         else
             slotsRefreshAt = GetTime() + 1
         end

--- a/core/Main.lua
+++ b/core/Main.lua
@@ -721,8 +721,16 @@ end
 -- this run's gains, the active loadout's convergence toward the ideal
 -- wishlist, and the loadout's specific missing echoes (what "close to
 -- ideal" actually means, not just a percentage).
+local NO_WISHLIST = {}
 local function BuildProgress(plan, owned, slots, catalog, wishlistOverride, previewBuildId)
-    local wl = wishlistOverride or Adapter.Wishlist()
+    -- The sentinel means the caller already resolved that there is no wishlist.
+    -- This avoids re-reading the full server-slot payload just to rediscover nil.
+    local wl = wishlistOverride
+    if wl == NO_WISHLIST then
+        wl = nil
+    elseif wl == nil then
+        wl = Adapter.Wishlist(slots)
+    end
     local lockOnlyFamilies = LockOnlyFamilies(plan, wl)
     local runStacks, wishTotal, wishlistMissing, toLock =
         WishlistProgress(plan, owned, catalog, lockOnlyFamilies, wl)
@@ -828,7 +836,7 @@ local function BuildProgress(plan, owned, slots, catalog, wishlistOverride, prev
 end
 
 
-local function BuildPanelProgress(activePlan, owned, slots, catalog)
+local function BuildPanelProgress(activePlan, owned, slots, catalog, activeWishlist)
     local C = Nexus.CommunityBuilds
     local build = C and C.GetSelectedBuildForPanel and C.GetSelectedBuildForPanel()
     if build and type(build.echoes) == "table" and #build.echoes > 0 then
@@ -836,7 +844,8 @@ local function BuildPanelProgress(activePlan, owned, slots, catalog)
         local previewPlan = Strategy.Compile(catalog, wl, Store.Settings())
         return BuildProgress(previewPlan, owned, slots, catalog, wl, build.id)
     end
-    return BuildProgress(activePlan, owned, slots, catalog)
+    return BuildProgress(activePlan, owned, slots, catalog,
+        activeWishlist or NO_WISHLIST)
 end
 
 local function CopyDisplay(value, seen)
@@ -931,21 +940,21 @@ end
 -- showing stale leveling-era content the rest of the time, which breaks
 -- both "check status at level 80" and "alt-tab between characters".
 -- All args may be nil; WishlistProgress/LoadoutCoverage are null-safe.
-local function RenderIdlePanel(plan, owned, slots, catalog)
+local function RenderIdlePanel(plan, owned, slots, catalog, wishlist)
     local settings = Store.Settings()
     local okAuto = AutoAllowed()
     RenderPanel({
         status = statusLine,
         cards = {},
         recommendation = "",
-        progress = BuildPanelProgress(plan, owned, slots, catalog),
+        progress = BuildPanelProgress(plan, owned, slots, catalog, wishlist),
         level = Adapter.Level(),
         auto = autoEnabled,
         version = Nexus.VERSION,
     })
 end
 
-local function StepArm(level, plan, owned, slots, disabledLevers)
+local function StepArm(level, plan, owned, slots, disabledLevers, catalog, wishlist)
     local settings = Store.Settings()
     -- (a) Loadout selection is owned by the stock Echo Journal. Each saved
     -- loadout has its own Nexus wishlist association, so automatically choosing
@@ -965,7 +974,7 @@ local function StepArm(level, plan, owned, slots, disabledLevers)
             and Adapter.TomeMutationPaused()) then
         if (GetTime() - lastLeverSendAt) <= 0.5 then
             RequestStepAt(lastLeverSendAt + 0.5)
-            RenderIdlePanel(plan, owned, slots, Adapter.Catalog())
+            RenderIdlePanel(plan, owned, slots, catalog, wishlist)
             return
         end
         local optOut = settings.leverOptOut or {}
@@ -1010,7 +1019,7 @@ local function StepArm(level, plan, owned, slots, disabledLevers)
             end
         end
     end
-    RenderIdlePanel(plan, owned, slots, Adapter.Catalog())
+    RenderIdlePanel(plan, owned, slots, catalog, wishlist)
 end
 
 local function WatchRerollHold(board)
@@ -1430,14 +1439,14 @@ local function LogText_AutoLock()
     return table.concat(out, "\n")
 end
 
-local function StepRun(level, plan, slots, owned, flags, disabledLevers)
+local function StepRun(level, plan, slots, owned, flags, disabledLevers, catalog, wishlist)
     local settings = Store.Settings()
-    local catalog = Adapter.Catalog()
     local board = Adapter.Board()
     if not board then
         SetStatus("waiting for board")
         RenderPanel({ status = statusLine, cards = {}, recommendation = "",
-            progress = BuildProgress(plan, owned, slots, catalog),
+            progress = BuildProgress(plan, owned, slots, catalog,
+                wishlist or NO_WISHLIST),
             auto = AutoAllowed() and settings.autoPick,
             version = Nexus.VERSION })
         return
@@ -1666,7 +1675,7 @@ local function StepRun(level, plan, slots, owned, flags, disabledLevers)
     RenderPanel({
         status = statusLine,
         cards = cardLines,
-        progress = BuildPanelProgress(plan, owned, slots, catalog),
+        progress = BuildPanelProgress(plan, owned, slots, catalog, wishlist),
         level = level,
         recommendation = recommendation,
         auto = autoEnabled,
@@ -1749,8 +1758,8 @@ local function StepRun(level, plan, slots, owned, flags, disabledLevers)
     end
 end
 
-local function StepSave(level, plan, slots, owned)
-    RenderIdlePanel(plan, owned, slots, Adapter.Catalog())
+local function StepSave(level, plan, slots, owned, catalog, wishlist)
+    RenderIdlePanel(plan, owned, slots, catalog, wishlist)
     local settings = Store.Settings()
     if not settings.autoSave or savedThisVisit then return end
     -- A level-80 character can load with owned data that looks like a
@@ -1768,7 +1777,6 @@ local function StepSave(level, plan, slots, owned)
     end
     if not slots then SetStatus("waiting for slot data"); return end
     if not owned.synced then SetStatus("waiting for owned-state sync"); return end
-    local catalog = Adapter.Catalog()
     local incumbent = ActiveSlotRow(slots)
     if incumbent then
         local incumbentCounts = FamilyCountsFromEchoes(incumbent.echoes, catalog)
@@ -1805,7 +1813,7 @@ local function StepSave(level, plan, slots, owned)
             end
             -- The saved loadout is the in-progress form of its associated
             -- wishlist, so keep both names aligned whenever Nexus overwrites it.
-            local wl = Adapter.Wishlist()
+            local wl = wishlist
             local saveName = wl and tostring(wl.name or "") or ""
             if saveName == "" then saveName = incumbent.name or "Nexus" end
             local saved = Adapter.Save(incumbent.slot, saveName)
@@ -1843,7 +1851,7 @@ local function StepSave(level, plan, slots, owned)
                 }
             end
         else
-            local wl = Adapter.Wishlist()
+            local wl = wishlist
             local wlName = wl and ((wl.name ~= "" and wl.name) or "your build") or "your build"
             -- Translate the raw Ratchet detail into something readable
             local readableDetail
@@ -2007,7 +2015,13 @@ local function Step()
         RenderIdlePanel(nil, nil, nil, nil)
         return
     end
-    local wishlist = Adapter.Wishlist()
+    local slots
+    if Nexus.Performance and type(Nexus.Performance.Measure) == "function" then
+        slots = Nexus.Performance.Measure("adapter.slots", Adapter.Slots)
+    else
+        slots = Adapter.Slots()
+    end
+    local wishlist = Adapter.Wishlist(slots or false)
     if not quickStartChecked then
         quickStartChecked = true
         if Nexus.QuickStart then
@@ -2015,7 +2029,6 @@ local function Step()
         end
     end
     local plan = Strategy.Compile(catalog, WishlistWithLockTargets(wishlist, catalog), Store.Settings())
-    local slots = Adapter.Slots()
     local owned = Adapter.Owned()
     local flags = EffectiveFlags()
     local disabledLevers = Adapter.DisabledLevers()
@@ -2123,12 +2136,12 @@ local function Step()
     end
 
     if level == 1 then
-        StepArm(level, plan, owned, slots, disabledLevers)
+        StepArm(level, plan, owned, slots, disabledLevers, catalog, wishlist)
         if plan.advisorOnly then
             SetStatus("No wishlist set -- advisor only")
         end
     elseif level >= 2 and level < 80 then
-        StepRun(level, plan, slots, owned, flags, disabledLevers)
+        StepRun(level, plan, slots, owned, flags, disabledLevers, catalog, wishlist)
     elseif level == 80 then
         -- A run is complete when the current rolled loadout reaches the
         -- server's 79-Echo capacity. Do not use an arbitrary no-board delay:
@@ -2136,11 +2149,11 @@ local function Step()
         -- Locked Echoes are not included in owned.total.
         local rolledTotal = tonumber(owned and owned.total) or 0
         if owned and owned.synced and rolledTotal >= 79 then
-            StepSave(level, plan, slots, owned)
+            StepSave(level, plan, slots, owned, catalog, wishlist)
         else
             local board = Adapter.Board()
             if board then
-                StepRun(level, plan, slots, owned, flags, disabledLevers)
+                StepRun(level, plan, slots, owned, flags, disabledLevers, catalog, wishlist)
             elseif Adapter.InFlight() then
                 SetStatus("finishing final Echo selections")
             else
@@ -2156,10 +2169,10 @@ end
 
 local function JournalData()
     local catalog = Adapter.Catalog()
-    local wishlist = Adapter.Wishlist()
+    local slots = Adapter.Slots()
+    local wishlist = Adapter.Wishlist(slots or false)
     local plan = Strategy.Compile(catalog, WishlistWithLockTargets(wishlist, catalog), Store.Settings())
     local owned = Adapter.Owned()
-    local slots = Adapter.Slots()
     local flags = EffectiveFlags()
     local disabledLevers = Adapter.DisabledLevers()
     local sections = {}
@@ -3225,7 +3238,13 @@ EH:SetScript("OnUpdate", function(_, elapsed)
     local now = GetTime()
     local isDirty = boardDirty or slotsDirty or dataDirty
     local deadlineDue = nextStepAt ~= nil and now >= nextStepAt
-    local fallbackDue = (now - lastFullStepAt) >= FALLBACK_RECOMPUTE
+    -- Missed-invalidation recovery is useful only while automation can still
+    -- act on a live run. Manual mode and completed level-80 characters are
+    -- fully event/deadline driven and must not rebuild an unchanged slot set.
+    local level = Adapter.Level()
+    local fallbackActive = autoEnabled and level >= 1 and level < 80
+    local fallbackDue = fallbackActive
+        and (now - lastFullStepAt) >= FALLBACK_RECOMPUTE
     if not (forceStep or isDirty or deadlineDue or fallbackDue) then
         recomputeStats.skipped = recomputeStats.skipped + 1
         return

--- a/core/Performance.lua
+++ b/core/Performance.lua
@@ -13,7 +13,9 @@ Nexus.Performance = Performance
 local PATH_ORDER = {
     "automation.step",
     "decision.policy",
+    "adapter.slots",
     "sync.update",
+    "sync.incoming",
     "dps.update",
     "community.refresh",
     "leaderboard.refresh",
@@ -194,6 +196,7 @@ function Performance.InstallDefaults()
     local targets = {
         {"decision.policy", Nexus.Policy, "Decide"},
         {"sync.update", Nexus.Sync, "OnUpdate"},
+        {"sync.incoming", Nexus.Sync, "HandleIncoming"},
         {"dps.update", Nexus.DpsCapture, "OnUpdate"},
         {"community.refresh", Nexus.CommunityBuilds, "Refresh"},
         {"leaderboard.refresh", Nexus.Leaderboard, "RefreshData"},

--- a/core/ViewProjections.lua
+++ b/core/ViewProjections.lua
@@ -286,8 +286,14 @@ local function PlayerKey(value)
     return tostring(value or "?"):lower():gsub("%s+", "")
 end
 
+local function CharacterKey(row)
+    if type(row) ~= "table" then return "?@unknown" end
+    return tostring(row.characterKey or row.ownerKey
+        or (PlayerKey(row.player) .. "@" .. tostring(row.realm or "unknown"))):lower()
+end
+
 local function RecordKey(row)
-    return PlayerKey(row and row.player)
+    return CharacterKey(row)
         .. "|" .. TypedIdentity(row and (row.fingerprint or row.buildId))
 end
 
@@ -307,7 +313,7 @@ local function CombinedRows()
     for _, row in ipairs(dummy) do
         dummyByKey[RecordKey(row)] = row
         if row.buildId then
-            dummyByBuild[PlayerKey(row.player) .. "|"
+            dummyByBuild[CharacterKey(row) .. "|"
                 .. TypedIdentity(row.buildId)] = row
         end
     end
@@ -315,7 +321,7 @@ local function CombinedRows()
     for _, lrow in ipairs(lk) do
         local drow = dummyByKey[RecordKey(lrow)]
         if not drow and lrow.buildId then
-            drow = dummyByBuild[PlayerKey(lrow.player)
+            drow = dummyByBuild[CharacterKey(lrow)
                 .. "|" .. TypedIdentity(lrow.buildId)]
         end
         if drow then
@@ -323,6 +329,9 @@ local function CombinedRows()
                 + (tonumber(lrow.dps) or 0)) / 2
             out[#out + 1] = {
                 player=lrow.player, dps=average, average=average,
+                displayPlayer=lrow.displayPlayer,
+                characterKey=CharacterKey(lrow), ownerKey=lrow.ownerKey,
+                realm=lrow.realm, realmAssumed=lrow.realmAssumed,
                 dummyDps=drow.dps, lkDps=lrow.dps,
                 dummyDuration=drow.duration, lkDuration=lrow.duration,
                 level=math.max(tonumber(drow.level) or 0,
@@ -336,6 +345,17 @@ local function CombinedRows()
                 build=lrow.build or drow.build,
             }
         end
+    end
+    local nameCounts = {}
+    for _, row in ipairs(out) do
+        local key = PlayerKey(row.player)
+        nameCounts[key] = (nameCounts[key] or 0) + 1
+    end
+    for _, row in ipairs(out) do
+        local key = PlayerKey(row.player)
+        row.displayPlayer = nameCounts[key] > 1
+            and (tostring(row.player or "?") .. "-" .. tostring(row.realm or "unknown"))
+            or row.player
     end
     counters.leaderboard.sorts = counters.leaderboard.sorts + 1
     table.sort(out, function(left, right)
@@ -355,7 +375,7 @@ local function LeaderboardProjection(filters)
         local classMatch = filters.classFilter == "ALL"
             or class == filters.classFilter
         local searchMatch = filters.search == ""
-            or tostring(row.player or ""):lower():find(filters.search, 1, true)
+            or tostring(row.displayPlayer or row.player or ""):lower():find(filters.search, 1, true)
             or tostring(build.title or ""):lower():find(filters.search, 1, true)
             or tostring(build.author or ""):lower():find(filters.search, 1, true)
         if classMatch and searchMatch then out[#out + 1] = DeepCopy(row) end

--- a/tests/run_dirty_recompute.lua
+++ b/tests/run_dirty_recompute.lua
@@ -77,12 +77,16 @@ assert(Nexus.Panel._lastModel.status == "status-only probe"
 -- An explicit user refresh authorizes exactly one full step on the next safe
 -- heartbeat; it does not bypass the direct tick or create a repeating task.
 local explicitBefore = Nexus.RecomputeStats()
+local explicitSlotReads = calls.slots
 assert(Nexus.RequestRecompute())
 H.Advance(0.2)
 local explicitAfter = Nexus.RecomputeStats()
 assert(explicitAfter.fullSteps == explicitBefore.fullSteps + 1
     and explicitAfter.forced == explicitBefore.forced + 1,
     "explicit refresh did not run exactly once on the next safe tick")
+assert(calls.slots == explicitSlotReads + 1,
+    "one full step materialized the server-slot payload more than once: before="
+        .. tostring(explicitSlotReads) .. " after=" .. tostring(calls.slots))
 H.Advance(0.2)
 assert(Nexus.RecomputeStats().fullSteps == explicitAfter.fullSteps,
     "explicit refresh leaked into a repeating recomputation")
@@ -112,19 +116,49 @@ assert(calls.panelRefresh == panelRefreshes + 1
     and Nexus.RecomputeStats().fullSteps == viewSteps,
     "revision burst failed to coalesce or entered automation")
 
--- A change with no hook is recovered only by the documented slow heartbeat.
-local beforeFallback = Nexus.RecomputeStats()
+-- Manual mode is fully reactive: a missed invalidation must not resurrect the
+-- expensive five-second heartbeat while the player is idle.
+local beforeManualIdle = Nexus.RecomputeStats()
+local manualSlotRequests = H.slotRequests or 0
 H.playerLevel = 6 -- intentionally bypass PLAYER_LEVEL_UP
+H.Advance(beforeManualIdle.fallbackSeconds + 0.5)
+assert(Nexus.RecomputeStats().fullSteps == beforeManualIdle.fullSteps,
+    "manual idle mode ran an unconditional fallback recomputation")
+assert((H.slotRequests or 0) == manualSlotRequests,
+    "manual idle mode continued requesting an unchanged server-slot payload")
+
+-- A concrete native build action schedules one settled refresh even though it
+-- bypasses the Adapter's own write helpers.
+assert(ProjectEbonhold.PerkService.ActivateServerBuildSlot(1))
+H.Advance(0.6)
+assert((H.slotRequests or 0) == manualSlotRequests + 1,
+    "native build action did not schedule one dynamic slot refresh")
+
+-- Active automation retains the slow self-healing heartbeat in case a client
+-- invalidation hook is missed during a live run.
+SlashCmdList.NEXUS("auto")
+H.Advance(0.2)
+local beforeFallback = Nexus.RecomputeStats()
+H.playerLevel = 7 -- intentionally bypass PLAYER_LEVEL_UP
 local remaining = beforeFallback.fallbackSeconds
     - (H.now - beforeFallback.lastFullStepAt)
 if remaining > 0.3 then H.Advance(remaining - 0.2) end
 assert(Nexus.RecomputeStats().fullSteps == beforeFallback.fullSteps,
-    "fallback recomputation ran before its slow heartbeat")
+    "active fallback recomputation ran before its slow heartbeat")
 H.Advance(0.3)
 local afterFallback = Nexus.RecomputeStats()
 assert(afterFallback.fullSteps == beforeFallback.fullSteps + 1
     and afterFallback.fallbacks == beforeFallback.fallbacks + 1,
-    "slow fallback did not self-heal a missed invalidation")
+    "active automation fallback did not self-heal a missed invalidation")
+
+-- A completed character has no recurring automation work; exact save/readback
+-- checks already schedule their own deadlines.
+H.playerLevel = 80
+local completedIdle = Nexus.RecomputeStats()
+H.Advance(completedIdle.fallbackSeconds + 0.5)
+assert(Nexus.RecomputeStats().fullSteps == completedIdle.fullSteps,
+    "level-80 idle mode ran an unconditional fallback recomputation")
+SlashCmdList.NEXUS("auto") -- restore manual mode for the next scenario
 
 -- The intent-to-action beat is an exact Main deadline: no dirty event is
 -- needed between showing the decision and issuing the safe action.
@@ -157,4 +191,4 @@ assert(#H.selectCalls == selectedBefore + 1
         .. " deadlines=" .. tostring(Nexus.RecomputeStats().deadlines - deadlinesBefore)
         .. " full=" .. tostring(Nexus.RecomputeStats().fullSteps))
 
-print("dirty, deadline, status, burst, fallback, and direct safety-poll recomputation -- OK")
+print("dirty, deadline, status, dynamic fallback, slot snapshot, and safety poll -- OK")

--- a/tests/run_dps_auto_build.lua
+++ b/tests/run_dps_auto_build.lua
@@ -39,7 +39,7 @@ assert(build.evidenceKey and NexusDB.loadoutEvidence
     and NexusDB.loadoutEvidence.entries[build.evidenceKey],
     "automatic page did not dual-write exact evidence")
 assert(NexusDB.dpsCapture.personalBest[fp].dummy.evidenceKey
-    and NexusDB.dpsCapture.characterBest.dummy.recordmage.evidenceKey,
+    and NexusDB.dpsCapture.characterBest.dummy["recordmage@ebonhold"].evidenceKey,
     "personal/public DPS rows did not dual-write exact evidence")
 local lb=DPS.GetLeaderboard(buildId,"dummy")
 assert(#lb==1 and lb[1].dps==24000000 and lb[1].player=="Recordmage", "captured personal best should become the public build record")

--- a/tests/run_dps_realm_identity.lua
+++ b/tests/run_dps_realm_identity.lua
@@ -1,0 +1,114 @@
+-- Realm-qualified DPS identity migration and presentation regression coverage.
+local H=dofile("tests/harness.lua")
+dofile("core/Codec.lua"); dofile("core/Sync.lua"); dofile("core/DpsCapture.lua")
+
+local DPS=Nexus.DpsCapture
+GetNormalizedRealmName=function() return "Rogue-Lite (Live)" end
+UnitName=function(unit) return unit=="player" and "Twin" or nil end
+UnitClass=function() return "Mage", "MAGE" end
+time=function() return 1000 end
+
+local currentOld={{spellId=200201,stacks=1}}
+local currentNew={{spellId=200202,stacks=2}}
+local future={{spellId=200203,stacks=3}}
+local currentOldFp=DPS.GetEchoKey(currentOld)
+local currentNewFp=DPS.GetEchoKey(currentNew)
+local futureFp=DPS.GetEchoKey(future)
+
+local function Row(player,realm,ownerKey,ts,dps,echoes,fingerprint,locked)
+    return {
+        player=player,realm=realm,ownerKey=ownerKey,ts=ts,dps=dps,
+        duration=65,level=80,class="MAGE",echoes=echoes,
+        fingerprint=fingerprint,lockedEchoes=locked,
+    }
+end
+
+NexusDB={communityBuilds={},syncTombstones={},dpsCapture={
+    characterBest={
+        dummy={
+            ["Twin@Rogue-Lite (Live)"]=Row("Twin","Rogue-Lite (Live)","twin@roguelite(live)",
+                100,30000000,currentOld,currentOldFp,{{spellId=200299,stacks=1}}),
+            ["twin"]=Row("Twin",nil,nil,
+                200,20000000,currentNew,currentNewFp,nil),
+            ["twin@future"]=Row("Twin","future","twin@future",
+                150,25000000,future,futureFp,{{spellId=200298,stacks=1}}),
+        },
+        lk={
+            ["twin"]=Row("Twin",nil,nil,
+                210,19000000,currentNew,currentNewFp,nil),
+            ["twin@future"]=Row("Twin","future","twin@future",
+                160,18000000,future,futureFp,nil),
+            ["Tie@Rogue-Lite (Live)"]=Row("Tie","Rogue-Lite (Live)","tie@rogue-lite(live)",
+                300,10000000,currentOld,currentOldFp,nil),
+            ["tie"]=Row("Tie",nil,nil,
+                300,11000000,currentNew,currentNewFp,nil),
+        },
+    },
+}}
+
+local adapter={LockedOwned=function()
+    return {bySpell={[200297]=1}}
+end}
+DPS.Init(adapter,nil)
+
+local store=NexusDB.dpsCapture.characterBest
+assert(store.dummy["twin"]==nil and store.dummy["Twin@Rogue-Lite (Live)"]==nil,
+    "legacy/original-case keys survived canonical migration")
+local current=store.dummy["twin@roguelitelive"]
+assert(current and current.ts==200 and current.dps==20000000,
+    "newest duplicate did not win realm identity migration")
+assert(current.ownerKey=="twin@roguelitelive" and current.realm=="roguelitelive"
+    and current.characterKey=="twin@roguelitelive" and current.realmAssumed==true,
+    "legacy row did not receive hidden assumed-realm metadata")
+assert(store.dummy["twin@future"] and store.dummy["twin@future"].realmAssumed==false,
+    "explicit future realm was collapsed or marked assumed")
+assert(store.lk["tie@roguelitelive"] and store.lk["tie@roguelitelive"].dps==11000000,
+    "equal-timestamp duplicate tie did not prefer higher DPS")
+
+local dummy=DPS.GetDpsBoard("dummy")
+assert(#dummy==2,"future realm identities did not remain distinct")
+local sawCurrent,sawFuture=false,false
+for _,row in ipairs(dummy) do
+    assert(row.displayPlayer=="Twin-"..row.realm,
+        "same-name cross-realm row was not visibly qualified")
+    if row.characterKey=="twin@roguelitelive" then
+        sawCurrent=true
+        assert(row.lockedEchoes and row.lockedEchoes[1].spellId==200297,
+            "current-realm locked Echoes were not backfilled")
+    elseif row.characterKey=="twin@future" then
+        sawFuture=true
+        assert(row.lockedEchoes and row.lockedEchoes[1].spellId==200298,
+            "locked Echo backfill mutated the other realm")
+    end
+end
+assert(sawCurrent and sawFuture,"realm-qualified board identities missing")
+
+-- Older, weaker Sync evidence resolves to the current realm but cannot
+-- recreate a second key or replace the selected public row.
+assert(not DPS.ReceiveRecord({v=7,f=currentOldFp,e=currentOld,c="dummy",
+    d=15000000,u=65,t=50,p="Twin",k="MAGE",l=80}),
+    "older weaker realm-less Sync record was accepted")
+assert(store.dummy["twin"]==nil and store.dummy["twin@roguelitelive"]==current,
+    "Sync recreated a legacy duplicate key")
+
+-- Re-loading the module over the migrated SavedVariables is idempotent.
+dofile("core/DpsCapture.lua")
+DPS=Nexus.DpsCapture
+DPS.Init(adapter,nil)
+store=NexusDB.dpsCapture.characterBest
+assert(store.dummy["twin@roguelitelive"] and store.dummy["twin@future"]
+    and store.dummy["twin@roguelitelive"].realmAssumed==true
+    and store.dummy["twin"]==nil,
+    "realm identity migration was not reload-idempotent")
+
+dofile("core/ViewProjections.lua")
+local combined=Nexus.ViewProjections.Leaderboard("combined",{})
+assert(#combined==2,"Combined board cross-paired or collapsed realm identities")
+for _,row in ipairs(combined) do
+    assert(row.characterKey=="twin@roguelitelive" or row.characterKey=="twin@future",
+        "Combined board lost canonical realm identity")
+    assert(row.displayPlayer=="Twin-"..row.realm,
+        "Combined board did not qualify same-name realm collision")
+end
+
+print("realm-qualified DPS migration, Sync, locked metadata, reload, and presentation -- OK")

--- a/tests/run_leaderboard_virtualization.lua
+++ b/tests/run_leaderboard_virtualization.lua
@@ -13,10 +13,12 @@ for index=1,150 do
     local build={id=buildId,title=string.format("Ranked Build %03d",index),author=player,class=class}
     boards.dummy[index]={player=player,dps=30000000-index*1000,duration=60,level=80,ts=index,
         category="dummy",fingerprint=fingerprint,buildId=buildId,echoes=echoes,
-        lockedEchoes=locked,build=build}
+        lockedEchoes=locked,build=build,realm="ebonhold",
+        characterKey=string.format("player%03d@ebonhold",index)}
     boards.lk[index]={player=player,dps=28000000-index*1000,duration=90,level=80,ts=index,
         category="lk",fingerprint=fingerprint,buildId=buildId,echoes=echoes,
-        lockedEchoes=locked,build=build}
+        lockedEchoes=locked,build=build,realm="ebonhold",
+        characterKey=string.format("player%03d@ebonhold",index)}
 end
 
 local boardReads=0
@@ -97,7 +99,7 @@ assert(ending.last==150 and ending.created<=7
     "scrolling rebuilt data or grew an unbounded row pool")
 
 -- Stable-key selection survives offscreen scrolling and a data revision.
-local selectedKey="player080|string:fp-080"
+local selectedKey="player080@ebonhold|string:fp-080"
 assert(L.SelectKey(selectedKey),"stable Leaderboard key was not selectable")
 L.ScrollTo((80-1)*40)
 assert(L.VirtualStats().selectedVisible,"selected rank did not show its highlight")

--- a/tests/run_loadout_evidence.lua
+++ b/tests/run_loadout_evidence.lua
@@ -231,7 +231,7 @@ assert(DPS.ReceiveRecord({
 }, "Peer"))
 assert(Revisions.Get(Revisions.DPS_CHANGED) == beforeDpsRevision + 1,
     "one evidence-backed DPS winner did not retain one DPS revision")
-local storedRow = NexusDB.dpsCapture.characterBest.dummy.peer
+local storedRow = NexusDB.dpsCapture.characterBest.dummy["peer@ebonhold"]
 assert(storedRow.evidenceKey and not Catalog.Get("missing-page"),
     "missing-page DPS fixture unexpectedly gained a catalog row")
 storedRow.echoes = nil

--- a/tests/run_performance_diagnostics.lua
+++ b/tests/run_performance_diagnostics.lua
@@ -4,8 +4,8 @@ local H = dofile("tests/harness.lua")
 local Performance = Nexus.Performance
 
 local definitions = Performance.Definitions()
-assert(#definitions == 8 and definitions[1] == "automation.step"
-    and definitions[8] == "overlay.refresh",
+assert(#definitions == 10 and definitions[1] == "automation.step"
+    and definitions[10] == "overlay.refresh",
     "performance path registry is not fixed and ordered")
 
 Performance.Reset()
@@ -179,6 +179,7 @@ H.FireEvent("ADDON_LOADED", "Nexus")
 H.FireEvent("SPELLS_CHANGED")
 H.FireEvent("PLAYER_ENTERING_WORLD")
 H.Advance(1)
+Nexus.Sync.HandleIncoming("bad", "Peer")
 
 local malformedDecision = Nexus.Policy.Decide(nil)
 assert(type(malformedDecision) == "table" and malformedDecision.type == "wait"
@@ -190,8 +191,8 @@ assert(Nexus.CommunityBuilds.Refresh("community") == "community"
     and optionalCalls.community == 1 and optionalCalls.leaderboard == 1
     and optionalCalls.overlay == 1,
     "installed optional UI instrumentation changed callback behavior")
-for _, name in ipairs({"automation.step", "decision.policy", "sync.update",
-    "dps.update", "community.refresh", "leaderboard.refresh",
+for _, name in ipairs({"automation.step", "decision.policy", "adapter.slots",
+    "sync.update", "sync.incoming", "dps.update", "community.refresh", "leaderboard.refresh",
     "panel.render", "overlay.refresh"}) do
     assert(Performance.Stats(name).count > 0,
         "real instrumentation did not observe " .. name)
@@ -246,7 +247,10 @@ assert(exportText:find("NEXUS_DIAGNOSTIC_LOG_5", 1, true)
     and exportText:find("END|boards=1", 1, true)
     and performanceRows == #Performance.Definitions()
     and exportText == exportTextAgain,
-    "aggregate-only export section is missing or prior export sections changed")
+    "aggregate-only export section is missing or prior export sections changed: rows="
+        .. tostring(performanceRows) .. "/" .. tostring(#Performance.Definitions())
+        .. " stable=" .. tostring(exportText == exportTextAgain)
+        .. " paths=" .. tostring(exportText:find("|automation.step", 1, true) ~= nil))
 assert(NexusDB.performance == nil and NexusDB.performanceHistory == nil,
     "performance diagnostics leaked into SavedVariables")
 print("real hot paths, log view, reset isolation, export, SavedVariables safety -- OK")

--- a/ui/CommunityBuilds.lua
+++ b/ui/CommunityBuilds.lua
@@ -347,7 +347,7 @@ local function DpsBoardRows(category)
         local classMatch = not classFilter
             or (build.class or row.class or ""):upper() == classFilter
         local searchMatch = search == ""
-            or tostring(row.player or ""):lower():find(search, 1, true)
+            or tostring(row.displayPlayer or row.player or ""):lower():find(search, 1, true)
             or tostring(build.title or ""):lower():find(search, 1, true)
             or tostring(build.author or ""):lower():find(search, 1, true)
         if classMatch and searchMatch then out[#out + 1] = row end

--- a/ui/Leaderboard.lua
+++ b/ui/Leaderboard.lua
@@ -77,10 +77,16 @@ local function PlayerKey(v)
     return tostring(v or "?"):lower():gsub("%s+", "")
 end
 
+local function CharacterKey(row)
+    if type(row) ~= "table" then return "?@unknown" end
+    return tostring(row.characterKey or row.ownerKey
+        or (PlayerKey(row.player) .. "@" .. tostring(row.realm or "unknown"))):lower()
+end
+
 local function RecordKey(row)
     if not row then return "" end
     local identity = row.fingerprint or row.buildId
-    return PlayerKey(row.player) .. "|" .. type(identity) .. ":"
+    return CharacterKey(row) .. "|" .. type(identity) .. ":"
         .. tostring(identity or "")
 end
 
@@ -97,7 +103,7 @@ local function CombinedRows()
     for _, row in ipairs(dummy) do
         dummyByKey[RecordKey(row)] = row
         if row.buildId then
-            dummyByBuild[PlayerKey(row.player).."|"..type(row.buildId)
+            dummyByBuild[CharacterKey(row).."|"..type(row.buildId)
                 ..":"..tostring(row.buildId)] = row
         end
     end
@@ -105,13 +111,16 @@ local function CombinedRows()
     for _, lrow in ipairs(lk) do
         local drow = dummyByKey[RecordKey(lrow)]
         if not drow and lrow.buildId then
-            drow = dummyByBuild[PlayerKey(lrow.player).."|"..type(lrow.buildId)
+            drow = dummyByBuild[CharacterKey(lrow).."|"..type(lrow.buildId)
                 ..":"..tostring(lrow.buildId)]
         end
         if drow then
             local avg = ((tonumber(drow.dps) or 0) + (tonumber(lrow.dps) or 0)) / 2
             out[#out+1] = {
-                player=lrow.player, dps=avg, average=avg, dummyDps=drow.dps, lkDps=lrow.dps,
+                player=lrow.player, displayPlayer=lrow.displayPlayer,
+                characterKey=CharacterKey(lrow), ownerKey=lrow.ownerKey,
+                realm=lrow.realm, realmAssumed=lrow.realmAssumed,
+                dps=avg, average=avg, dummyDps=drow.dps, lkDps=lrow.dps,
                 dummyDuration=drow.duration, lkDuration=lrow.duration,
                 level=math.max(tonumber(drow.level) or 0, tonumber(lrow.level) or 0),
                 ts=math.min(tonumber(drow.ts) or 0, tonumber(lrow.ts) or 0),
@@ -120,6 +129,17 @@ local function CombinedRows()
                 buildId=lrow.buildId or drow.buildId, build=lrow.build or drow.build,
             }
         end
+    end
+    local nameCounts = {}
+    for _, row in ipairs(out) do
+        local key = PlayerKey(row.player)
+        nameCounts[key] = (nameCounts[key] or 0) + 1
+    end
+    for _, row in ipairs(out) do
+        local key = PlayerKey(row.player)
+        row.displayPlayer = nameCounts[key] > 1
+            and (tostring(row.player or "?") .. "-" .. tostring(row.realm or "unknown"))
+            or row.player
     end
     table.sort(out,function(a,b)
         if a.average ~= b.average then return a.average > b.average end
@@ -145,7 +165,7 @@ local function Rows()
         local class = tostring(build.class or row.class or "UNKNOWN"):upper()
         local classOk = classFilter == "ALL" or class == classFilter
         local searchOk = query == ""
-            or tostring(row.player or ""):lower():find(query,1,true)
+            or tostring(row.displayPlayer or row.player or ""):lower():find(query,1,true)
             or tostring(build.title or ""):lower():find(query,1,true)
             or tostring(build.author or ""):lower():find(query,1,true)
         if classOk and searchOk then out[#out+1] = row end
@@ -279,7 +299,7 @@ local function EnsureDetail(parent)
         local b = row.build or {}
         M.Hide()
         Nexus.WishlistEditor.OpenForCandidate({
-            title = b.title or (row.player and (tostring(row.player) .. "'s Loadout")) or "Leaderboard Build",
+            title = b.title or (row.player and (tostring(row.displayPlayer or row.player) .. "'s Loadout")) or "Leaderboard Build",
             echoes = echoes,
         })
     end)
@@ -301,7 +321,7 @@ local function RenderDetail(row)
     detail.empty:Hide()
     for _,x in ipairs({detail.title,detail.owner,detail.record,detail.desc,detail.echoTitle,detail.more,detail.copy,detail.open}) do x:Show() end
     local b=row.build or {}; local c=CLASS_COLOR[tostring(b.class or ""):upper()] or {1,1,1}
-    detail.title:SetText(b.title or "Record Loadout"); detail.title:SetTextColor(c[1],c[2],c[3]); detail.owner:SetText("by "..tostring(b.author or row.player or "?"))
+    detail.title:SetText(b.title or "Record Loadout"); detail.title:SetTextColor(c[1],c[2],c[3]); detail.owner:SetText("by "..tostring(row.displayPlayer or b.author or row.player or "?"))
     if row.category=="combined" then
         detail.record:SetText("|cff4dff80Average "..DpsText(row.average).." DPS|r\nDummy "..DpsText(row.dummyDps).."  •  Lich King "..DpsText(row.lkDps))
     else
@@ -351,7 +371,7 @@ local function BindRows(reason)
             local c=CLASS_COLOR[class] or {0.8,0.8,0.8}
             r.rank:SetText(index<=3 and "|cffffd200"..index.."|r" or tostring(index))
             r.icon:SetTexture(CLASS_ICON[class] or "Interface\\Icons\\INV_Misc_QuestionMark")
-            r.player:SetText(tostring(row.player or "?"))
+            r.player:SetText(tostring(row.displayPlayer or row.player or "?"))
             r.player:SetTextColor(c[1],c[2],c[3])
             r.build:SetText(tostring((row.build or {}).title or "Record Loadout"))
             if category=="combined" then


### PR DESCRIPTION
## Summary

- store and project DPS character identity through a hidden normalized `name@realm` key
- migrate legacy name-only rows onto the current realm and reconcile collisions by newest timestamp, then DPS and fingerprint
- keep explicitly different realms distinct and qualify their visible names only when a same-name collision exists
- prevent Sync from recreating legacy duplicate keys and keep Dummy, Lich King, and Combined projections realm-consistent
- replace idle five-second server-slot polling/full recomputation with event-driven one-shot refreshes
- materialize server slots once per full step and add slot/incoming-Sync performance diagnostics

## Identity decision

The active product currently has one realm, so a realm-less historical row is assigned to the current realm during migration. This intentionally resolves the ambiguity raised in #19 using the deployed server topology. Realm remains hidden identity metadata, and records carrying explicitly different realm evidence remain separate so the storage and UI are ready for a future multi-realm environment.

Duplicate migration is recency-based only while reconciling durable rows that resolve to the same identity. Normal capture and Sync replacement remain best-DPS based.

## Validation

- `tests/run_dps_realm_identity.lua`
- `tests/run_dirty_recompute.lua`
- `tests/run_dps_auto_build.lua`
- `tests/run_leaderboard_virtualization.lua`
- `tests/run_loadout_evidence.lua`
- `tests/run_performance_diagnostics.lua`
- `tests/run_dps_boards.lua`
- `tests/run_sync_hash_cache.lua`

All affected suites pass in the portable Lua harness.

An actual August 14 SavedVariables snapshot was also merged into the current test profile: 141 Dummy and 144 Lich King historical rows. The fixture contained an older name-only Ogie result at 2,708,723 DPS and a newer `ogie@roguelitelive` result at 797,435 DPS. Migration retained the newer row and displayed exactly one Ogie. A live playtest also confirmed one new Dummy result and no recurring two-to-five-second hitch after settling.

Closes #19.
