### PR TITLE
WP6: Build hash buckets erase build-ID type and can report false Sync convergence

### DIFF
--- a/.vibe/CONTEXT.md
+++ b/.vibe/CONTEXT.md
@@ -2,67 +2,43 @@
 
 ## Architecture
 
-- WP5 runs on `bugfix/test19-wp5-historical-dps-authority-and-real-paired-summari` from accepted WP4 handoff `e70de8a7582d0146cc6746677084b3f4a270290b`; Stage 48 product/test bytes are frozen.
-- Historical DPS capture and locked evidence flow through `core/DpsCapture.lua` and `core/CandidateEvidence.lua`; current/build relation and copy decisions cross `core/CommunityController.lua` and Community/Sync ingress.
-- DPS qualification and summary consumers span `core/CommunityController.lua`, `core/CommunityProjection.lua`, `core/DataRetention.lua`, `ui/Leaderboard.lua`, and view/DPS-board runners. WP5 must centralize the real-pair metric.
-- WP4 is isolated in `.test19-wp4-worktree` on `bugfix/test19-wp4-exact-wishlist-evidence`, based exactly on frozen WP3 head `e674f033cc51494a382191b987c9a99cb6827f4a`.
-- Wishlist draft flow is `core/WishlistModel.lua` -> `core/WishlistController.lua` -> `ui/WishlistEditor.lua` / `ui/WishlistRenderer.lua`; EBH1 transfer passes through `core/Codec.lua`.
-- Typed record evidence is owned by `core/CandidateEvidence.lua`; live active/locked reads and Wishlist association are behind `core/GameAdapter.lua` and `core/LoadoutEvidence.lua`.
-- Progress and automation decisions flow through `logic/Model.lua` -> `logic/Policy.lua` -> `logic/Ratchet.lua` -> GameAdapter; `ui/WishlistOverlay.lua` must consume the same exact progress authority.
+- WP6 runs on `bugfix/test19-wp6-build-hash-buckets-erase-build-id-type-and-can-r` from accepted WP5 head `8f5d28008935cef2d973b800167695ab50e0f70b`.
+- `core/BuildCatalog.lua` preserves exact typed build IDs. `core/BuildHashCache.lua` owns the eight-bucket delta and legacy canonical build/tombstone material consumed by Sync compatibility hashes.
+- `core/SyncCompatibility.lua`, `core/SyncReconciler.lua`, and `core/Sync.lua` decide whether matching bucket hashes can skip reconciliation.
 - Runtime targets WoW 3.3.5a and Lua 5.1. `tools/Invoke-QualityGate.ps1` owns Fast/Full/Package/Security validation.
 
-## Key Decisions (2026-08-21)
+## Key Decisions (2026-08-22)
 
-- WP5 decision (2026-08-22): capture-time Dummy/LK locked snapshots are immutable history; exact independently proven current/build association alone grants copy authority.
-- WP5 decision (2026-08-22): a paired Average requires verified canonical owner, ordinary fingerprint, and locked full-combat identity equality; independent category bests remain available without a pair.
-- WP5 decision (2026-08-22): category, timestamp, recency, title, short name, and resemblance are never authority or tie-break inputs; one deterministic real-pair metric feeds Community, Leaderboard, retention, and sorting.
-- Execute WP4 in order: #43 exact ordinary draft identity -> #44 counted locked evidence -> #20 read-time role derivation -> #35 exact progress.
-- Trustworthy exact `spellId` owns ordinary draft rows. Family is display/search grouping only; compatibility rows need deterministic collision-safe fallback identity.
-- Locked validation uses total copies `sum(stacks) <= 6`, preserving exact tier, count, provenance, and unknown fields; ordinary and locked limits remain separate.
-- #20 derives `exact active total - authoritative exact locked counts = exact ordinary counts` without rewriting active, Snapshot, Designed, or historical evidence. Partial, stale, ambiguous, or underflow inputs fail closed.
-- #35 must share one exact-tier progress boundary across model, policy/ratchet, editor, HUD, and overlay; family possession never satisfies a sibling tier.
-- Freeze product/test/workflow bytes, complete independent Spec/Standards/adversarial review, then run one final Full. Any governed-byte repair after Full requires another Full.
+- Encode raw ID type at the existing BuildHashCache canonical-material boundary; do not coerce BuildCatalog identities or change the eight-bucket layout.
+- Apply one typed identity rule to build and tombstone entries in both delta and legacy modes.
+- Prove deterministic ordering, targeted/full invalidation, reconciliation, and mixed-client behavior before accepting the candidate.
+- Preserve protocol, release metadata, Test 18, and accepted WP5 behavior.
 
 ## Gotchas
 
-- Existing average semantics occur in `CommunityController`, `DataRetention`, and view projection paths; changing only the visible Leaderboard leaves qualification, retention, or sorting inconsistent.
-- WP5 must not globally change the ordinary fingerprint; pair identity adds verified owner and locked/full-combat equality at the DPS boundary.
-- Preserve original historical tables and nested locked rows across missing/conflicting authority, reload, restart, and Sync. Unavailable copy authority must not mark an uncertain Echo locked.
+- `BuildEntry`, `TombstoneEntry`, and cache entry keys currently use `tostring(id)`; numeric `1` and string `"1"` can collide even though Lua tables and BuildCatalog distinguish them.
+- Delta and legacy caches share helpers, and targeted invalidation must update both without a full collection walk.
+- A digest change can affect mixed-version peers. Compatibility must prevent permanent false equality without widening the wire/protocol scope unnecessarily.
 - Root and `.lag-hotfix-worktree` contain unrelated user changes. Earlier WP2/WP3 worktrees are frozen and must not be edited, rebased, cleaned, stashed, or deleted.
-- Vibe flags and routing are dispatcher-owned. The Stage 48 maintenance scan/review/hygiene is complete and deliberately left product checkpoint 48.1 `NOT_STARTED`.
-- Current draft code repeatedly uses `family` as the map/action handle; change the handle explicitly before switching ordinary identity so sibling actions cannot alias.
-- CandidateEvidence currently limits locked row count and rejects duplicate spell identities; WP4 must validate counted copies and preserve legitimate exact counted evidence instead.
-- GameAdapter locked reads already produce `bySpell` counts. Do not infer count one from row presence or derive roles from title, short hash/name, family, slot proximity, or approximate similarity.
 - LuaLS, Luacheck, and StyLua may remain advisory-unavailable and must not be reported as passes. Offline checks do not prove native WoW behavior.
 
 ## Hot Files
 
