### PR TITLE
WP7: HUD progress labels quality 4 as `q4` instead of Legendary

### DIFF
--- a/.vibe/EVIDENCE.md
+++ b/.vibe/EVIDENCE.md
@@ -708,3 +708,15 @@ Record concise command/result receipts here. A skipped or unavailable command is
 
 - Bounded inspection covered typed canonical material, cache entry/invalidation identity, Sync compatibility parity, and their direct typed-ID regressions. No correctness/security signal, safe high-ROI cleanup, or actionable debt remained.
 - No product or test byte changed after exact-head Full; Full was not repeated. Strict Vibe validation passed with only the installed-prompt-catalog provenance warning.
+
+# 2026-08-22 — WP7 issue #38 HUD quality-label implementation BLOCKED
+
+- Added the focused HUD oracle in `tests/run_main_viewmodel_parity.lua`: a missing multi-tier target asserts labels `Common`, `Uncommon`, `Rare`, `Epic`, `Legendary`, and explicit future fallback `q5` across repeated projections. Against the pre-fix map, the asserted quality-4 term is the expected-red `q4` versus `Legendary` defect.
+- Scoped repair: `core/MainViewModel.lua` now maps quality `4` to `Legendary`; qualities `0`–`3`, selection/order logic, and `QualityName`'s `q<quality>` fallback are unchanged. `git diff --check` passed.
+- Validation is unavailable, not passed: the focused Node runner failed to start in sandbox and normal-user routes because `node` is not recognized. Both Fast and Full each abort with `Node.js is required to write the compact validation summary`; no `summary.json`, Lua, parse, integration, or policy result exists. Native WoW/SavedVariables remains unverified.
+
+# 2026-08-22 — WP7 Node-runtime recovery validation
+
+- Recovery: Node v24.19.0 is now on PATH. An isolated temporary pre-fix checkout at `34dae2feafcd0b2ae000fa3fe1533bed90213e71`, with only the focused oracle applied, exited 1 at `HUD quality labels or deterministic multi-tier progress text regressed`; this is the expected-red quality-4 `q4` versus `Legendary` result.
+- Green: `node tools/run-lua.js tests/run_main_viewmodel_parity.lua` passes with the scoped quality-4 mapping, all existing quality labels, explicit `q5` fallback, and repeated deterministic multi-tier text assertion.
+- Fast: `tools/Invoke-QualityGate.ps1 -Mode Fast -BaseRef cdbfef98f7079b7f6e13ee79fd3044bd3683e0dc` passes 13/13, with zero failed, unavailable, or skipped checks. Full: the same base-ref Full gate passes 18 blocking checks: Lua 221/221, parse 294/294, integration 70/70, zero failed/unavailable; its one manual SavedVariables backup smoke is nonblocking `SKIPPED` and native WoW remains unverified.

--- a/.vibe/EVIDENCE.md
+++ b/.vibe/EVIDENCE.md
@@ -703,3 +703,8 @@ Record concise command/result receipts here. A skipped or unavailable command is
 - Expected red: `node tools/run-lua.js tests/run_sync_compatibility_parity.lua` exited 1 at `EXPECTED RED: numeric and string build IDs share one bucket hash` before product changes.
 - Focused green: compatibility parity, hash cache, and baseline delta runners pass with typed build/tombstone separation, deterministic dual-ID ordering, mixed old/new inequality, distinct resumable candidate tokens, and cached/fallback delta/legacy parity.
 - Fast: `tools/Invoke-QualityGate.ps1 -Mode Fast -BaseRef 8f5d28008935cef2d973b800167695ab50e0f70b` passed 20/20 blocking checks in 194.852s with zero failed, skipped, or unavailable checks; integration passed 70/70. Native WoW and SavedVariables remain unverified.
+
+# 2026-08-22 — Checkpoint 50.1 hygiene CLEAN
+
+- Bounded inspection covered typed canonical material, cache entry/invalidation identity, Sync compatibility parity, and their direct typed-ID regressions. No correctness/security signal, safe high-ROI cleanup, or actionable debt remained.
+- No product or test byte changed after exact-head Full; Full was not repeated. Strict Vibe validation passed with only the installed-prompt-catalog provenance warning.

