### PR TITLE
Fix UTF-8-safe diagnostic history truncation

### DIFF
--- a/core/DiagnosticHistory.lua
+++ b/core/DiagnosticHistory.lua
@@ -28,7 +28,14 @@ function DiagnosticHistory.SafeText(value, maxBytes)
     local ok, text = pcall(tostring, value)
     if not ok then text = "<unprintable:" .. type(value) .. ">" end
     text = tostring(text or ""):gsub("[%c]", " ")
-    if #text > maxBytes then text = text:sub(1, maxBytes) end
+    if #text > maxBytes then
+        -- Preserve the established raw byte-prefix policy for already-invalid
+        -- input. Valid UTF-8 must never become invalid through truncation.
+        local Identity = Nexus.Identity
+        local prefix = Identity and Identity.TruncateUtf8Bytes
+            and Identity.TruncateUtf8Bytes(text, maxBytes)
+        text = prefix or text:sub(1, maxBytes)
+    end
     return text
 end
 

--- a/core/Identity.lua
+++ b/core/Identity.lua
@@ -85,6 +85,21 @@ function Identity.ValidUtf8(value)
     return Decode(value)
 end
 
+function Identity.TruncateUtf8Bytes(text, maxBytes)
+    if type(text) ~= "string" or not Identity.ValidUtf8(text) then return nil end
+    local limit = tonumber(maxBytes) or #text
+    if #text <= limit then return text end
+    local start = limit
+    while start > 0 and text:byte(start) >= 0x80
+        and text:byte(start) <= 0xBF do start = start - 1 end
+    local width = text:byte(start) and (text:byte(start) < 0x80 and 1
+        or text:byte(start) < 0xE0 and 2
+        or text:byte(start) < 0xF0 and 3 or 4) or 0
+    local last = start + width - 1 <= limit and start + width - 1
+        or start - 1
+    return text:sub(1, math.max(0, last))
+end
+
 function Identity.ValidDisplayText(value, maxBytes, allowEmpty, allowLineBreaks)
     return type(value) == "string"
         and (allowEmpty or value ~= "")
@@ -528,14 +543,5 @@ function Identity.SanitizeText(value, maxBytes)
         :gsub("^%s+", ""):gsub("%s+$", "")
     if not SafeSequence(text, true) then return "invalid" end
     local limit = tonumber(maxBytes) or 96
-    if #text <= limit then return text end
-    local start = limit
-    while start > 0 and text:byte(start) >= 0x80
-        and text:byte(start) <= 0xBF do start = start - 1 end
-    local width = text:byte(start) and (text:byte(start) < 0x80 and 1
-        or text:byte(start) < 0xE0 and 2
-        or text:byte(start) < 0xF0 and 3 or 4) or 0
-    local last = start + width - 1 <= limit and start + width - 1
-        or start - 1
-    return text:sub(1, math.max(0, last))
+    return Identity.TruncateUtf8Bytes(text, limit)
 end

--- a/tests/run_diagnostic_history.lua
+++ b/tests/run_diagnostic_history.lua
@@ -44,6 +44,44 @@ assert(safe == "<unprintable:table>", "hostile tostring was not isolated")
 local bounded = DiagnosticHistory.SafeText("line\n" .. string.rep("x", 40), 16)
 assert(#bounded == 16 and not bounded:find("[%c]"),
     "diagnostic text was not control-safe and byte-bounded")