-- WP5 #23: `core/CandidateEvidence.lua`, `core/DpsCapture.lua`, `core/CommunityController.lua`, `core/CommunityProjection.lua`, Sync relation paths, `tests/run_locked_evidence_resolver.lua`, and `tests/run_stage32_leaderboard_locked_fidelity.lua`.
-- WP5 #26: the shared DPS projection owner, `core/CommunityController.lua`, `core/DataRetention.lua`, `ui/Leaderboard.lua`, `tests/run_dps_boards.lua`, `tests/run_view_projections.lua`, and `tests/run_leaderboard_ui.lua`.
-- #43: `core/WishlistModel.lua`, `core/WishlistController.lua`, `ui/WishlistEditor.lua`, `ui/WishlistRenderer.lua`, `core/Codec.lua`, and Wishlist model/editor/controller/import tests.
-- #44: `core/CandidateEvidence.lua`, `core/WishlistModel.lua`, `core/GameAdapter.lua`, `core/LoadoutEvidence.lua`, and CandidateEvidence/locked-loadout tests.
-- #20: `core/GameAdapter.lua`, `core/LoadoutEvidence.lua`, association fixtures, and exact active/locked evidence tests.
-- #35: `logic/Model.lua`, `logic/Policy.lua`, `logic/Ratchet.lua`, `core/MainViewModel.lua`, `ui/WishlistOverlay.lua`, and Wishlist progress/parity tests.
+- Product seam: `core/BuildHashCache.lua`; compatibility consumers: `core/SyncCompatibility.lua`, `core/SyncReconciler.lua`, `core/Sync.lua`.
+- Focused coverage: `tests/run_sync_hash_cache.lua`, `tests/run_sync_baseline_delta.lua`, `tests/run_sync_compatibility_parity.lua`.
+- Validation: `tests/validation-map.json`, `tools/Invoke-QualityGate.ps1`, and `build/verify/summary.json`.
 - Workflow: `AGENTS.md`, `.vibe/STATE.md`, `.vibe/PLAN.md`, this file, and append-only `.vibe/EVIDENCE.md`.
 
 ## Agent Notes
 
-- Current state: Stage 49 checkpoints 49.1 and 49.2 are `DONE`; WP5 issues #23/#26 are implemented, reviewed, and hygiene-complete on the reconciled WP5 branch.
-- Historical Dummy/LK snapshots remain immutable capture-time evidence. Exact independently proven current/build association alone grants copy authority, and unresolved or conflicting authority fails closed without rewriting history.
-- One clock-neutral deterministic real-pair selector now feeds Community qualification/averages, Leaderboard projection, retention, and DPS sorting; incompatible rows retain independent category bests while Average remains unavailable.
-- Next action: return the clean local WP5 receipt head to the controller-owned independent review. Do not start another product checkpoint or redesign cycle in this worker.
-- Preserve the 79 ordinary-copy budget and the existing policy that overflow does not automatically become locked intent unless current trusted rules authorize it.
-- Completed WP5 repository and Vibe receipt bytes are authorized in this worktree. No further product/test work, push, PR/issue mutation, merge, package/install, live SavedVariables access, native WoW, history rewrite, or earlier-worktree mutation is authorized.
+- Current state: Stage 50 checkpoint 50.1 is `NOT_STARTED`; retrospective, design, and the scheduled documentation scan are complete.
+- Next action: use Caveman expected-red discipline to reproduce typed build/tombstone hash collisions, then implement the smallest coherent BuildHashCache change and focused tests.
+- One clean local WP6 commit is authorized after focused and Fast validation. The controller owns independent review; no push, PR mutation, package/install, native WoW, or SavedVariables work is authorized.
 
 ## Stage Retrospective Notes
 
-- Build the complete compatibility-positive inventory before freezing an authority migration; late Full-only fixture discovery is avoidable.
-- Define one typed authority verdict and cross-surface alias matrix before updating ingress, summary, projection, and export callers.
-- Expected-red preservation matrices must include collisions, malformed values, future-owned data, and restart/reload ordering.
-- Public quarantine rules require sync/async/detail/fallback/count/sort/page parity.
-- Reserve Full until all independent review axes accept the exact frozen bytes.
-- Stage 48.1 needed repeated review repairs for catalog admission and defensive-copy drift; for Stage 49, define one public DPS authority verdict and make every projection consume it before widening callers.
-- Stage 48.2 exposed copy-count and bound-snapshot edge cases after the first implementation; issue #23 tests must cover immutable nested aliases, conflicting provenance, future fields, and copy totals before product edits.
-- Stage 48.3 succeeded with a narrow read-only derivation boundary; keep current/build copy resolution read-only over historical DPS rows and prove source immutability at every failure path.
-- Stage 48.4 found presentation and automation parity gaps across repeated review cycles; issue #26 must test Community, Leaderboard, sorting, and detail projections against the same paired-summary output from the start.
-- Stage 48 added no checkpoints but accumulated multiple implementation→review cycles; freeze Full only after focused adversarial matrices cover malformed identity, order changes, reload/restart, and Sync convergence.
+- Stage 49 checkpoint 49.1 needed repeated implement-review repairs because equal-DPS tie inputs and copy authority differed across consumers; define one explicit semantic projection and make all consumers share it before widening callers.
+- Stage 49 review found async, empty-authority, nonfinite, and mixed-state gaps after focused success; include sync/async, empty, malformed, and partially migrated states in the expected-red matrix before the first product edit.
+- Stage 49 Full exposed unbounded real-pair work in the active Sync projection pump; test bounded work budgets on the production async path before freezing bytes for Full.
+- Stage 49 checkpoint 49.2 showed retention needed preserved source references while presentation needed a narrow allowlist; keep source identity separate from display metadata and test permutation invariance explicitly.
+- Stage 49 completed without checkpoint splits, skipped work, or decision blockers; retaining one bounded authority checkpoint plus a separate hygiene pass kept repairs scoped despite multiple review cycles.

--- a/.vibe/EVIDENCE.md
+++ b/.vibe/EVIDENCE.md
@@ -697,3 +697,9 @@ Record concise command/result receipts here. A skipped or unavailable command is
 - Exact product/test head `de04122620aa30b42113fe7fea30255b0fa8047f` uses an explicit authority/output tie allowlist and preserves original source references separately for deterministic retention.
 - Exact-head Full passes all `18` blocking checks with Lua `221/221`, Lua 5.1 parse `294/294`, integration `70/70`, zero failed/unavailable checks, and one explicit nonblocking manual SavedVariables skip that remains unverified.
 - Bounded checkpoint hygiene inspected only the explicit pair tie/projection, preserved source arrays, deterministic retention resolver, and their regressions. No safe behavior-preserving cleanup or actionable debt remained; product/test bytes did not change after Full.
+
+# 2026-08-22 — Checkpoint 50.1 typed build identity implementation
+
+- Expected red: `node tools/run-lua.js tests/run_sync_compatibility_parity.lua` exited 1 at `EXPECTED RED: numeric and string build IDs share one bucket hash` before product changes.
+- Focused green: compatibility parity, hash cache, and baseline delta runners pass with typed build/tombstone separation, deterministic dual-ID ordering, mixed old/new inequality, distinct resumable candidate tokens, and cached/fallback delta/legacy parity.
+- Fast: `tools/Invoke-QualityGate.ps1 -Mode Fast -BaseRef 8f5d28008935cef2d973b800167695ab50e0f70b` passed 20/20 blocking checks in 194.852s with zero failed, skipped, or unavailable checks; integration passed 70/70. Native WoW and SavedVariables remain unverified.