--- a/.vibe/PLAN.md
+++ b/.vibe/PLAN.md
@@ -85,3 +85,34 @@ depends_on: [49.2]
   - `pwsh -NoProfile -File tools/Invoke-QualityGate.ps1 -Mode Full -BaseRef 8f5d28008935cef2d973b800167695ab50e0f70b`
 - Evidence:
   - Expected-red typed-collision receipt, focused green compatibility matrix, and exact-head gate/diff receipt.
+
+## Stage 51 — HUD progress quality-label presentation
+
+- Goal: make HUD progress render the authoritative human-readable quality names, including quality `4` as `Legendary`, without changing progress selection or ordering.
+- Decision: keep the repair at the HUD presentation mapping boundary; numeric qualities remain inputs to existing progress math, and unknown future numeric values render through an explicit safe fallback.
+- Decision: cover both direct quality-label rendering and missing multi-tier text, because the reported defect is visible when HUD chooses a missing target among multiple qualities.
+
+### 51.1 — Repair quality 4 HUD progress label (#38)
+
+depends_on: [50.1]
+
+- Status: `NOT_STARTED`
+- Objective:
+  - Render quality `4` as `Legendary` in deterministic HUD progress text while preserving quality `0`–`3` labels and an explicit fallback for unknown numeric qualities.
+- Deliverables:
+  - Focused expected-red and regression coverage at the HUD progress display seam, including a missing multi-quality quality-4 target.
+  - One scoped HUD quality-label mapping repair with no selection-math or quality-ordering change.
+  - Explicit safe fallback for future numeric qualities and assertions for existing labels.
+- Acceptance:
+  - [ ] Before the repair, the focused oracle reproduces the quality-4 label defect and missing multi-quality text renders `q4` rather than `Legendary`.
+  - [ ] After the repair, qualities `0`–`4` render `Common`, `Uncommon`, `Rare`, `Epic`, and `Legendary` respectively.
+  - [ ] Unknown future numeric qualities use an explicit safe fallback.
+  - [ ] Missing multi-tier HUD progress text remains deterministic.
+  - [ ] Focused HUD regressions and all available required Fast/Full/Lua/parse/integration/policy checks pass; nonblocking native validation remains unverified.
+  - [ ] Test 18 and unrelated product surfaces remain unchanged.
+- Demo commands:
+  - `node tools/run-lua.js tests/run_hud_progress.lua`
+  - `pwsh -NoProfile -File tools/Invoke-QualityGate.ps1 -Mode Fast -BaseRef cdbfef98f7079b7f6e13ee79fd3044bd3683e0dc`
+  - `pwsh -NoProfile -File tools/Invoke-QualityGate.ps1 -Mode Full -BaseRef cdbfef98f7079b7f6e13ee79fd3044bd3683e0dc`
+- Evidence:
+  - Expected-red quality-4/multi-tier receipt, focused green HUD matrix, Fast/Full summary, exact diff, and controller-owned review receipt.

--- a/.vibe/PLAN.md
+++ b/.vibe/PLAN.md
@@ -96,7 +96,7 @@ depends_on: [49.2]
 
 depends_on: [50.1]
 
-- Status: `NOT_STARTED`
+- Status: `IN_REVIEW`
 - Objective:
   - Render quality `4` as `Legendary` in deterministic HUD progress text while preserving quality `0`–`3` labels and an explicit fallback for unknown numeric qualities.
 - Deliverables:

--- a/.vibe/STATE.md
+++ b/.vibe/STATE.md
@@ -35,7 +35,7 @@ Render quality `4` as `Legendary` in deterministic HUD progress text while prese
 ## Evidence
 
 - path: .vibe/EVIDENCE.md