+
+local twoByte = string.char(0xC3, 0xA9)
+local threeByte = string.char(0xE2, 0x82, 0xAC)
+local fourByte = string.char(0xF0, 0x9F, 0x98, 0x80)
+local utf8Cases = {
+    {"ASCII below limit", "abc", 4, "abc"},
+    {"ASCII at limit", "abcd", 4, "abcd"},
+    {"ASCII above limit", "abcde", 4, "abcd"},
+    {"two-byte split", "A" .. twoByte, 2, "A"},
+    {"three-byte split", "A" .. threeByte, 3, "A"},
+    {"four-byte split", "A" .. fourByte, 4, "A"},
+    {"complete multibyte boundary", twoByte .. twoByte, 4,
+        twoByte .. twoByte},
+}
+for _, case in ipairs(utf8Cases) do
+    local actual = DiagnosticHistory.SafeText(case[2], case[3])
+    assert(actual == case[4], case[1] .. " truncation was wrong")
+    assert(#actual <= case[3], case[1] .. " exceeded its byte limit")
+    assert(Nexus.Identity.ValidUtf8(actual),
+        case[1] .. " produced invalid UTF-8 from valid input")
+end
+local controlUtf8 = DiagnosticHistory.SafeText("A\n" .. twoByte, 4)
+assert(controlUtf8 == "A " .. twoByte,
+    "UTF-8 truncation changed control-character replacement")
+assert(DiagnosticHistory.Format(3, "A%s", threeByte) == "A",
+    "DiagnosticHistory.Format did not inherit UTF-8-safe truncation")
+local invalidUtf8 = "A" .. string.char(0x80) .. "B"
+assert(DiagnosticHistory.SafeText(invalidUtf8, 2) == invalidUtf8:sub(1, 2),
+    "already-invalid diagnostic input changed its raw byte-prefix policy")
+local utf8History = DiagnosticHistory.New({cap=2, trimAt=4, maxTextBytes=4})
+utf8History.Append({text=threeByte .. threeByte})
+local firstUtf8Snapshot = utf8History.Snapshot()
+local secondUtf8Snapshot = utf8History.Snapshot()
+assert(firstUtf8Snapshot[1].text == threeByte
+    and secondUtf8Snapshot[1].text == threeByte
+    and #secondUtf8Snapshot[1].text <= 4
+    and Nexus.Identity.ValidUtf8(secondUtf8Snapshot[1].text),
+    "diagnostic snapshots were not UTF-8-safe, bounded, and deterministic")
 assert(DiagnosticHistory.Format(16, "%d", "not-a-number") == "%d",
     "failed diagnostic formatting was not isolated deterministically")
 history.Clear()


### PR DESCRIPTION
## Summary

Fixes diagnostic byte truncation that could split a valid multibyte UTF-8 codepoint and retain malformed text.

The change extracts the existing UTF-8 boundary logic from `Identity.SanitizeText` into `Identity.TruncateUtf8Bytes`. `DiagnosticHistory.SafeText` now uses that helper when truncating valid UTF-8.

Already-invalid input retains the previous raw byte-prefix behavior.

Refs #36.

This is a draft stacked PR based on `bugfix/test19-wp3-realm-persistence`. It is intended for source review and exact-head CI. It should not be merged into WP3 yet.

## Scope

Changed:

- `core/Identity.lua`
  - Adds a shared UTF-8 byte-boundary helper.
  - Reuses it from `Identity.SanitizeText`.
- `core/DiagnosticHistory.lua`
  - Prevents valid diagnostic text from being cut inside a UTF-8 codepoint.
- `tests/run_diagnostic_history.lua`
  - Adds ASCII, two-byte, three-byte, four-byte, control, formatting, invalid-input, and snapshot coverage.

Intentionally unchanged:

- character and owner primary keys;
- gameplay state;
- Sync text validation and wire behavior;
- diagnostic retention limits;
- SavedVariables and migrations;
- automation, Wishlist, DPS, and Community behavior;
- addon metadata and packaging.

Character keys continue to use `PlayerKey`, `OwnerKey`, `CanonicalOwnerKey`, and ASCII-only case folding. They do not call the new truncation helper.

## Validation

Expected red before the fix:

```text
tests/run_diagnostic_history.lua:63:
two-byte split truncation was wrong
```

Focused validation after the fix:

- diagnostic history runner: PASS;
- Identity UTF-8 runner: PASS;
- diagnostic overflow: PASS;
- durable diagnostic history: PASS;
- diagnostic identity: PASS;
- performance diagnostics: PASS;
- main diagnostics parity: PASS;
- installed Lua 5.1 parse and focused UTF-8 probe: PASS.

Fast gate:

```text
passed=11 failed=0 unavailable=0 skipped=0
```

Full gate:

```text
blocking checks: 18 passed, 0 failed
Lua suite: 215/215
Lua 5.1 parse: 288/288
integration: 70/70
```

One nonblocking manual legacy-backup test was skipped because it requires an explicitly authorized SavedVariables backup. It is unrelated to this diagnostic-only change.

Full ran on commit `bcefd6a`. Signed head `e4f36f1` has the identical tested tree:

```text
4814ae026a592f54600fdb5910d48ad08632fa0f
```

## Risk

Compatibility risk is low.

- Existing ASCII behavior is unchanged.
- Valid UTF-8 remains byte-bounded and valid.
- Already-invalid input keeps the old raw byte-prefix policy.
- Control-character replacement is unchanged.
- `Identity.SanitizeText` uses the same truncation algorithm as before.
- Character primary keys do not use either sanitization path.
- No schema, migration, SavedVariables, wire, or retention change is included.
- The helper adds a bounded UTF-8 scan only on diagnostic and peer-debug text.
- Rollback requires reverting one product/test commit.

## Native testing

The exact proposed branch head was not installed as a complete addon package.

The equivalent two-file patch was applied to the installed `test.18-d9b48c5` addon and tested in WoW 3.3.5a / Project Ebonhold.

Results:

- two-byte split probe: PASS;
- three-byte split probe: PASS;
- four-byte split probe: PASS;
- control replacement probe: PASS;
- Log Viewer remained responsive;
- copied diagnostic output was strict valid UTF-8;
- replacement characters: 0;
- structured errors: 0.

The remaining native boundary is running the complete exact proposed branch head as an installed package.

## Confirmation

- [x] The PR contains no unrelated changes.
- [x] Lua changes remain compatible with Lua 5.1.
- [x] `NexusDB` and `WishlistRealizerDB` compatibility is preserved.
- [x] No packages, SavedVariables, private logs, AI transcripts, or transient artifacts are included.
- [ ] Published or exact-SHA-reviewed history was not rewritten.

The final box remains unchecked because the unreviewed fork-only commit `bcefd6a` was replaced before opening this draft so the contributor commit could be signed. The replacement has identical source and test bytes. No upstream or reviewed branch history was rewritten.