--- a/.vibe/HISTORY.md
+++ b/.vibe/HISTORY.md
@@ -1,5 +1,11 @@
 # HISTORY
 
+## Stage 49 — Historical DPS authority and real paired summaries (completed)
+
+- WP5 issues #23/#26 separated immutable historical locked snapshots from exact current/build copy authority and centralized one deterministic real Dummy/LK pair metric across Community, Leaderboard, retention, and sorting.
+- Accepted receipt head `8f5d28008935cef2d973b800167695ab50e0f70b`; Full passed 18 blocking checks with Lua `221/221`, parse `294/294`, integration `70/70`, and one explicit nonblocking manual SavedVariables skip.
+- Independent review and hygiene completed; native WoW remained unverified.
+
 This file is non-authoritative. Archive completed checkpoints, resolved issues, and consolidation notes here.
 
 ## Completed checkpoints

--- a/.vibe/PLAN.md
+++ b/.vibe/PLAN.md
@@ -53,3 +53,35 @@ depends_on: [49.1]
   - `pwsh -NoProfile -File tools/Invoke-QualityGate.ps1 -Mode Fast -BaseRef e70de8a7582d0146cc6746677084b3f4a270290b`
 - Evidence:
   - Pairing expected-red/green matrix, exact summary receipts, and independent Spec/Standards review.
+
+## Stage 50 — Typed build identity in Sync bucket hashes
+
+- Goal: make every eight-bucket build digest preserve the typed build identity that BuildCatalog and Sync reconciliation already treat as semantically distinct.
+- Decision: encode the raw ID type in canonical build and tombstone hash material at the existing BuildHashCache boundary; do not coerce catalog identity or change bucket count.
+- Decision: preserve deterministic ordering and validate delta, legacy, invalidation, reconciliation, and mixed-client behavior together so protocol-compatible peers cannot retain false equality.
+
+### 50.1 — Preserve typed IDs in build and tombstone bucket material (#40)
+
+depends_on: [49.2]
+
+- Status: `IN_REVIEW`
+- Objective:
+  - Ensure numeric and string forms of the same textual build ID produce distinct deterministic build and tombstone bucket hashes without changing the bounded eight-bucket design.
+- Deliverables:
+  - Focused expected-red typed build/tombstone, peer-reconciliation, delta/legacy, invalidation, and iteration-order coverage.
+  - Typed canonical entry material for build and tombstone rows in `core/BuildHashCache.lua`.
+  - Explicit mixed old/new digest compatibility behavior that prevents permanent false equality.
+- Acceptance:
+  - [ ] Numeric `1` and string `"1"` hash differently for builds and tombstones; exactly equal typed records hash equally.
+  - [ ] A numeric/string peer mismatch cannot report bucket equality or skip reconciliation.
+  - [ ] A bucket containing both typed IDs is deterministic across Lua table iteration order and targeted/full rebuilds.
+  - [ ] Delta and legacy hash modes preserve the same typed identity rule, while ordinary string IDs remain deterministic.
+  - [ ] Mixed old/new behavior is compatibility-gated or versioned if required to prevent protocol-compatible false equality.
+  - [ ] Blocking focused, mapped, Fast, Full, Lua, parse, integration, policy, and exact-diff checks pass; native WoW remains explicitly unverified.
+- Demo commands:
+  - `luajit tests/run_sync_hash_cache.lua`
+  - `luajit tests/run_sync_baseline_delta.lua && luajit tests/run_sync_compatibility_parity.lua`
+  - `pwsh -NoProfile -File tools/Invoke-QualityGate.ps1 -Mode Fast -BaseRef 8f5d28008935cef2d973b800167695ab50e0f70b`
+  - `pwsh -NoProfile -File tools/Invoke-QualityGate.ps1 -Mode Full -BaseRef 8f5d28008935cef2d973b800167695ab50e0f70b`
+- Evidence:
+  - Expected-red typed-collision receipt, focused green compatibility matrix, and exact-head gate/diff receipt.

--- a/.vibe/STATE.md
+++ b/.vibe/STATE.md
@@ -8,7 +8,7 @@
 
 - Stage: 50
 - Checkpoint: 50.1
-- Status: IN_REVIEW
+- Status: IN_PROGRESS
 - Branch: `bugfix/test19-wp6-build-hash-buckets-erase-build-id-type-and-can-r`
 - Starting head: exact accepted WP5 handoff head `8f5d28008935cef2d973b800167695ab50e0f70b`
 - Worktree: `.test19-wp4-worktree`
@@ -185,5 +185,6 @@ Preserve typed build identity in Sync's canonical build and tombstone bucket-has
 
 
 ## Work log (current session)
+- Controller review repair: SPEC-TYPED-CACHE-KEY-ALIAS; VALIDATION-TYPED-COEXISTENCE-ORACLE
 - WP6 typed cache matrix and exact-head Fast/Full validation pass; native WoW remains unverified
 - Controller review repair: VALIDATION-EXACT-HEAD-AND-FULL-MISSING; SPEC-TYPED-CACHE-INVALIDATION-COVERAGE

--- a/.vibe/STATE.md
+++ b/.vibe/STATE.md
@@ -8,7 +8,7 @@
 
 - Stage: 50
 - Checkpoint: 50.1
-- Status: IN_PROGRESS
+- Status: IN_REVIEW
 - Branch: `bugfix/test19-wp6-build-hash-buckets-erase-build-id-type-and-can-r`
 - Starting head: exact accepted WP5 handoff head `8f5d28008935cef2d973b800167695ab50e0f70b`
 - Worktree: `.test19-wp4-worktree`
@@ -185,4 +185,5 @@ Preserve typed build identity in Sync's canonical build and tombstone bucket-has
 
 
 ## Work log (current session)
+- WP6 typed cache matrix and exact-head Fast/Full validation pass; native WoW remains unverified
 - Controller review repair: VALIDATION-EXACT-HEAD-AND-FULL-MISSING; SPEC-TYPED-CACHE-INVALIDATION-COVERAGE

--- a/.vibe/STATE.md
+++ b/.vibe/STATE.md
@@ -8,7 +8,7 @@
 
 - Stage: 50
 - Checkpoint: 50.1
-- Status: IN_PROGRESS
+- Status: IN_REVIEW
 - Branch: `bugfix/test19-wp6-build-hash-buckets-erase-build-id-type-and-can-r`
 - Starting head: exact accepted WP5 handoff head `8f5d28008935cef2d973b800167695ab50e0f70b`
 - Worktree: `.test19-wp4-worktree`
@@ -185,6 +185,7 @@ Preserve typed build identity in Sync's canonical build and tombstone bucket-has
 
 
 ## Work log (current session)
+- Typed cache sibling oracle and targeted invalidation repair pass focused, Fast 22/22, and exact-head Full 18 blocking checks
 - Controller review repair: SPEC-TYPED-CACHE-KEY-ALIAS; VALIDATION-TYPED-COEXISTENCE-ORACLE
 - WP6 typed cache matrix and exact-head Fast/Full validation pass; native WoW remains unverified
 - Controller review repair: VALIDATION-EXACT-HEAD-AND-FULL-MISSING; SPEC-TYPED-CACHE-INVALIDATION-COVERAGE