-- WP7 is a controller-selected presentation-only issue #38 package on accepted WP6 head `cdbfef98f7079b7f6e13ee79fd3044bd3683e0dc`; no product/test byte has been changed for it.
+- WP7 is a controller-selected presentation-only issue #38 package on accepted WP6 head `cdbfef98f7079b7f6e13ee79fd3044bd3683e0dc`; product/test commit `1d397ed` adds the quality-4 `Legendary` mapping and focused deterministic/fallback regression coverage.
 - Controller repair excludes labels, category, resemblance, and temporal metadata from equal-DPS ties through an explicit projection allowlist; retention resolves the accepted pair through preserved source references. Expected-red reproduced both findings, focused paired/retention/board/Leaderboard/view tests pass, and Fast passes `43/43`.
 - WP5 implementation candidate separates historical locked snapshots from exact current/build copy authority and centralizes verified-owner + ordinary + locked/full-combat real-pair metrics across Community eligibility/averages, Leaderboard sync/resumable projections, retention, and DPS sorting. Focused authority/pairing matrices pass; Fast passes `37/37`; final Full passes `18` blocking checks with Lua `221/221`, parse `294/294`, integration `70/70`, zero failed/unavailable checks, and one explicit manual SavedVariables skip.
 - Stage 49 test-gap analysis prioritized five risk-backed matrices: `[MAJOR]` immutable historical snapshots versus exact later copy authority; `[MAJOR]` verified-owner + ordinary + locked/full-combat pair compatibility; `[MAJOR]` Community/Leaderboard/sort parity from one metric; `[MODERATE]` category/timestamp permutation invariance; `[MODERATE]` reload/restart/Sync convergence with preserved conflict evidence.
@@ -182,6 +182,8 @@ Render quality `4` as `Legendary` in deterministic HUD progress text while prese
 
 
 ## Work log (current session)
+- Reconciled WP7 PLAN/STATE truth; final exact-head focused, Fast, and Full validation follows the lifecycle commit.
+- Review FAIL: VALIDATION-EXACT-HEAD-MISMATCH and VIBE-CHECKPOINT-CONTRADICTION require exact-head validation and truthful checkpoint metadata.
 - WP7 quality-4 label repair committed at 1d397ed; exact-head HUD parity, Fast 13/13, and Full 18 blocking checks pass.
 - Controller retired ISSUE-WP7-NODE-RUNTIME after isolated expected-red, focused green, Fast 13/13, and Full 18/18 proved its unblock condition.
 - Node runtime blocker resolved: isolated expected-red, focused green, Fast 13/13, and Full 18 blocking checks passed; return 51.1 to IN_PROGRESS.

--- a/.vibe/STATE.md
+++ b/.vibe/STATE.md
@@ -8,7 +8,7 @@
 
 - Stage: 50
 - Checkpoint: 50.1
-- Status: IN_REVIEW
+- Status: DONE
 - Branch: `bugfix/test19-wp6-build-hash-buckets-erase-build-id-type-and-can-r`
 - Starting head: exact accepted WP5 handoff head `8f5d28008935cef2d973b800167695ab50e0f70b`
 - Worktree: `.test19-wp4-worktree`
@@ -185,6 +185,7 @@ Preserve typed build identity in Sync's canonical build and tombstone bucket-has
 
 
 ## Work log (current session)
+- Checkpoint 50.1 review PASS: exact head 5e1a6e20 passed focused typed-identity checks and Full 18 blocking checks; no checkpoint-hygiene signals identified; native WoW remains unverified.
 - Typed cache sibling oracle and targeted invalidation repair pass focused, Fast 22/22, and exact-head Full 18 blocking checks
 - Controller review repair: SPEC-TYPED-CACHE-KEY-ALIAS; VALIDATION-TYPED-COEXISTENCE-ORACLE
 - WP6 typed cache matrix and exact-head Fast/Full validation pass; native WoW remains unverified

--- a/.vibe/STATE.md
+++ b/.vibe/STATE.md
@@ -8,7 +8,7 @@
 
 - Stage: 51
 - Checkpoint: 51.1
-- Status: NOT_STARTED
+- Status: IN_REVIEW
 - Branch: `bugfix/test19-wp7-hud-progress-labels-quality-4-as-q4-instead-of-l`
 - Starting head: exact accepted WP6 handoff head `cdbfef98f7079b7f6e13ee79fd3044bd3683e0dc`
 - Worktree: `.test19-wp4-worktree`