--- a/.vibe/STATE.md
+++ b/.vibe/STATE.md
@@ -6,37 +6,39 @@
 
 ## Current focus
 
-- Stage: 49
-- Checkpoint: 49.2
-- Status: DONE
-- Branch: `bugfix/test19-wp5-historical-dps-authority-and-real-paired-summari`
-- Starting head: exact accepted WP4 handoff head `e70de8a7582d0146cc6746677084b3f4a270290b`
+- Stage: 50
+- Checkpoint: 50.1
+- Status: IN_REVIEW
+- Branch: `bugfix/test19-wp6-build-hash-buckets-erase-build-id-type-and-can-r`
+- Starting head: exact accepted WP5 handoff head `8f5d28008935cef2d973b800167695ab50e0f70b`
 - Worktree: `.test19-wp4-worktree`
-- Base: exact accepted WP4 handoff head `e70de8a7582d0146cc6746677084b3f4a270290b`
+- Base: exact accepted WP5 handoff head `8f5d28008935cef2d973b800167695ab50e0f70b`
 
 ## Objective (current checkpoint)
 
-Project Community DPS only from deterministic real Dummy/LK pairs with verified canonical owner, ordinary fingerprint, and locked full-combat identity.
+Preserve typed build identity in Sync's canonical build and tombstone bucket-hash material without changing the deterministic eight-bucket reconciliation design.
 
 ## Deliverables (current checkpoint)
 
-- One clock-neutral pair-compatibility predicate and deterministic best-real-pair selector in CandidateEvidence.
-- Equal-DPS permutation, reload/Sync, Community, Leaderboard, retention, and sorting parity coverage.
-- Independent Dummy/LK category bests when no compatible real pair exists.
+- Focused expected-red typed build/tombstone, reconciliation, delta/legacy, invalidation, and ordering coverage.
+- Typed canonical build and tombstone entry material in `core/BuildHashCache.lua`.
+- Explicit mixed old/new digest compatibility behavior preventing permanent false equality.
 
 ## Acceptance (current checkpoint)
 
-- [x] Every Average comes from two actual records with the same verified canonical owner.
-- [x] The pair shares the same ordinary fingerprint and locked/full-combat identity.
-- [x] Timestamp and recency fields at every depth cannot select or change the projected pair.
-- [x] Mixed or incomplete authority leaves Average unavailable while preserving independent category bests.
-- [x] Community, Leaderboard, retention, and sorting consume the same deterministic real-pair metric.
-- [x] Blocking focused, mapped, Fast, exact-head review/Full, and diff checks pass.
+- [ ] Numeric `1` and string `"1"` hash differently for builds and tombstones; equal typed states remain equal.
+- [ ] Numeric/string peer mismatch cannot skip reconciliation.
+- [ ] Both typed IDs hash deterministically across iteration order and rebuild paths.
+- [ ] Delta and legacy modes preserve typed identity and ordinary strings remain deterministic.
+- [ ] Mixed old/new behavior prevents permanent protocol-compatible false equality.
+- [ ] Blocking focused, mapped, Fast, Full, Lua, parse, integration, policy, and diff checks pass.
 - [ ] Nonblocking manual SavedVariables/native validation remains explicitly unverified.
 
 ## Evidence
 
 - path: .vibe/EVIDENCE.md
+- Issue #40 expected red failed at `numeric and string build IDs share one bucket hash`; typed build/tombstone, mixed old/new, ordering, candidate-token, cache invalidation, and baseline-delta focused runners now pass.
+- Fast passed `20/20` blocking checks with Lua 5.1 parse, Sync mapped tests, integration `70/70`, policy, metadata, release, security, and diff checks; zero failed, skipped, or unavailable checks.
 - Controller repair excludes labels, category, resemblance, and temporal metadata from equal-DPS ties through an explicit projection allowlist; retention resolves the accepted pair through preserved source references. Expected-red reproduced both findings, focused paired/retention/board/Leaderboard/view tests pass, and Fast passes `43/43`.
 - WP5 implementation candidate separates historical locked snapshots from exact current/build copy authority and centralizes verified-owner + ordinary + locked/full-combat real-pair metrics across Community eligibility/averages, Leaderboard sync/resumable projections, retention, and DPS sorting. Focused authority/pairing matrices pass; Fast passes `37/37`; final Full passes `18` blocking checks with Lua `221/221`, parse `294/294`, integration `70/70`, zero failed/unavailable checks, and one explicit manual SavedVariables skip.
 - Stage 49 test-gap analysis prioritized five risk-backed matrices: `[MAJOR]` immutable historical snapshots versus exact later copy authority; `[MAJOR]` verified-owner + ordinary + locked/full-combat pair compatibility; `[MAJOR]` Community/Leaderboard/sort parity from one metric; `[MODERATE]` category/timestamp permutation invariance; `[MODERATE]` reload/restart/Sync convergence with preserved conflict evidence.
@@ -66,7 +68,7 @@ Project Community DPS only from deterministic real Dummy/LK pairs with verified 
 - Stage 47 hygiene was CLEAN across the bounded 30-path WP3 surface; product/test/workflow/contract bytes did not change after Full.
 - Stage 48.1 is pointer-only and `NOT_STARTED`; no WP4 design or implementation occurred during consolidation.
 
-## Work log
+## Archived Stage 48/49 work detail
 
 - WP5 implementation completed issues #23/#26 on one coherent candidate: copy paths require exact build-bound locked authority; historical category rows remain preserved for display; one deterministic real-pair owner feeds qualification, Community averages, Leaderboard, retention, and sorting. Final Fast `37/37` and Full `18/18` pass.
 - Stage 49 maintenance test-gap analysis selected five non-duplicative expected-red matrices covering immutable history, exact copy authority, real-pair identity, cross-surface parity, ordering, and persistence/Sync convergence.
@@ -98,6 +100,15 @@ Project Community DPS only from deterministic real Dummy/LK pairs with verified 
 - Stage 48 design reconciled #43 -> #44 -> #20 -> #35 against the accepted issue comments and corrected checkpoint 48.3 to read-time exact multiset subtraction without source mutation.
 - Stage 47 retrospective completed with five lessons on compatibility inventory, shared authority normalization, adversarial preservation coverage, public-surface parity, and reserving Full for accepted bytes.
 - Stage 47 consolidation archived the completed WP3 plan surface, moved the pointer from 47.5 `DONE` to 48.1 `NOT_STARTED`, and retained the exact review/Full/hygiene receipt without starting WP4.
+
+## Work log
+
+- Checkpoint 50.1 preserves typed build/tombstone identity in cached and fallback delta/legacy digest material plus resumable reconciliation tokens; focused tests pass and Fast passes 20/20.
+- Stage 49 retrospective completed with five lessons on shared semantic projections, adversarial state matrices, bounded async work, source/display separation, and checkpoint scope.
+- Stage 50 design confirmed checkpoint 50.1 as the single bounded issue #40 implementation seam in BuildHashCache with focused Sync compatibility coverage.
+- Stage 50 documentation gap scan found no WP6-scoped documentation change; typed digest identity remains a source-and-regression-test contract.
+- Stage 50 designed one bounded issue #40 checkpoint and archived completed WP5 detail.
+- Stage 49 completed with accepted review, hygiene, Fast, and Full receipts.
 
 ## Workflow state
 
@@ -140,7 +151,8 @@ Project Community DPS only from deterministic real Dummy/LK pairs with verified 
 - Return the clean local WP5 receipt commit to the controller-owned independent review; do not begin another design cycle or publish from this worker.
 
 
-## Work log (current session)
+## Archived session detail
+- Stage 50 design added one bounded issue #40 checkpoint for typed build/tombstone hash identity, reconciliation, invalidation, delta/legacy determinism, and mixed-client compatibility.
 - Checkpoint 49.2 prohibited-tie/retention-source hygiene CLEAN: bounded repaired surface has no correctness, security, duplication, or safe high-ROI cleanup signal; Full was not repeated.
 - Review PASS at exact head de04122: Full 18 blocking passes; Lua 221/221, parse 294/294, integration 70/70; one nonblocking manual SavedVariables skip remains unverified
 - Repair prohibited DPS tie inputs and preserve retention pair sources

--- a/.vibe/STATE.md
+++ b/.vibe/STATE.md
@@ -8,7 +8,7 @@
 
 - Stage: 50
 - Checkpoint: 50.1
-- Status: IN_REVIEW
+- Status: IN_PROGRESS
 - Branch: `bugfix/test19-wp6-build-hash-buckets-erase-build-id-type-and-can-r`
 - Starting head: exact accepted WP5 handoff head `8f5d28008935cef2d973b800167695ab50e0f70b`
 - Worktree: `.test19-wp4-worktree`
@@ -182,3 +182,7 @@ Preserve typed build identity in Sync's canonical build and tombstone bucket-has
 - Full found unbounded real-pair selector work in active Sync projection pump
 - WP5 review repairs validated: async parity, empty authority, finite DPS, and mixed-state coverage
 - Controller review repair: SPEC-PAIR-ASYNC-DIVERGENCE; SPEC-EMPTY-COPY-AUTHORITY; ADV-NONFINITE-PAIR; VALIDATION-MIXED-STATE-GAP; VIBE-CHECKPOINT-CONTRADICTION
+
+
+## Work log (current session)
+- Controller review repair: VALIDATION-EXACT-HEAD-AND-FULL-MISSING; SPEC-TYPED-CACHE-INVALIDATION-COVERAGE

--- a/core/BuildHashCache.lua
+++ b/core/BuildHashCache.lua
@@ -26,6 +26,12 @@ local function Bucket(id)
     return (hash % BUCKETS) + 1
 end
 
+-- BuildCatalog keys are typed identities. Keep the bucket assignment stable
+-- for wire compatibility, but preserve that type in canonical hash material.
+local function TypedId(id)
+    return type(id) .. ":" .. tostring(id)
+end
+
 local function TombStamp(value)
     if type(value) == "table" then return tonumber(value.stamp) or 0 end
     return tonumber(value) or 0
@@ -45,13 +51,13 @@ local function BuildEntry(id, build)
     end
     complete = complete and "F" or "S"
     local fingerprint = tostring(build.fingerprintHash or build.fingerprint or "0")
-    return tostring(id) .. ":" .. tostring(build.lastModified or build.postedAt or 0)
+    return TypedId(id) .. ":" .. tostring(build.lastModified or build.postedAt or 0)
         .. ":" .. complete .. ":" .. fingerprint
 end
 
 local function TombstoneEntry(id, tombstone)
     if tombstone == nil then return nil end
-    return "!" .. tostring(id) .. ":" .. tostring(TombStamp(tombstone))
+    return "!" .. TypedId(id) .. ":" .. tostring(TombStamp(tombstone))
         .. ":" .. TombAuthor(tombstone)
 end
 

--- a/core/SyncCompatibility.lua
+++ b/core/SyncCompatibility.lua
@@ -41,6 +41,10 @@ function Compatibility.New(options)
     local candidateCache
     local C = {}
 
+    local function TypedId(id)
+        return type(id) .. ":" .. tostring(id)
+    end
+
     local function HasCompleteOrdinary(build)
         if type(build) ~= "table" then return false end
         if build.ordinaryComplete ~= nil then
@@ -75,13 +79,13 @@ function Compatibility.New(options)
             local complete = HasCompleteOrdinary(build) and "F" or "S"
             local fingerprint = tostring(build.fingerprintHash
                 or build.fingerprint or "0")