@@ -182,6 +182,10 @@ Render quality `4` as `Legendary` in deterministic HUD progress text while prese
 
 
 ## Work log (current session)
+- WP7 quality-4 label repair committed at 1d397ed; exact-head HUD parity, Fast 13/13, and Full 18 blocking checks pass.
+- Controller retired ISSUE-WP7-NODE-RUNTIME after isolated expected-red, focused green, Fast 13/13, and Full 18/18 proved its unblock condition.
+- Node runtime blocker resolved: isolated expected-red, focused green, Fast 13/13, and Full 18 blocking checks passed; return 51.1 to IN_PROGRESS.
+- WP7 implementation is blocked pending a Node.js runtime: the scoped MainViewModel quality-4 mapping and focused expected-red/green oracle are ready, but focused, Fast, and Full execution cannot start and neither gate can write its required summary.
 - Stage 51 design adds bounded WP7 issue #38 HUD quality-label coverage and presentation-only repair after accepted WP6 hygiene.
 - Checkpoint 50.1 hygiene CLEAN: bounded typed BuildHashCache/SyncCompatibility and focused regression surface has no safe high-ROI cleanup or actionable debt; no product/test byte changed and Full was not repeated.
 - Checkpoint 50.1 review PASS: exact head 5e1a6e20 passed focused typed-identity checks and Full 18 blocking checks; no checkpoint-hygiene signals identified; native WoW remains unverified.

--- a/.vibe/STATE.md
+++ b/.vibe/STATE.md
@@ -6,39 +6,36 @@
 
 ## Current focus
 
-- Stage: 50
-- Checkpoint: 50.1
-- Status: DONE
-- Branch: `bugfix/test19-wp6-build-hash-buckets-erase-build-id-type-and-can-r`
-- Starting head: exact accepted WP5 handoff head `8f5d28008935cef2d973b800167695ab50e0f70b`
+- Stage: 51
+- Checkpoint: 51.1
+- Status: NOT_STARTED
+- Branch: `bugfix/test19-wp7-hud-progress-labels-quality-4-as-q4-instead-of-l`
+- Starting head: exact accepted WP6 handoff head `cdbfef98f7079b7f6e13ee79fd3044bd3683e0dc`
 - Worktree: `.test19-wp4-worktree`
-- Base: exact accepted WP5 handoff head `8f5d28008935cef2d973b800167695ab50e0f70b`
+- Base: exact accepted WP6 handoff head `cdbfef98f7079b7f6e13ee79fd3044bd3683e0dc`
 
 ## Objective (current checkpoint)
 
-Preserve typed build identity in Sync's canonical build and tombstone bucket-hash material without changing the deterministic eight-bucket reconciliation design.
+Render quality `4` as `Legendary` in deterministic HUD progress text while preserving quality `0`–`3` labels and an explicit fallback for unknown numeric qualities.
 
 ## Deliverables (current checkpoint)
 
-- Focused expected-red typed build/tombstone, reconciliation, delta/legacy, invalidation, and ordering coverage.
-- Typed canonical build and tombstone entry material in `core/BuildHashCache.lua`.
-- Explicit mixed old/new digest compatibility behavior preventing permanent false equality.
+- Focused expected-red and regression coverage at the HUD progress display seam, including a missing multi-quality quality-4 target.
+- One scoped HUD quality-label mapping repair with no selection-math or quality-ordering change.
+- Explicit safe fallback for future numeric qualities and assertions for existing labels.
 
 ## Acceptance (current checkpoint)
 