-            grouped[bucket][#grouped[bucket] + 1] = id .. ":"
+            grouped[bucket][#grouped[bucket] + 1] = TypedId(id) .. ":"
                 .. tostring(build.lastModified or build.postedAt or 0)
                 .. ":" .. complete .. ":" .. fingerprint
         end
         for id, tombstone in pairs(tombstoneSource or getTombstones() or {}) do
             local bucket = C.BuildBucket(id)
-            grouped[bucket][#grouped[bucket] + 1] = "!" .. id .. ":"
+            grouped[bucket][#grouped[bucket] + 1] = "!" .. TypedId(id) .. ":"
                 .. tostring(C.TombStamp(tombstone)) .. ":"
                 .. C.TombAuthor(tombstone)
         end
@@ -304,7 +308,7 @@ function Compatibility.New(options)
             snapshot.cursor = id
             if build then
                 local complete = HasCompleteOrdinary(build) and "F" or "S"
-                local token = table.concat({"B", tostring(id),
+                local token = table.concat({"B", TypedId(id),
                     tostring(build.lastModified or build.postedAt or 0),
                     complete, tostring(build.fingerprintHash
                         or build.fingerprint or "0")}, ":")
@@ -336,7 +340,7 @@ function Compatibility.New(options)
             }
             snapshot.byBucket[bucket][#snapshot.byBucket[bucket] + 1] = {
                 kind="tomb", id=id, tomb=copy,
-                token=table.concat({"T", tostring(id),
+                token=table.concat({"T", TypedId(id),
                     tostring(C.TombStamp(copy)), C.TombAuthor(copy)}, ":"),
             }
         end

--- a/tests/run_sync_compatibility_parity.lua
+++ b/tests/run_sync_compatibility_parity.lua
@@ -123,7 +123,8 @@ local function RefLibraryHash(builds, tombstoneSource)
     for id, build in pairs(builds or {}) do
         local complete = type(build.echoes) == "table"
             and #build.echoes > 0 and "F" or "S"
-        grouped[RefBucket(id)][#grouped[RefBucket(id)] + 1] = id .. ":"
+        local typedId = type(id) .. ":" .. tostring(id)
+        grouped[RefBucket(id)][#grouped[RefBucket(id)] + 1] = typedId .. ":"
             .. tostring(build.lastModified or build.postedAt or 0) .. ":"
             .. complete .. ":"
             .. tostring(build.fingerprintHash or build.fingerprint or "0")
@@ -133,7 +134,8 @@ local function RefLibraryHash(builds, tombstoneSource)
             and (tonumber(tombstone.stamp) or 0) or (tonumber(tombstone) or 0)
         local author = type(tombstone) == "table"
             and tostring(tombstone.author or "") or ""
-        grouped[RefBucket(id)][#grouped[RefBucket(id)] + 1] = "!" .. id
+        local typedId = type(id) .. ":" .. tostring(id)
+        grouped[RefBucket(id)][#grouped[RefBucket(id)] + 1] = "!" .. typedId
             .. ":" .. tostring(stamp) .. ":" .. author
     end
     local hashes = {}
@@ -159,6 +161,54 @@ local function RefCatalogToken(value)
     end
     return table.concat(out)
 end
+
+-- Canonical material must preserve the same typed identity boundary as the
+-- catalog. Numeric and string IDs can occupy one Lua table simultaneously and
+-- must never collapse into equal build or tombstone bucket hashes.
+local typedBuild = {
+    id=1, lastModified=77, fingerprintHash="abc",
+    echoes={{spellId=200001,stacks=1}},
+}
+local numericBuildHash = C.LibraryHash({[1]=typedBuild}, {})
+typedBuild.id = "1"
+local stringBuildHash = C.LibraryHash({["1"]=typedBuild}, {})
+assert(numericBuildHash ~= stringBuildHash,
+    "EXPECTED RED: numeric and string build IDs share one bucket hash")
+
+local tombstone = {stamp=88,author="Peer"}
+local numericTombHash = C.LibraryHash({}, {[1]=tombstone})
+local stringTombHash = C.LibraryHash({}, {["1"]=tombstone})
+assert(numericTombHash ~= stringTombHash,
+    "EXPECTED RED: numeric and string tombstone IDs share one bucket hash")
+
+local function OldSingleHash(id, material)
+    local hashes = {"0","0","0","0","0","0","0","0"}
+    local hash = 5381
+    for index = 1, #material do
+        hash = ((hash * 33) + material:byte(index)) % 2147483648
+    end
+    hashes[RefBucket(id)] = string.format("%x", hash)
+    return table.concat(hashes, ",")
+end
+local oldBuildHash = OldSingleHash(1, "1:77:F:abc")
+local oldTombHash = OldSingleHash(1, "!1:88:Peer")
+assert(oldBuildHash == OldSingleHash("1", "1:77:F:abc")
+    and oldTombHash == OldSingleHash("1", "!1:88:Peer"),
+    "legacy collision fixture no longer represents the old digest")
+assert(numericBuildHash ~= oldBuildHash and stringBuildHash ~= oldBuildHash
+    and numericTombHash ~= oldTombHash and stringTombHash ~= oldTombHash,
+    "mixed old/new clients can retain a false typed-ID bucket equality")
+
+local bothTypedA = C.LibraryHash({
+    [1]={id=1,lastModified=77,fingerprintHash="abc",echoes={{spellId=1}}},
+    ["1"]={id="1",lastModified=77,fingerprintHash="abc",echoes={{spellId=1}}},
+}, {[1]=tombstone,["1"]={stamp=88,author="Peer"}})
+local bothTypedB = C.LibraryHash({
+    ["1"]={id="1",lastModified=77,fingerprintHash="abc",echoes={{spellId=1}}},
+    [1]={id=1,lastModified=77,fingerprintHash="abc",echoes={{spellId=1}}},
+}, {["1"]={stamp=88,author="Peer"},[1]=tombstone})
+assert(bothTypedA == bothTypedB,
+    "typed bucket material depends on Lua table iteration order")
 
 local expectedDelta = RefLibraryHash(delta, tombstones)
 local expectedLegacy = RefLibraryHash(all, tombstones)
@@ -270,6 +320,37 @@ C.Reset()
 assert(C.BuildCandidateSnapshot(cachedDelta) ~= hashReplacement
     and stats.candidateSnapshots == 6,
     "session reset retained derived candidate state")
+
+-- Resumable reconciliation progress uses the same typed identity boundary, so
+-- one peer can carry both legacy numeric and string IDs without aliasing work.
+local typedCandidate = {
+    lastModified=77,fingerprintHash="abc",echoes={{spellId=200001,stacks=1}},
+}
+delta = {[1]=typedCandidate,["1"]=typedCandidate}
+orderedIds, positions = {1,"1"}, {[1]=1,["1"]=2}
+tombstones = {
+    [1]={stamp=88,author="Local-Realm",ownerKey=currentOwner,ownerVerified=true},
+    ["1"]={stamp=88,author="Local-Realm",ownerKey=currentOwner,ownerVerified=true},
+}
+cachedDelta, buildRevision = "typed-candidate-delta", buildRevision + 1
+local typedSnapshot = C.BuildCandidateSnapshot(cachedDelta)
+local typedSteps = 0
+while not typedSnapshot.complete do
+    local _, typedWhy, typedProgress = C.AdvanceCandidateSnapshot(typedSnapshot)
+    assert(typedWhy == nil and typedProgress == true)
+    typedSteps = typedSteps + 1
+    assert(typedSteps <= 6, "typed candidate snapshot did not terminate")
+end
+local typedTokens, typedRows = {}, 0
+for bucket = 1, 8 do
+    for _, item in ipairs(typedSnapshot.byBucket[bucket]) do
+        assert(not typedTokens[item.token],
+            "numeric/string reconciliation candidates share a progress token")
+        typedTokens[item.token], typedRows = true, typedRows + 1
+    end
+end
+assert(typedRows == 4 and typedSteps == 6,
+    "typed build/tombstone candidates were lost during bounded reconciliation")
 
 -- Fingerprints and compact summaries preserve the established exact fields.
 local summaryBuild = {

--- a/tests/run_sync_hash_cache.lua
+++ b/tests/run_sync_hash_cache.lua
@@ -230,8 +230,31 @@ local function TypedCacheFixture(builds, tombstones)
     return cache, Hashes, Target, Rebuild
 end
 
+local function TypedOracle(builds, tombstones)
+    local compatibility = Nexus.SyncInternals.Compatibility.New({
+        buckets=8,
+        getCatalog=function() return {} end,
+        getBuildHashCache=function() return nil end,
+        getBuildRevision=function() return 0 end,
+        getDpsCapture=function() return nil end,
+        getTombstones=function() return tombstones end,
+        localOwnsTomb=function() return false end,
+        relayEligible=function() return false end,
+        myName=function() return "Local" end,
+        currentOwnerKey=function() return "local-ebonhold" end,
+        now=function() return 0 end,
+        getCodec=function() return Nexus.Codec end,
+        validIdentifier=function() return true end,
+        validHash=function() return true end,
+        escapedLen=function(value) return #tostring(value or "") end,
+        codeIndex="WLI2",maxBuildIdBytes=160,chatLimit=255,chatSafety=12,
+    })
+    return compatibility.LibraryHash(builds, tombstones)
+end
+
 local typedBuild = {
-    lastModified=77,fingerprintHash="typed",loadoutAvailable=true,
+    lastModified=77,fingerprintHash="typed",
+    loadoutAvailable=true,ordinaryComplete=true,
 }
 local typedTombstone = {stamp=88,author="Peer"}
 local _, NumericBuildHashes = TypedCacheFixture({[1]=typedBuild}, {})
@@ -259,17 +282,22 @@ local bothTombs = {
 local typedCache, TypedHashes, TargetTyped, RebuildTyped =
     TypedCacheFixture(bothBuilds, bothTombs)
 local bothDelta, bothLegacy = TypedHashes()
-assert(bothDelta == TypedHashes() and bothLegacy == select(2, TypedHashes()),
-    "equal typed cache state was not stable across unchanged reads")
+local bothOracle = TypedOracle(bothBuilds, bothTombs)
+assert(bothDelta == bothOracle and bothLegacy == bothOracle
+    and bothDelta == TypedHashes() and bothLegacy == select(2, TypedHashes()),
+    "combined typed cache lost a build/tombstone sibling or was unstable")
 
 bothBuilds[1] = {
-    lastModified=78,fingerprintHash="typed",loadoutAvailable=true,
+    lastModified=78,fingerprintHash="typed",
+    loadoutAvailable=true,ordinaryComplete=true,
 }
 local beforeTarget = typedCache.Stats()
 TargetTyped(1)
 local targetedDelta, targetedLegacy = TypedHashes()
 local afterTarget = typedCache.Stats()
-assert(targetedDelta ~= bothDelta and targetedLegacy ~= bothLegacy
+local targetedOracle = TypedOracle(bothBuilds, bothTombs)
+assert(targetedDelta == targetedOracle and targetedLegacy == targetedOracle
+    and targetedDelta ~= bothDelta and targetedLegacy ~= bothLegacy
     and afterTarget.targetedInvalidations
         == beforeTarget.targetedInvalidations + 1
     and afterTarget.fullRebuilds == beforeTarget.fullRebuilds
@@ -280,11 +308,39 @@ assert(targetedDelta ~= bothDelta and targetedLegacy ~= bothLegacy
         == beforeTarget.legacyBucketRebuilds + 1,
     "typed targeted invalidation did not rebuild exactly one cache bucket")
 
+local numericBuild, numericTombstone = bothBuilds[1], bothTombs[1]
+bothBuilds[1], bothTombs[1] = nil, nil
+TargetTyped(1)
+local stringOnlyDelta, stringOnlyLegacy = TypedHashes()
+local stringOnlyOracle = TypedOracle(bothBuilds, bothTombs)
+assert(stringOnlyDelta == stringOnlyOracle
+    and stringOnlyLegacy == stringOnlyOracle,
+    "invalidating numeric ID removed or replaced its string sibling")
+bothBuilds[1], bothTombs[1] = numericBuild, numericTombstone
+TargetTyped(1)
+assert(TypedHashes() == targetedOracle
+    and select(2, TypedHashes()) == targetedOracle,
+    "restoring numeric ID did not recover both typed siblings")
+
+local stringBuild, stringTombstone = bothBuilds["1"], bothTombs["1"]
+bothBuilds["1"], bothTombs["1"] = nil, nil
+TargetTyped("1")
+local numericOnlyDelta, numericOnlyLegacy = TypedHashes()
+local numericOnlyOracle = TypedOracle(bothBuilds, bothTombs)
+assert(numericOnlyDelta == numericOnlyOracle
+    and numericOnlyLegacy == numericOnlyOracle,
+    "invalidating string ID removed or replaced its numeric sibling")
+bothBuilds["1"], bothTombs["1"] = stringBuild, stringTombstone
+TargetTyped("1")
+local restoredDelta, restoredLegacy = TypedHashes()
+assert(restoredDelta == targetedOracle and restoredLegacy == targetedOracle,
+    "restoring string ID did not recover both typed siblings")
+
 local beforeFull = typedCache.Stats()
 RebuildTyped()
 local rebuiltDelta, rebuiltLegacy = TypedHashes()
 local afterFull = typedCache.Stats()
-assert(rebuiltDelta == targetedDelta and rebuiltLegacy == targetedLegacy
+assert(rebuiltDelta == restoredDelta and rebuiltLegacy == restoredLegacy
     and afterFull.fullRebuilds == beforeFull.fullRebuilds + 1
     and afterFull.collectionWalks == beforeFull.collectionWalks + 2,
     "typed full rebuild diverged from targeted cache state")

--- a/tests/run_sync_hash_cache.lua
+++ b/tests/run_sync_hash_cache.lua
@@ -189,4 +189,121 @@ assert(Sync.GetCompatibilityHashes() == expectedCurrent
     and Nexus.BuildHashCache.Stats().fullRebuilds == 1,
     "cache reload did not recover canonical compatibility hashes")
 
+-- Exercise typed identity through the real BuildHashCache, independently of
+-- SyncCompatibility's uncached reference implementation.  The fixture exposes
+-- the production revision callback so the same records can be checked after a
+-- targeted update and after a full rebuild in both hash modes.
+local function TypedCacheFixture(builds, tombstones)
+    local revision, subscriber = 0, nil
+    local catalog = {
+        DeltaSnapshot=function() return builds end,
+        DeltaSummaries=function() return builds end,
+        All=function() return builds end,
+        Summaries=function() return builds end,
+        TombstoneSnapshot=function() return tombstones end,
+        SyncState=function(id)
+            return {
+                delta=builds[id], visible=builds[id],
+                tombstone=tombstones[id],
+            }
+        end,
+    }
+    Nexus.BuildCatalog = catalog
+    Nexus.Revisions = {
+        BUILD_LIBRARY_CHANGED="build_library_changed",
+        Get=function() return revision end,
+        Subscribe=function(_, callback) subscriber = callback end,
+    }
+    dofile("core/BuildHashCache.lua")
+    local cache = Nexus.BuildHashCache
+    local function Hashes()
+        return cache.Delta(), cache.Legacy()
+    end
+    local function Target(id)
+        revision = revision + 1
+        subscriber(nil, revision, {scope="record",id=id})
+    end
+    local function Rebuild()
+        revision = revision + 1
+        subscriber(nil, revision, {scope="all"})
+    end
+    return cache, Hashes, Target, Rebuild
+end
+
+local typedBuild = {
+    lastModified=77,fingerprintHash="typed",loadoutAvailable=true,
+}
+local typedTombstone = {stamp=88,author="Peer"}
+local _, NumericBuildHashes = TypedCacheFixture({[1]=typedBuild}, {})
+local numericBuildDelta, numericBuildLegacy = NumericBuildHashes()
+local _, StringBuildHashes = TypedCacheFixture({["1"]=typedBuild}, {})
+local stringBuildDelta, stringBuildLegacy = StringBuildHashes()
+assert(numericBuildDelta ~= stringBuildDelta
+    and numericBuildLegacy ~= stringBuildLegacy,
+    string.format("real delta/legacy cache erased numeric/string build identity: %s / %s; %s / %s",
+        tostring(numericBuildDelta), tostring(stringBuildDelta),
+        tostring(numericBuildLegacy), tostring(stringBuildLegacy)))
+
+local _, NumericTombHashes = TypedCacheFixture({}, {[1]=typedTombstone})
+local numericTombDelta, numericTombLegacy = NumericTombHashes()
+local _, StringTombHashes = TypedCacheFixture({}, {["1"]=typedTombstone})
+local stringTombDelta, stringTombLegacy = StringTombHashes()
+assert(numericTombDelta ~= stringTombDelta
+    and numericTombLegacy ~= stringTombLegacy,
+    "real delta/legacy cache erased numeric/string tombstone identity")
+
+local bothBuilds = {[1]=typedBuild,["1"]=typedBuild}
+local bothTombs = {
+    [1]=typedTombstone,["1"]={stamp=88,author="Peer"},
+}
+local typedCache, TypedHashes, TargetTyped, RebuildTyped =
+    TypedCacheFixture(bothBuilds, bothTombs)
+local bothDelta, bothLegacy = TypedHashes()
+assert(bothDelta == TypedHashes() and bothLegacy == select(2, TypedHashes()),
+    "equal typed cache state was not stable across unchanged reads")
+
+bothBuilds[1] = {
+    lastModified=78,fingerprintHash="typed",loadoutAvailable=true,
+}
+local beforeTarget = typedCache.Stats()
+TargetTyped(1)
+local targetedDelta, targetedLegacy = TypedHashes()
+local afterTarget = typedCache.Stats()
+assert(targetedDelta ~= bothDelta and targetedLegacy ~= bothLegacy
+    and afterTarget.targetedInvalidations
+        == beforeTarget.targetedInvalidations + 1
+    and afterTarget.fullRebuilds == beforeTarget.fullRebuilds
+    and afterTarget.collectionWalks == beforeTarget.collectionWalks
+    and afterTarget.deltaBucketRebuilds
+        == beforeTarget.deltaBucketRebuilds + 1
+    and afterTarget.legacyBucketRebuilds
+        == beforeTarget.legacyBucketRebuilds + 1,
+    "typed targeted invalidation did not rebuild exactly one cache bucket")
+
+local beforeFull = typedCache.Stats()
+RebuildTyped()
+local rebuiltDelta, rebuiltLegacy = TypedHashes()
+local afterFull = typedCache.Stats()
+assert(rebuiltDelta == targetedDelta and rebuiltLegacy == targetedLegacy
+    and afterFull.fullRebuilds == beforeFull.fullRebuilds + 1
+    and afterFull.collectionWalks == beforeFull.collectionWalks + 2,
+    "typed full rebuild diverged from targeted cache state")
+
+local reversedBuilds = {["1"]=bothBuilds["1"],[1]=bothBuilds[1]}
+local reversedTombs = {["1"]=bothTombs["1"],[1]=bothTombs[1]}
+local _, ReversedHashes = TypedCacheFixture(reversedBuilds, reversedTombs)
+local reversedDelta, reversedLegacy = ReversedHashes()
+assert(reversedDelta == rebuiltDelta and reversedLegacy == rebuiltLegacy,
+    "real typed cache hash depends on Lua table insertion order")
+
+local ordinary = {
+    lastModified=9,fingerprintHash="ordinary",loadoutAvailable=true,
+}
+local _, OrdinaryHashesA = TypedCacheFixture({ordinary=ordinary}, {})
+local ordinaryDeltaA, ordinaryLegacyA = OrdinaryHashesA()
+local _, OrdinaryHashesB = TypedCacheFixture({ordinary=ordinary}, {})
+local ordinaryDeltaB, ordinaryLegacyB = OrdinaryHashesB()
+assert(ordinaryDeltaA == ordinaryDeltaB and ordinaryLegacyA == ordinaryLegacyB,
+    "ordinary string build IDs stopped hashing deterministically")
+
 print("revision-cached build/DPS hashes preserve wire output and targeted buckets -- OK")

--- a/tests/run_sync_late_post.lua
+++ b/tests/run_sync_late_post.lua
@@ -97,8 +97,8 @@ H.sentChatMessages={}
 -- Compute the same hash the answering side would compute
 local function bucketHash(builds)
     local buckets={}; for i=1,8 do buckets[i]={} end
-    local function bucket(id) local h=5381; for i=1,#id do h=((h*33)+id:byte(i))%2147483648 end; return (h%8)+1 end
-    for id,b in pairs(builds) do local n=bucket(id); local complete=(type(b.echoes)=="table" and #b.echoes>0) and "F" or "S"; local fp=tostring(b.fingerprintHash or b.fingerprint or "0"); buckets[n][#buckets[n]+1]=id..":"..tostring(b.lastModified or b.postedAt or 0)..":"..complete..":"..fp end
+    local function bucket(id) local text=tostring(id); local h=5381; for i=1,#text do h=((h*33)+text:byte(i))%2147483648 end; return (h%8)+1 end
+    for id,b in pairs(builds) do local n=bucket(id); local complete=(type(b.echoes)=="table" and #b.echoes>0) and "F" or "S"; local fp=tostring(b.fingerprintHash or b.fingerprint or "0"); buckets[n][#buckets[n]+1]=type(id)..":"..tostring(id)..":"..tostring(b.lastModified or b.postedAt or 0)..":"..complete..":"..fp end
     local out={}
     for n=1,8 do
         table.sort(buckets[n]); local h=5381


### PR DESCRIPTION
## Scope

Fix issue #40 by preserving typed build identity in canonical build and tombstone bucket-hash material so semantically distinct numeric and string IDs cannot produce false Sync convergence, while retaining deterministic hashing and compatibility across delta, legacy, invalidation, and mixed-client paths.

Refs #40

## Validation contract

- Focused expected-red coverage reproduces issue #40 before the fix.
- Focused regression coverage and related subsystem tests pass after the fix.
- Repository-required Fast, Full, Lua, parse, integration, and policy checks pass when available.
- The final exact HEAD, diff, Vibe checkpoint, and independent review are recorded.
- Numeric `1` and string `"1"` produce different build-bucket hashes.
- Numeric and string tombstone IDs produce different hashes.
- Two peers with exactly equal typed records produce equal hashes.
- One peer using a numeric ID and one using the corresponding string ID does not skip reconciliation.
- A bucket containing both typed IDs is deterministic independent of Lua table iteration order.
- Targeted invalidation and rebuild preserve the typed distinction.
- Delta and legacy hash modes obey the same typed identity rule.
- Existing ordinary string IDs continue to hash deterministically.
- Mixed old/new client behavior is tested, with digest versioning or compatibility gating validated if required to prevent permanent false-equality.

## Boundaries

This is an automated stacked draft checkpoint. Merge, release, deployment, force-push, destructive Git, native SavedVariables mutation, and live-WoW claims remain prohibited.