-- [ ] Numeric `1` and string `"1"` hash differently for builds and tombstones; equal typed states remain equal.
-- [ ] Numeric/string peer mismatch cannot skip reconciliation.
-- [ ] Both typed IDs hash deterministically across iteration order and rebuild paths.
-- [ ] Delta and legacy modes preserve typed identity and ordinary strings remain deterministic.
-- [ ] Mixed old/new behavior prevents permanent protocol-compatible false equality.
-- [ ] Blocking focused, mapped, Fast, Full, Lua, parse, integration, policy, and diff checks pass.
-- [ ] Nonblocking manual SavedVariables/native validation remains explicitly unverified.
+- [ ] Before the repair, focused coverage reproduces the quality-4 label defect and missing multi-quality text renders `q4` rather than `Legendary`.
+- [ ] Qualities `0`–`4` render Common, Uncommon, Rare, Epic, and Legendary; unknown future numeric qualities use an explicit safe fallback.
+- [ ] Missing multi-tier HUD progress text remains deterministic without changing selection or ordering.
+- [ ] Focused, Fast, Full, Lua, parse, integration, policy, and exact-diff checks pass when available; nonblocking native validation remains unverified.
+- [ ] Test 18 and unrelated product surfaces remain unchanged.
 
 ## Evidence
 
 - path: .vibe/EVIDENCE.md
-- Issue #40 expected red failed at `numeric and string build IDs share one bucket hash`; typed build/tombstone, mixed old/new, ordering, candidate-token, cache invalidation, and baseline-delta focused runners now pass.
-- Fast passed `20/20` blocking checks with Lua 5.1 parse, Sync mapped tests, integration `70/70`, policy, metadata, release, security, and diff checks; zero failed, skipped, or unavailable checks.
+- WP7 is a controller-selected presentation-only issue #38 package on accepted WP6 head `cdbfef98f7079b7f6e13ee79fd3044bd3683e0dc`; no product/test byte has been changed for it.
 - Controller repair excludes labels, category, resemblance, and temporal metadata from equal-DPS ties through an explicit projection allowlist; retention resolves the accepted pair through preserved source references. Expected-red reproduced both findings, focused paired/retention/board/Leaderboard/view tests pass, and Fast passes `43/43`.
 - WP5 implementation candidate separates historical locked snapshots from exact current/build copy authority and centralizes verified-owner + ordinary + locked/full-combat real-pair metrics across Community eligibility/averages, Leaderboard sync/resumable projections, retention, and DPS sorting. Focused authority/pairing matrices pass; Fast passes `37/37`; final Full passes `18` blocking checks with Lua `221/221`, parse `294/294`, integration `70/70`, zero failed/unavailable checks, and one explicit manual SavedVariables skip.
 - Stage 49 test-gap analysis prioritized five risk-backed matrices: `[MAJOR]` immutable historical snapshots versus exact later copy authority; `[MAJOR]` verified-owner + ordinary + locked/full-combat pair compatibility; `[MAJOR]` Community/Leaderboard/sort parity from one metric; `[MODERATE]` category/timestamp permutation invariance; `[MODERATE]` reload/restart/Sync convergence with preserved conflict evidence.
@@ -185,6 +182,7 @@ Preserve typed build identity in Sync's canonical build and tombstone bucket-has
 
 
 ## Work log (current session)
+- Stage 51 design adds bounded WP7 issue #38 HUD quality-label coverage and presentation-only repair after accepted WP6 hygiene.
 - Checkpoint 50.1 hygiene CLEAN: bounded typed BuildHashCache/SyncCompatibility and focused regression surface has no safe high-ROI cleanup or actionable debt; no product/test byte changed and Full was not repeated.
 - Checkpoint 50.1 review PASS: exact head 5e1a6e20 passed focused typed-identity checks and Full 18 blocking checks; no checkpoint-hygiene signals identified; native WoW remains unverified.
 - Typed cache sibling oracle and targeted invalidation repair pass focused, Fast 22/22, and exact-head Full 18 blocking checks

--- a/.vibe/STATE.md
+++ b/.vibe/STATE.md
@@ -185,6 +185,7 @@ Preserve typed build identity in Sync's canonical build and tombstone bucket-has
 
 
 ## Work log (current session)
+- Checkpoint 50.1 hygiene CLEAN: bounded typed BuildHashCache/SyncCompatibility and focused regression surface has no safe high-ROI cleanup or actionable debt; no product/test byte changed and Full was not repeated.
 - Checkpoint 50.1 review PASS: exact head 5e1a6e20 passed focused typed-identity checks and Full 18 blocking checks; no checkpoint-hygiene signals identified; native WoW remains unverified.
 - Typed cache sibling oracle and targeted invalidation repair pass focused, Fast 22/22, and exact-head Full 18 blocking checks
 - Controller review repair: SPEC-TYPED-CACHE-KEY-ALIAS; VALIDATION-TYPED-COEXISTENCE-ORACLE

--- a/core/MainViewModel.lua
+++ b/core/MainViewModel.lua
@@ -7,7 +7,7 @@ if type(Nexus.MainInternals) ~= "table" then Nexus.MainInternals = {} end
 local ViewModel = {}
 Nexus.MainInternals.ViewModel = ViewModel
 
-local QUALITY_NAMES = { [0]="Common", [1]="Uncommon", [2]="Rare", [3]="Epic" }
+local QUALITY_NAMES = { [0]="Common", [1]="Uncommon", [2]="Rare", [3]="Epic", [4]="Legendary" }
 local function QualityName(quality)
     return QUALITY_NAMES[quality] or ("q" .. quality)
 end

--- a/tests/run_main_viewmodel_parity.lua
+++ b/tests/run_main_viewmodel_parity.lua
@@ -72,6 +72,28 @@ assert(progress.dpsEchoes[1].stacks==2
     and progress.unknownTomes[1]=="Tome X",
     "progress model retained caller-owned wishlist or tome tables")
 
+-- HUD progress must expose every known quality by its human-readable name.
+-- Keep a future quality in this multi-tier missing target to prove the fallback
+-- remains explicit and the rendered text is stable across repeat projections.
+local qualityCatalog={familyName={[30]="Six"}}
+local qualityPlan={wishedFamilies={[30]=true},targets={[30]={targetStacks=6,
+    qualityTiers={
+        {spellId=301,q=0,n=1},{spellId=302,q=1,n=1},
+        {spellId=303,q=2,n=1},{spellId=304,q=3,n=1},
+        {spellId=305,q=4,n=1},{spellId=306,q=5,n=1},
+    },
+}}}
+local function MissingQualityText()
+    local _, _, missingRows=view.WishlistProgress(qualityPlan,
+        {byFamily={},bySpell={}},qualityCatalog,{},
+        {synced=true,byFamily={},bySpell={}}, {}, nil)
+    return assert(missingRows[1],"multi-tier quality fixture produced no HUD text")
+end
+local expectedQualityText="Six ×6 (Common:×1 Uncommon:×1 Rare:×1 Epic:×1 Legendary:×1 q5:×1)"
+assert(MissingQualityText()==expectedQualityText
+    and MissingQualityText()==expectedQualityText,
+    "HUD quality labels or deterministic multi-tier progress text regressed")
+
 local hidden=view.BuildProgress({
     plan=plan,owned=owned,slots=slots,catalog=catalog,wishlist=wishlist,
     lockedOwned={byFamily={[10]=3},bySpell={[101]=2,[102]=1},synced=true},


### PR DESCRIPTION
## Scope

Repair the human-readable quality-label mapping used by HUD progress so quality 4 renders as `Legendary`, while preserving existing labels, deterministic progress text, and an explicit safe fallback for unknown future numeric qualities.

Refs #38

## Validation contract

- Focused expected-red coverage reproduces issue #38 before the fix.
- Focused regression coverage and related subsystem tests pass after the fix.
- Repository-required Fast, Full, Lua, parse, integration, and policy checks pass when available.
- The final exact HEAD, diff, Vibe checkpoint, and independent review are recorded.
- Verify quality labels 0–4 render Common, Uncommon, Rare, Epic, and Legendary respectively, and unknown future qualities retain an explicit safe fallback.
- Verify multi-tier missing-progress text remains deterministic.
- Verify Test 18 is unchanged.

## Boundaries

This is an automated stacked draft checkpoint. Merge, release, deployment, force-push, destructive Git, native SavedVariables mutation, and live-WoW claims remain prohibited.
